### PR TITLE
Prepare 0.1.2 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,5 +28,5 @@ workflows:
           requires: [orb-tools/publish-dev]
           filters:
             branches:
-              #only: master
-              ignore: /.*/
+              only: master
+              #ignore: /.*/


### PR DESCRIPTION
This PR includes one last change that was omitted in https://github.com/giantswarm/architect-orb/pull/14 as preparation for 0.1.2 release.