### PR TITLE
push-to-app-collection: add "unique" parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add "unique" parameter to push-to-app-collection job.
+
 ## [0.4.5] 2019-12-11
 
 ### Added

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -8,6 +8,8 @@ parameters:
     type: "string"
   app_collection_repo:
     type: "string"
+  unique:
+    type: "string"
 steps:
   - run: |
         architect project version > .version
@@ -19,12 +21,30 @@ steps:
         git clone -q --depth=1 --single-branch -b master git@github.com:giantswarm/<<parameters.app_collection_repo>>.git .app-collection
   - run: |
         mkdir -p .app-collection/helm/<<parameters.app_collection_repo>>-chart/templates
+  - when:
+      condition: <<parameters.unique>>
+      steps:
+        - run: |
+              cd .app-collection && git rm helm/<<parameters.app_collection_repo>>-chart/templates/<<parameters.app_name>>-*.yaml
+        - run: |
+              echo -n "<<parameters.app_name>>-unique.yaml" > .app_file_name
+        - run: |
+              echo -n "update <<parameters.app_name>>-unique to $(cat .version)" > .git_commit_message
+  - unless:
+      condition: <<parameters.unique>>
+      steps:
+        - run: |
+              echo -n "<<parameters.app_name>>-$(cat .version).yaml" > .app_file_name
+        - run: |
+              echo -n "add <<parameters.app_name>>-$(cat .version)" > .git_commit_message
   - run: |
-        mv -n .app.yaml .app-collection/helm/<<parameters.app_collection_repo>>-chart/templates/<<parameters.app_name>>-$(cat .version).yaml
+        mv -n .app.yaml .app-collection/helm/<<parameters.app_collection_repo>>-chart/templates/$(cat .app_file_name)
   - run: |
-        cd .app-collection && git add helm/<<parameters.app_collection_repo>>-chart/templates/<<parameters.app_name>>-$(cat ../.version).yaml
+        cd .app-collection && git add helm/<<parameters.app_collection_repo>>-chart/templates/$(cat .app_file_name)
   - run: |
-        cd .app-collection && git commit -m "add $(git status --porcelain | cut -c4-)"
+        cd .app-collection && git commit -m "$(cat .git_commit_message)"
   - run: |
         cd .app-collection && git push || (echo "Error pushing app to the collection. See known errors in https://github.com/giantswarm/architect-orb/blob/master/README.md#push-to-app-collection" && exit 1)
+  - run: |
+        rm .version .app_file_name .git_commit_message
 

--- a/src/jobs/push-to-app-collection.yaml
+++ b/src/jobs/push-to-app-collection.yaml
@@ -1,6 +1,8 @@
 description: >
   Generates and adds an App CR to an app-collection.
   Note: version will be detected automatically by architect.
+
+
 executor: architect
 parameters:
   app_name:
@@ -14,7 +16,7 @@ parameters:
     description: "Name of the app collection repository."
     type: "string"
   unique:
-    description: "Whether the previous App versions in the collection should be replaced with this one. Any non-empty string means true."
+    description: "Whether the previous App versions in the collection should be replaced with this one. Any non-empty string means true. This is useful when only one (usually latest) version of the app should be installed at a time. E.g. OPA gatekeeper."
     type: "string"
     default: ""
 steps:

--- a/src/jobs/push-to-app-collection.yaml
+++ b/src/jobs/push-to-app-collection.yaml
@@ -4,15 +4,19 @@ description: >
 executor: architect
 parameters:
   app_name:
-    description: "Name of the application"
+    description: "Name of the application."
     type: "string"
   app_catalog:
-    description: "Name of the catalog CR where the application belongs"
+    description: "Name of the catalog CR where the application belongs."
     type: "string"
     default: "control-plane-catalog"
   app_collection_repo:
-    description: "Name of the app collection repository"
+    description: "Name of the app collection repository."
     type: "string"
+  unique:
+    description: "Whether the previous App versions in the collection should be replaced with this one. Any non-empty string means true."
+    type: "string"
+    default: ""
 steps:
   - checkout
   - prepare-catalogbot-git-ssh
@@ -20,3 +24,4 @@ steps:
       app_name: <<parameters.app_name>>
       app_catalog: <<parameters.app_catalog>>
       app_collection_repo: <<parameters.app_collection_repo>>
+      unique: <<parameters.unique>>


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7648

If `unique` is specified then:

- All other app files will be removed from the collection with `git rm APP-*.yaml`
- This app will be added with `git add APP-unique.yaml`

Note I decided to replace `APP-1.2.3.yaml` with `APP-unique.yaml`. This is because I'd like to have an update instead of replacement in case of unique app. When this is a problem? E.g. with OPA gatekeeper (which we make this feature for) behaviour is undefined (at least to me) when two of them are installed at the same time. So when one app CR is deleting and other creating we don't have a guarantee that there won't be two deployments at the same time.