### PR TITLE
Goimports local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fail when .go files not satisfying import rules specified in fmt are present.
+
 ## [0.5.2] 2020-02-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Design and goals of the project:
 This job:
 
 - Checks if Go modules are tidy.
+- Checks if imports in .go files satisfy import rules defined in fmt.
 - Runs `go vet` against the codebase.
 - Runs `go test` against the codebase.
 

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -19,8 +19,7 @@ steps:
       echo -n " -X '<< parameters.pkg >>.version=$(cat .project_version)'" >> .ldflags
   - run: |
       echo "\"$(cat .ldflags)\""
-  - name: Check if imports are properly sorted
-    run: |
+  - run: |
       go get golang.org/x/tools/cmd/goimports && [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -l .) ]] && goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d . && exit 1
   - run: |
       test -z $(gofmt -l .) || gofmt -d .

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -6,6 +6,8 @@ steps:
   - run: |
       go mod tidy && git diff --exit-code
   - run: |
+      find . -path ./vendor -prune -o -name '*.go' -exec goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d "{}" +
+  - run: |
       architect project version > .project_version
   - run: |
       cat .project_version

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -19,8 +19,10 @@ steps:
       echo -n " -X '<< parameters.pkg >>.version=$(cat .project_version)'" >> .ldflags
   - run: |
       echo "\"$(cat .ldflags)\""
-  - run: |
-      go get golang.org/x/tools/cmd/goimports && [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -l .) ]] && goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d . && exit 1
+  - run:
+      name: Check if imports are properly sorted
+      command: |
+        go get golang.org/x/tools/cmd/goimports && [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -l .) ]] && goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d . && exit 1
   - run: |
       test -z $(gofmt -l .) || gofmt -d .
   - run: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -20,7 +20,7 @@ steps:
   - run: |
       echo "\"$(cat .ldflags)\""
   - run: |
-      go get golang.org/x/tools/cmd/goimports && [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d .) ]] && exit 1
+      go get golang.org/x/tools/cmd/goimports && [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -l .) ]] && goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d . && exit 1
   - run: |
       test -z $(gofmt -l .) || gofmt -d .
   - run: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -6,8 +6,6 @@ steps:
   - run: |
       go mod tidy && git diff --exit-code
   - run: |
-      find . -path ./vendor -prune -o -name '*.go' -exec goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d "{}" +
-  - run: |
       architect project version > .project_version
   - run: |
       cat .project_version
@@ -21,6 +19,8 @@ steps:
       echo -n " -X '<< parameters.pkg >>.version=$(cat .project_version)'" >> .ldflags
   - run: |
       echo "\"$(cat .ldflags)\""
+  - run: |
+      go get golang.org/x/tools/cmd/goimports && find . -path ./vendor -prune -o -name '*.go' -exec goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d "{}" +
   - run: |
       test -z $(gofmt -l .) || gofmt -d .
   - run: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -20,7 +20,7 @@ steps:
   - run: |
       echo "\"$(cat .ldflags)\""
   - run: |
-      go get golang.org/x/tools/cmd/goimports && find . -path ./vendor -prune -o -name '*.go' -exec goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d "{}" +
+      go get golang.org/x/tools/cmd/goimports && [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d .) ]] && exit 1
   - run: |
       test -z $(gofmt -l .) || gofmt -d .
   - run: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -19,7 +19,8 @@ steps:
       echo -n " -X '<< parameters.pkg >>.version=$(cat .project_version)'" >> .ldflags
   - run: |
       echo "\"$(cat .ldflags)\""
-  - run: |
+  - name: Check if imports are properly sorted
+    run: |
       go get golang.org/x/tools/cmd/goimports && [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -l .) ]] && goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d . && exit 1
   - run: |
       test -z $(gofmt -l .) || gofmt -d .


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7485

Adds a step to the `go-test` command which runs the command suggested by giantswarm/giantswarm/issues/7485 on *.go files except for the vendor directory.

I think this won't make the job fail but will print offending files in the log. I think some old files are not following the convention defined in fmt. (https://github.com/giantswarm/fmt/blob/master/go/imports.md)