### PR TITLE
Simplify dev versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,21 @@ workflows:
             tags:
               only: /.*/
 
-      - orb-tools/publish-dev:
-          orb-name: giantswarm/architect
+      - orb-tools/publish:
+          name: publish-branch
+          attach-workspace: true
           orb-path: workspace/packed/orb.yml
+          orb-ref: giantswarm/architect@dev:${CIRCLE_BRANCH}
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
           requires: [orb-tools/pack]
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              ignore: /.*/
 
       - orb-tools/publish:
+          name: publish-tag
           attach-workspace: true
           orb-path: workspace/packed/orb.yml
           orb-ref: giantswarm/architect@${CIRCLE_TAG##v}

--- a/README.md
+++ b/README.md
@@ -32,14 +32,10 @@ Design and goals of the project:
   fastest way to prototype is probably creating an inline orb. Here is an
   example of working inline orb prototype:
   https://github.com/giantswarm/release-operator/pull/121/files.
-- Create a PR and test your changes using `dev:$(git rev-parse --short=7 HEAD)` version. This
-  version is updated every time job `orb-tools/publish-dev` configured in
-  [circleci config](.circleci/config.yml) runs. Which is basically on every
-  pushed commit in the feature branch. Dev versions are mutable and deleted
-  after 90 days. Details here
+- Create a PR and test your changes using the dev version, by changing
+  the orb declaration to `architect: giantswarm/architect@dev:your-branch`.
+  Dev versions are mutable and deleted after 90 days. Details here
   https://circleci.com/docs/2.0/using-orbs/#development-and-production-orbs-versioning-semantics.
-  To use the dev version you need to  change the version of the orb
-  declaration to `architect: giantswarm/architect@dev:$(git rev-parse --short=7 HEAD)`.
 - Update [Unreleased section of CHANGELOG.md](CHANGELOG.md#Unreleased) file
   with the changes introduced in your PR.
 - If you want to also make a new release follow the steps in


### PR DESCRIPTION
After simplifying the release process https://github.com/giantswarm/architect-orb/pull/34 I though it would be cool to also simplify the dev process.

So instead of using `dev:<git-sha>` we can just use `dev:<git-branch>` and remove the need to change the version when we want to test our changes.

This PR replace the `orb-tools/publish-dev` job with `orb-tools/publish` and use `dev:${CIRCLE_BRANCH}` as the orb version.

I tested this and learned that git branch names can be quite funny:
```
$ circleci orb source 'theo/hello@dev:th!s)_is]/a>_va|!d&_branch<_%name+#'
commands:
  hello:
    steps:
    - run: echo hello orb
description: |
  Hello orb.
  code: https://github.com/TheoBrigitte/hello-orb.
version: 2.1
```