### PR TITLE
fix push-to-app-collection unique parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix pushing new unique app in push-to-app-collection job. https://github.com/giantswarm/architect-orb/pull/69
+
 ## [0.5.3] 2020-02-11
 
 ### Added

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -33,7 +33,7 @@ steps:
       condition: <<parameters.unique>>
       steps:
         - run: |
-              cd .app-collection && git rm helm/<<parameters.app_collection_repo>>-chart/templates/<<parameters.app_name>>-*.yaml
+              cd .app-collection && git rm --ignore-unmatch helm/<<parameters.app_collection_repo>>-chart/templates/<<parameters.app_name>>-*.yaml
         - run: |
               echo -n "<<parameters.app_name>>-unique.yaml" > .app_file_name
         - run: |


### PR DESCRIPTION
This PR fixes an issue with the `unique` parameter in the `push-to-app-collection` job.

When a new app with the unique flag is added to the app-collection, there is no previous app with the same name to be cleaned up and the job fails with the following error:

![image](https://user-images.githubusercontent.com/6536819/74441358-f2cbcb80-4e6f-11ea-886b-021a6572f89e.png)

see https://circleci.com/gh/giantswarm/gatekeeper-control-plane-rules/46