### PR TITLE
Simplify release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,10 @@ orbs:
 workflows:
   catalog_build:
     jobs:
-      - orb-tools/lint
+      - orb-tools/lint:
+          filters:
+            tags:
+              only: /.*/
 
       - orb-tools/pack:
           source-dir: src
@@ -14,6 +17,9 @@ workflows:
           workspace-path: packed/orb.yml
           artifact-path: packed/orb.yml
           requires: [orb-tools/lint]
+          filters:
+            tags:
+              only: /.*/
 
       - orb-tools/publish-dev:
           orb-name: giantswarm/architect
@@ -21,12 +27,14 @@ workflows:
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
           requires: [orb-tools/pack]
 
-      - orb-tools/dev-promote-prod:
-          orb-name: giantswarm/architect
+      - orb-tools/publish:
+          attach-workspace: true
+          orb-path: workspace/packed/orb.yml
+          orb-ref: giantswarm/architect@${CIRCLE_TAG##v}
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
-          release: minor
-          requires: [orb-tools/publish-dev]
+          requires: [orb-tools/pack]
           filters:
             branches:
-              only: master
-              #ignore: /.*/
+              ignore: /.*/
+            tags:
+              only: /.*/

--- a/README.md
+++ b/README.md
@@ -48,23 +48,13 @@ Design and goals of the project:
 
 ## Releases
 
-1. Open a new PR with changes to `orb-tools/dev-promote-prod` job in [circleci
-   config](.circleci/config.yml):
-    - Change `release: patch` line to `minor` or `major` if the release isn't
-      a patch release.
-    - Uncomment `only: master` line and comment `ignore: /.*/`.
-2. Change [Unreleased header of CHANGELOG.md](CHANGELOG.md#Unreleased) to the
-   version you are going to release. Please also update the URLs at the bottom.
-   To check the current version of the orb check "orb version" badge on the
-   top.
-3. Create new _Unreleased_ section in _CHANGELOG.md_.
-4. Merge your PR.
-5. **IMPORTANT:** Create a new PR reverting changes introduced in step 1.
-   **immediately** so we don't create useless versions in branches created from
-   master.
-6. Push the version tag for the commit against which
-   `orb-tools/dev-promote-prod` job ran. E.g. `git tag v0.1.0
-   dc15f409d09884784fab86ebb6725b14a3f3cd2e` so links in
+1. Open a new PR with following changes:
+    - Change [Unreleased header of CHANGELOG.md](CHANGELOG.md#Unreleased) to
+    the version you are going to release.
+    - Create new _Unreleased_ section in _CHANGELOG.md_.
+    - Update the URLs at the bottom.
+2. Merge your PR.
+3. Tag the version (e.g. `git tag v0.1.0 dc15f409d09884784fab86ebb6725b14a3f3cd2e && git push origin v0.1.0`) so links in
    [CHANGELOG.md](CHANGELOG.md) work nicely.
 
 ## Jobs


### PR DESCRIPTION
This PR simplifies the process to release this orb to CircleCI.

Before we had:
- 1 PR for changes to changelog + enable release
- 1 PR to revert "enable release"
- tag version

Now:
- 1 PR for changes to changelog
- tag version

Also major benefit here is that the git tag is what will be used as the orb version. So we no longer need to guess what version we are publishing, it's just the git tag.