### PR TITLE
add-old-push-docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add "tag-latest-branch" parameter to the push-to-docker job.
+- Add "push-to-docker-legacy" command to be able push old style docker image tags.
 
 ## [0.4.3] 2019-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add "push-to-docker-legacy" command to be able push old style docker image tags.
+
 ## [0.4.4] 2019-10-31
 
 ### Added
 
 - Add "tag-latest-branch" parameter to the push-to-docker job.
-- Add "push-to-docker-legacy" command to be able push old style docker image tags.
 
 ## [0.4.3] 2019-10-10
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ workflows:
               only: /^v.*/
 ```
 
+### push-to-docker-legacy
+
+Same as `push-to-docker` with only change that the docker image tag is only including SHA of commit instead of version + SHA.
+
 ### push-to-app-collection
 
 This job generate an App CR and add it to the an app collection chart repository.

--- a/src/commands/push-to-docker-legacy.yaml
+++ b/src/commands/push-to-docker-legacy.yaml
@@ -1,0 +1,22 @@
+parameters:
+  image:
+    type: "string"
+  password_envar:
+    type: "string"
+  username_envar:
+    type: "string"
+  tag-latest-branch:
+    type: "string"
+steps:
+  - run: |
+      echo -n "<<parameters.image>>:${CIRCLE_SHA1}" > .docker_image_name
+  - run: |
+      echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "$(echo -n '<<parameters.image>>' | cut -d/ -f1)"
+  - run: |
+      docker build -t "$(cat .docker_image_name)" .
+  - run: |
+      docker push "$(cat .docker_image_name)"
+  - run: |
+      ! [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && echo "skip" || docker tag "$(cat .docker_image_name)" "<<parameters.image>>:latest"
+  - run: |
+      ! [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && echo "skip" || docker push "<<parameters.image>>:latest"

--- a/src/jobs/push-to-docker-legacy.yaml
+++ b/src/jobs/push-to-docker-legacy.yaml
@@ -1,0 +1,28 @@
+executor: architect
+parameters:
+  image:
+    description: "Name of the docker image, without tag. e.g. \"quay.io/my-org/my-repo\"."
+    type: "string"
+  password_envar:
+    default: "ARCHITECT_DOCKER_REGISTRY_PASSWORD"
+    description: "Environment variable name holding docker registry password."
+    type: "string"
+  username_envar:
+    default: "ARCHITECT_DOCKER_REGISTRY_USERNAME"
+    description: "Environment variable name holding registry username."
+    type: "string"
+  tag-latest-branch:
+    description: "Name of the branch on which the image will be additionally tagged as \"latest\"."
+    type: "string"
+    default: "master"
+steps:
+  - checkout
+  - setup_remote_docker:
+      docker_layer_caching: true
+  - attach_workspace:
+      at: .
+  - push-to-docker-legacy:
+      image: <<parameters.image>>
+      tag-latest-branch: <<parameters.tag-latest-branch>>
+      password_envar: <<parameters.password_envar>>
+      username_envar: <<parameters.username_envar>>


### PR DESCRIPTION
add new job for pushing the images the old way ( without version, tag is just SHA)
This is for pushing CP components images to china

### Checklist

- [ ] Update the [appcatalog docs](https://github.com/giantswarm/giantswarm/blob/master/processes/appcatalog.md) to use the new release.


towards https://github.com/giantswarm/giantswarm/issues/7435
