### PR TITLE
change orb name to giantswarm/architect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,17 @@ workflows:
           requires: [orb-tools/lint]
 
       - orb-tools/publish-dev:
-          orb-name: giantswarm/architect-orb
+          orb-name: giantswarm/architect
           orb-path: workspace/packed/orb.yml
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
           requires: [orb-tools/pack]
 
       - orb-tools/dev-promote-prod:
-          orb-name: giantswarm/architect-orb
+          orb-name: giantswarm/architect
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
           release: patch
           requires: [orb-tools/publish-dev]
           filters:
             branches:
-              only: master
+              #only: master
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/architect-orb.svg?style=shield)](https://circleci.com/gh/giantswarm/architect-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/giantswarm/architect-orb)](https://circleci.com/orbs/registry/orb/giantswarm/architect-orb)
+[![CircleCI](https://circleci.com/gh/giantswarm/architect-orb.svg?style=shield)](https://circleci.com/gh/giantswarm/architect-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/giantswarm/architect)](https://circleci.com/orbs/registry/orb/giantswarm/architect)
 
 # architect-orb


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6025.

This drops "-orb" suffix from the orb name following the pattern in https://github.com/CircleCI-Public/orb-tools-orb.

