### PR TITLE
Index new package only on package-and-push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2019-07-22
+
+### Fixed
+
+- Index new package only in package-and-push command.
+
 ## [0.1.1] - 2019-06-14
 
 ### Fixed

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -17,7 +17,7 @@ steps:
   - run: |
       mkdir build && helm package ./helm/<<parameters.chart>> --destination ./build
   - run: |
-      helm repo index --url https://giantswarm.github.com/$(cat .app_catalog_name) --merge <<parameters.app_catalog>>/index.yaml ./build
+      helm repo index --url https://giantswarm.github.com/$(cat .app_catalog_name) --merge .app_catalog/index.yaml ./build
   - run: |
       cp ./build/* .app_catalog
   - run: |

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -15,9 +15,11 @@ steps:
   - run: |
       git clone -q --depth=1 --single-branch -b master "git@github.com:giantswarm/$(cat .app_catalog_name).git" .app_catalog
   - run: |
-      helm package --save=false ./helm/<<parameters.chart>> --destination .app_catalog
+      mkdir build && helm package ./helm/<<parameters.chart>> --destination ./build
   - run: |
-      helm repo index --url https://giantswarm.github.com/$(cat .app_catalog_name) .app_catalog
+      helm repo index --url https://giantswarm.github.com/$(cat .app_catalog_name) --merge <<parameters.app_catalog>>/index.yaml ./build
+  - run: |
+      cp ./build/* .app_catalog
   - run: |
       cd .app_catalog && git add -A
   - run: |

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -15,6 +15,8 @@ steps:
   - run: |
       git clone -q --depth=1 --single-branch -b master "git@github.com:giantswarm/$(cat .app_catalog_name).git" .app_catalog
   - run: |
+      helm init --client-only
+  - run: |
       mkdir build && helm package ./helm/<<parameters.chart>> --destination ./build
   - run: |
       helm repo index --url https://giantswarm.github.com/$(cat .app_catalog_name) --merge .app_catalog/index.yaml ./build


### PR DESCRIPTION
`package-and-push` command currently re-indexes whole app catalog repo, resetting `created` timestamp for all entries when the new package is being added. This is especially problematic for test app catalogs, without semver (only sha) and the timestamp reset it's hard (for Happa) to determine and select latest package.

This PR adjusts the steps of the command to index the new package separately from the rest of the catalog repo content and then merges the two indices.