### PR TITLE
go-test: stop injecting version into build info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Stop injecting version into build info in `go-test` command to allow version to be maintained directly in source.
+
 ### Fixed
 
 - Fix pushing new unique app in push-to-app-collection job. https://github.com/giantswarm/architect-orb/pull/69

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -6,17 +6,11 @@ steps:
   - run: |
       go mod tidy && git diff --exit-code
   - run: |
-      architect project version > .project_version
-  - run: |
-      cat .project_version
-  - run: |
       echo -n "-w -linkmode 'auto' -extldflags '-static'" > .ldflags
   - run: |
       echo -n " -X '<< parameters.pkg >>.buildTimestamp=$(date --utc '+%FT%TZ')'" >> .ldflags
   - run: |
       echo -n " -X '<< parameters.pkg >>.gitSHA=${CIRCLE_SHA1}'" >> .ldflags
-  - run: |
-      echo -n " -X '<< parameters.pkg >>.version=$(cat .project_version)'" >> .ldflags
   - run: |
       echo "\"$(cat .ldflags)\""
   - run:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8637

We want to invert how the project version is maintained and instead of
generating it from git data and injecting during the build, we want to
maintain it in source files. This will allow managing releases by
merging PRs and that they'll undergo a review process.
