### PR TITLE
push-to-docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3] - 2019-07-26
-
 ## Added
 
 - Add push-to-docker job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2019-07-26
+
+## Added
+
+- Add push-to-docker job.
+
 ## [0.1.2] - 2019-07-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -119,5 +119,34 @@ workflows:
               only: /^v.*/
 ```
 
+### push-to-docker
+
+This job builds a docker image and pushes it to a registry.
+It requires the build context and Dockefile to be present at the root of worksapce directory.
+
+**NOTE**: The docker image will be tagged with the version found by `architect project version` command.
+
+Example usage
+
+```yaml
+version: 2.1
+orbs:
+  architect: giantswarm/architect@VERSION
+
+workflows:
+  my-workflow:
+    jobs:
+      - architect/push-to-docker:
+          image: "quay.io/giantswarm/magic-operator"
+          username: "${QUAY_USERNAME}"
+          password: "${QUAY_PASSWORD}"
+          registry: "quay.io"
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+```
+
 [architect]: https://github.com/giantswarm/architect
 [architect-executor]: https://github.com/giantswarm/architect-orb/blob/master/src/executors/architect.yaml

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ workflows:
       - architect/push-to-docker:
           image: "giantswarm/magic-operator"
           registry: "quay.io"
-          username_var: "QUAY_USERNAME"
-          password_var: "QUAY_PASSWORD"
+          username_envvar: "QUAY_USERNAME"
+          password_envvar: "QUAY_PASSWORD"
           requires:
             - build
           filters:

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ workflows:
   my-workflow:
     jobs:
       - architect/push-to-docker:
-          image: "quay.io/giantswarm/magic-operator"
-          username: "${QUAY_USERNAME}"
-          password: "${QUAY_PASSWORD}"
+          image: "giantswarm/magic-operator"
           registry: "quay.io"
+          username_var: "QUAY_USERNAME"
+          password_var: "QUAY_PASSWORD"
           requires:
             - build
           filters:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ workflows:
 This job builds a docker image and pushes it to a registry.
 It requires the build context and Dockefile to be present at the root of worksapce directory.
 
+**NOTE**: docker registry username and password are read from environement variables which default to `ARCHITECT_DOCKER_REGISTRY_USERNAME` and `ARCHITECT_DOCKER_REGISTRY_PASSWORD` respectively. This can be changed via `username_var` and `password_var` arguments.
 **NOTE**: The docker image will be tagged with the version found by `architect project version` command.
 
 Example usage

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -1,14 +1,14 @@
 parameters:
-  username:
+  image:
     type: "string"
   password:
     type: "string"
   registry:
     type: "string"
-  image:
+  username:
     type: "string"
 steps:
   - run: echo -n "<<parameters.image>>:$(architect project version)" > docker_image_name
   - run: docker login --username "<<parameters.username>>" --password "<<parameters.password>>" "<<parameters.registry>>"
   - run: docker build -t "$(cat docker_image_name)" .
-  - run: docker push $(cat docker_image_name)
+  - run: docker push "$(cat docker_image_name)"

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -5,8 +5,10 @@ parameters:
     type: "string"
   registry:
     type: "string"
+  image:
+    type: "string"
 steps:
-  - run: architect project version > project_version
+  - run: echo -n "<<parameters.image>>:$(architect project version)" > docker_image_name
   - run: docker login --username "<<parameters.username>>" --password "<<parameters.password>>" "<<parameters.registry>>"
-  - run: docker build -t $(cat project_version) .
-  - run: docker push $(cat project_version)
+  - run: docker build -t "$(cat docker_image_name)" .
+  - run: docker push $(cat docker_image_name)

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -3,15 +3,13 @@ parameters:
     type: "string"
   password_envar:
     type: "string"
-  registry:
-    type: "string"
   username_envar:
     type: "string"
 steps:
   - run: |
-      echo -n "<<parameters.registry>>/<<parameters.image>>:$(architect project version)" > docker_image_name
+      echo -n "<<parameters.image>>:$(architect project version)" > docker_image_name
   - run: |
-      echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "<<parameters.registry>>"
+      echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "$(echo -n '<<parameters.image>>'| cut -d/ -f1"
   - run: |
       docker build -t "$(cat docker_image_name)" .
   - run: |

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -3,9 +3,10 @@ parameters:
     type: "string"
   password:
     type: "string"
-  tag:
+  registry:
     type: "string"
 steps:
-  - run: docker login --username '<<parameters.username>>' --password '<<parameters.password>>'
-  - run: docker build -t '<<parameters.tag>>' .
-  - run: docker push '<<parameters.tag>>'
+  - run: architect project version > project_version
+  - run: docker login --username '<<parameters.username>>' --password '<<parameters.password>>' '<<parameters.registry>>'
+  - run: docker build -t $(cat project_version) .
+  - run: docker push $(cat project_version)

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -1,14 +1,18 @@
 parameters:
   image:
     type: "string"
-  password:
+  password_var:
     type: "string"
   registry:
     type: "string"
-  username:
+  username_var:
     type: "string"
 steps:
-  - run: echo -n "<<parameters.image>>:$(architect project version)" > docker_image_name
-  - run: echo -n "<<parameters.password>>" | docker login --username "<<parameters.username>>" --password-stdin "<<parameters.registry>>"
-  - run: docker build -t "$(cat docker_image_name)" .
-  - run: docker push "$(cat docker_image_name)"
+  - run: |
+      echo -n "<<parameters.registry>>/<<parameters.image>>:$(architect project version)" > docker_image_name
+  - run: |
+      echo -n "${<<parameters.password_var>>}" | docker login --username "${<<parameters.username_var>>}" --password-stdin "<<parameters.registry>>"
+  - run: |
+      docker build -t "$(cat docker_image_name)" .
+  - run: |
+      docker push "$(cat docker_image_name)"

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -9,6 +9,6 @@ parameters:
     type: "string"
 steps:
   - run: echo -n "<<parameters.image>>:$(architect project version)" > docker_image_name
-  - run: docker login --username "<<parameters.username>>" --password "<<parameters.password>>" "<<parameters.registry>>"
+  - run: echo -n "<<parameters.password>>" | docker login --username "<<parameters.username>>" --password-stdin "<<parameters.registry>>"
   - run: docker build -t "$(cat docker_image_name)" .
   - run: docker push "$(cat docker_image_name)"

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -1,0 +1,11 @@
+parameters:
+  username:
+    type: "string"
+  password:
+    type: "string"
+  tag:
+    type: "string"
+steps:
+  - run: docker login --username '<<parameters.username>>' --password '<<parameters.password>>'
+  - run: docker build -t '<<parameters.tag>>' .
+  - run: docker push '<<parameters.tag>>'

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -7,6 +7,6 @@ parameters:
     type: "string"
 steps:
   - run: architect project version > project_version
-  - run: docker login --username '<<parameters.username>>' --password '<<parameters.password>>' '<<parameters.registry>>'
+  - run: docker login --username "<<parameters.username>>" --password "<<parameters.password>>" "<<parameters.registry>>"
   - run: docker build -t $(cat project_version) .
   - run: docker push $(cat project_version)

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -1,17 +1,17 @@
 parameters:
   image:
     type: "string"
-  password_var:
+  password_envar:
     type: "string"
   registry:
     type: "string"
-  username_var:
+  username_envar:
     type: "string"
 steps:
   - run: |
       echo -n "<<parameters.registry>>/<<parameters.image>>:$(architect project version)" > docker_image_name
   - run: |
-      echo -n "${<<parameters.password_var>>}" | docker login --username "${<<parameters.username_var>>}" --password-stdin "<<parameters.registry>>"
+      echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "<<parameters.registry>>"
   - run: |
       docker build -t "$(cat docker_image_name)" .
   - run: |

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -11,6 +11,8 @@ parameters:
     type: "string"
     default: "quay.io"
 steps:
+  - attach_workspace:
+      at: .
   - push-to-docker:
       username: <<parameters.username>>
       password: <<parameters.password>>

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -1,15 +1,11 @@
 executor: architect
 parameters:
   image:
-    description: "Name of the docker image, without tag"
+    description: "Name of the docker image, without tag. e.g. quay.io/my-org/my-repo"
     type: "string"
   password_envar:
     default: "ARCHITECT_DOCKER_REGISTRY_PASSWORD"
     description: "Environment variable name holding docker registry password"
-    type: "string"
-  registry:
-    default: "quay.io"
-    description: "Docker registry server"
     type: "string"
   username_envar:
     default: "ARCHITECT_DOCKER_REGISTRY_USERNAME"
@@ -24,5 +20,4 @@ steps:
   - push-to-docker:
       image: <<parameters.image>>
       password_envar: <<parameters.password_envar>>
-      registry: <<parameters.registry>>
       username_envar: <<parameters.username_envar>>

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -3,15 +3,17 @@ parameters:
   image:
     description: "Name of the docker image, without tag"
     type: "string"
-  password:
-    description: "Docker registry password"
+  password_var:
+    default: "ARCHITECT_DOCKER_REGISTRY_PASSWORD"
+    description: "Environment variable name holding docker registry password"
     type: "string"
   registry:
     default: "quay.io"
     description: "Docker registry server"
     type: "string"
-  username:
-    description: "Docker registry username"
+  username_var:
+    default: "ARCHITECT_DOCKER_REGISTRY_USERNAME"
+    description: "Environment variable name holding registry username"
     type: "string"
 steps:
   - checkout
@@ -21,6 +23,6 @@ steps:
       at: .
   - push-to-docker:
       image: <<parameters.image>>
-      password: <<parameters.password>>
+      password_var: <<parameters.password_var>>
       registry: <<parameters.registry>>
-      username: <<parameters.username>>
+      username_var: <<parameters.username_var>>

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -1,0 +1,17 @@
+executor: architect
+parameters:
+  username:
+    description: "Docker username"
+    type: "string"
+  password:
+    description: "Docker password"
+    type: "string"
+  registry:
+    description: "Docker registry"
+    type: "string"
+    default: "quay.io"
+steps:
+  - push-to-docker:
+      username: <<parameters.username>>
+      password: <<parameters.password>>
+      registry: <<parameters.registry>>

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -12,6 +12,9 @@ parameters:
     default: "quay.io"
 steps:
   - checkout
+  - setup_remote_docker:
+      docker_layer_caching: true
+      version: 18.09.3
   - attach_workspace:
       at: .
   - push-to-docker:

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -17,7 +17,6 @@ steps:
   - checkout
   - setup_remote_docker:
       docker_layer_caching: true
-      version: 18.09.3
   - attach_workspace:
       at: .
   - push-to-docker:

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -11,6 +11,7 @@ parameters:
     type: "string"
     default: "quay.io"
 steps:
+  - checkout
   - attach_workspace:
       at: .
   - push-to-docker:

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -10,6 +10,8 @@ parameters:
     description: "Docker registry"
     type: "string"
     default: "quay.io"
+  image:
+    type: "string"
 steps:
   - checkout
   - setup_remote_docker:
@@ -21,3 +23,4 @@ steps:
       username: <<parameters.username>>
       password: <<parameters.password>>
       registry: <<parameters.registry>>
+      image: <<parameters.image>>

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -3,7 +3,7 @@ parameters:
   image:
     description: "Name of the docker image, without tag"
     type: "string"
-  password_var:
+  password_envar:
     default: "ARCHITECT_DOCKER_REGISTRY_PASSWORD"
     description: "Environment variable name holding docker registry password"
     type: "string"
@@ -11,7 +11,7 @@ parameters:
     default: "quay.io"
     description: "Docker registry server"
     type: "string"
-  username_var:
+  username_envar:
     default: "ARCHITECT_DOCKER_REGISTRY_USERNAME"
     description: "Environment variable name holding registry username"
     type: "string"
@@ -23,6 +23,6 @@ steps:
       at: .
   - push-to-docker:
       image: <<parameters.image>>
-      password_var: <<parameters.password_var>>
+      password_envar: <<parameters.password_envar>>
       registry: <<parameters.registry>>
-      username_var: <<parameters.username_var>>
+      username_envar: <<parameters.username_envar>>

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -1,16 +1,17 @@
 executor: architect
 parameters:
-  username:
-    description: "Docker username"
+  image:
+    description: "Name of the docker image, without tag"
     type: "string"
   password:
-    description: "Docker password"
+    description: "Docker registry password"
     type: "string"
   registry:
-    description: "Docker registry"
-    type: "string"
     default: "quay.io"
-  image:
+    description: "Docker registry server"
+    type: "string"
+  username:
+    description: "Docker registry username"
     type: "string"
 steps:
   - checkout
@@ -20,7 +21,7 @@ steps:
   - attach_workspace:
       at: .
   - push-to-docker:
-      username: <<parameters.username>>
+      image: <<parameters.image>>
       password: <<parameters.password>>
       registry: <<parameters.registry>>
-      image: <<parameters.image>>
+      username: <<parameters.username>>


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6557

Provides a new CircleCI job: `architect/push-to-docker`

Which does the following:
- get the current version we are building
- log into docker registry
- build docker image
- push docker image

This was tested here: https://circleci.com/gh/giantswarm/aws-operator/21548