### PR TITLE
fixes to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2019-07-26
 
-## Added
+### Added
 
 - Add push-to-docker job.
 
@@ -33,5 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/giantswarm/architect-orb/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/giantswarm/architect-orb/releases/tag/v0.2.0
+[0.1.2]: https://github.com/giantswarm/architect-orb/releases/tag/v0.1.2
 [0.1.1]: https://github.com/giantswarm/architect-orb/releases/tag/v0.1.1
 [0.1.0]: https://github.com/giantswarm/architect-orb/releases/tag/v0.1.0


### PR DESCRIPTION
Small fixed to CHANGELOG.md:

* link to `v0.1.2` version was missing.
* align `Added` header under 0.2.0