### PR TITLE
add "tag-latest-branch" parameter to the push-to-docker job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add "latest" parameter to the push-to-docker job.
+- Add "tag-latest-branch" parameter to the push-to-docker job.
 
 ## [0.4.3] 2019-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add "latest" parameter to the push-to-docker job.
+
 ## [0.4.3] 2019-10-10
 
 ### Added

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -1,26 +1,22 @@
 parameters:
   image:
     type: "string"
-  latest:
-    type: "boolean"
   password_envar:
     type: "string"
   username_envar:
     type: "string"
+  tag-latest-branch:
+    type: "boolean"
 steps:
   - run: |
+      echo -n "<<parameters.image>>:$(architect project version)" > .docker_image_name
+  - run: |
       echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "$(echo -n '<<parameters.image>>' | cut -d/ -f1)"
-  - unless:
-      condition: <<parameters.latest>>
-      steps:
-        - run: |
-            echo -n "<<parameters.image>>:$(architect project version)" > .docker_image_name
-  - when:
-      condition: <<parameters.latest>>
-      steps:
-        - run: |
-            echo -n "<<parameters.image>>:latest" > .docker_image_name
   - run: |
       docker build -t "$(cat .docker_image_name)" .
   - run: |
       docker push "$(cat .docker_image_name)"
+  - run: |
+      [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && docker tag "$(cat .docker_image_name)" "<<parameters.image>>:latest" || true
+  - run: |
+      [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && docker push "<<parameters.image>>:latest" || true

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -1,16 +1,26 @@
 parameters:
   image:
     type: "string"
+  latest:
+    type: "boolean"
   password_envar:
     type: "string"
   username_envar:
     type: "string"
 steps:
   - run: |
-      echo -n "<<parameters.image>>:$(architect project version)" > docker_image_name
-  - run: |
       echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "$(echo -n '<<parameters.image>>' | cut -d/ -f1)"
+  - unless:
+      condition: <<parameters.latest>>
+      steps:
+        - run: |
+            echo -n "<<parameters.image>>:$(architect project version)" > .docker_image_name
+  - when:
+      condition: <<parameters.latest>>
+      steps:
+        - run: |
+            echo -n "<<parameters.image>>:latest" > .docker_image_name
   - run: |
-      docker build -t "$(cat docker_image_name)" .
+      docker build -t "$(cat .docker_image_name)" .
   - run: |
-      docker push "$(cat docker_image_name)"
+      docker push "$(cat .docker_image_name)"

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -6,7 +6,7 @@ parameters:
   username_envar:
     type: "string"
   tag-latest-branch:
-    type: "boolean"
+    type: "string"
 steps:
   - run: |
       echo -n "<<parameters.image>>:$(architect project version)" > .docker_image_name

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -17,6 +17,6 @@ steps:
   - run: |
       docker push "$(cat .docker_image_name)"
   - run: |
-      [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && docker tag "$(cat .docker_image_name)" "<<parameters.image>>:latest" || true
+      ! [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && echo "skip" || docker tag "$(cat .docker_image_name)" "<<parameters.image>>:latest"
   - run: |
-      [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && docker push "<<parameters.image>>:latest" || true
+      ! [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && echo "skip" || docker push "<<parameters.image>>:latest"

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -23,5 +23,6 @@ steps:
       at: .
   - push-to-docker:
       image: <<parameters.image>>
+      latest: <<parameters.latest>>
       password_envar: <<parameters.password_envar>>
       username_envar: <<parameters.username_envar>>

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -1,15 +1,19 @@
 executor: architect
 parameters:
   image:
-    description: "Name of the docker image, without tag. e.g. quay.io/my-org/my-repo"
+    description: "Name of the docker image, without tag. e.g. \"quay.io/my-org/my-repo\"."
     type: "string"
+  latest:
+    description: "Whether the image should be tagged as \"latest\". By default it is tagged with the output of `architect project version`."
+    type: "boolean"
+    default: false
   password_envar:
     default: "ARCHITECT_DOCKER_REGISTRY_PASSWORD"
-    description: "Environment variable name holding docker registry password"
+    description: "Environment variable name holding docker registry password."
     type: "string"
   username_envar:
     default: "ARCHITECT_DOCKER_REGISTRY_USERNAME"
-    description: "Environment variable name holding registry username"
+    description: "Environment variable name holding registry username."
     type: "string"
 steps:
   - checkout

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -3,10 +3,6 @@ parameters:
   image:
     description: "Name of the docker image, without tag. e.g. \"quay.io/my-org/my-repo\"."
     type: "string"
-  latest:
-    description: "Whether the image should be tagged as \"latest\". By default it is tagged with the output of `architect project version`."
-    type: "boolean"
-    default: false
   password_envar:
     default: "ARCHITECT_DOCKER_REGISTRY_PASSWORD"
     description: "Environment variable name holding docker registry password."
@@ -15,6 +11,10 @@ parameters:
     default: "ARCHITECT_DOCKER_REGISTRY_USERNAME"
     description: "Environment variable name holding registry username."
     type: "string"
+  tag-latest-branch:
+    description: "Name of the branch on which the image will be additionally tagged as latest."
+    type: "string"
+    default: "master"
 steps:
   - checkout
   - setup_remote_docker:
@@ -23,6 +23,6 @@ steps:
       at: .
   - push-to-docker:
       image: <<parameters.image>>
-      latest: <<parameters.latest>>
+      tag-latest-branch: <<parameters.tag-latest-branch>>
       password_envar: <<parameters.password_envar>>
       username_envar: <<parameters.username_envar>>

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -12,7 +12,7 @@ parameters:
     description: "Environment variable name holding registry username."
     type: "string"
   tag-latest-branch:
-    description: "Name of the branch on which the image will be additionally tagged as latest."
+    description: "Name of the branch on which the image will be additionally tagged as \"latest\"."
     type: "string"
     default: "master"
 steps:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7480

I figured that when architect image is build it's pushed to quay using version from `architect project version` command but the `latest` tag isn't updated. The job is updated to also push `latest` image on (by default) `master` branch.