### PR TITLE
push-to-app-collection: rename .cr-name to .cr_name to fix cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix working files cleanup in push-to-app-collection job.
+
 ## [0.5.2] 2020-02-03
 
 ### Fixed

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -17,14 +17,14 @@ steps:
       condition: <<parameters.unique>>
       steps:
         - run: |
-              echo -n "<<parameters.app_name>>-unique" > .cr-name
+              echo -n "<<parameters.app_name>>-unique" > .cr_name
   - unless:
       condition: <<parameters.unique>>
       steps:
         - run: |
-              echo -n "<<parameters.app_name>>-$(cat .version)" | head -c 53 > .cr-name
+              echo -n "<<parameters.app_name>>-$(cat .version)" | head -c 53 > .cr_name
   - run: |
-        architect create appcr --name $(cat .cr-name) --app-name <<parameters.app_name>> --app-version $(cat .version) --catalog <<parameters.app_catalog>> -o yaml > .app.yaml
+        architect create appcr --name $(cat .cr_name --app-name <<parameters.app_name>> --app-version $(cat .version) --catalog <<parameters.app_catalog>> -o yaml > .app.yaml
   - run: |
         git clone -q --depth=1 --single-branch -b master git@github.com:giantswarm/<<parameters.app_collection_repo>>.git .app-collection
   - run: |

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -24,7 +24,7 @@ steps:
         - run: |
               echo -n "<<parameters.app_name>>-$(cat .version)" | head -c 53 > .cr_name
   - run: |
-        architect create appcr --name $(cat .cr_name --app-name <<parameters.app_name>> --app-version $(cat .version) --catalog <<parameters.app_catalog>> -o yaml > .app.yaml
+        architect create appcr --name $(cat .cr_name) --app-name <<parameters.app_name>> --app-version $(cat .version) --catalog <<parameters.app_catalog>> -o yaml > .app.yaml
   - run: |
         git clone -q --depth=1 --single-branch -b master git@github.com:giantswarm/<<parameters.app_collection_repo>>.git .app-collection
   - run: |


### PR DESCRIPTION
Otherwise the line below fails:

    rm .cr_name .version .app_file_name .git_commit_message



## Checklist

- [x] Update the [appcatalog docs](https://github.com/giantswarm/giantswarm/blob/master/areas/managed-services/adding_app_to_appcatalog.md) to use the new release.