### PR TITLE
revert build changes after release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ workflows:
       - orb-tools/dev-promote-prod:
           orb-name: giantswarm/architect
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
-          release: minor
+          release: patch
           requires: [orb-tools/publish-dev]
           filters:
             branches:
-              only: master
-              #ignore: /.*/
+              #only: master
+              ignore: /.*/


### PR DESCRIPTION
Towards: giantswarm/giantswarm#6557

Revert changes after version [0.2.0](https://github.com/giantswarm/architect-orb/pull/20) was released.