### PR TITLE
Add golanglint-ci as linter for Go code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduce `go-lint` for running configurable linting jobs on `Go` code
+
 ## [0.6.0] 2020-02-19
 
 ### Changed

--- a/src/commands/go-lint.yaml
+++ b/src/commands/go-lint.yaml
@@ -1,0 +1,64 @@
+parameters:
+  # Many additional parameters are supported by golanglint-ci.
+  disable:
+    description: "The names of default linting modules to skip."
+    type: "string"
+  disable-all:
+    description: "If set, will disable all linters (except those included by '--enable')."
+    type: "boolean"
+  enable:
+    description: "The names of additional linting modules to run."
+    type: "string"
+  new-from-rev:
+    description: "Show only new issues created after git revision REV."
+    type: "string"
+  presets:
+    description: "Enable preset list of linters (bugs|complexity|format|performance|style|unused)."
+    type: "enum"
+    enum: ["bugs", "complexity", "format", "performance", "style", "unused", "none"]
+  skip-dirs:
+    description: "Regular expressions for folder paths which should be skipped."
+    type: "string"
+  skip-files:
+    description: "Regular expressions for file paths which should be skipped."
+    type: "string"
+  verbose:
+    description: "If set, will print verbose output."
+    type: "boolean"
+steps:
+  - run: |
+      DISABLE="<< parameters.disable >>"
+      DISABLE_ALL="<< parameters.disable-all >>"
+      ENABLE="<< parameters.enable >>"
+      NEW_FROM_REV="<< parameters.new-from-rev >>"
+      PRESETS="<< parameters.presets >>"
+      SKIP_DIRS="<< parameters.skip-dirs >>"
+      SKIP_FILES="<< parameters.skip-files >>"
+      VERBOSE="<< parameters.verbose >>"
+      LINT_ARGS="--out-format json"
+      if [ -n "${DISABLE}" ]; then
+        LINT_ARGS+=" --disable ${DISABLE}";
+      fi
+      if [ "${DISABLE_ALL}" = "true" ]; then
+        LINT_ARGS+=" --disable-all";
+      fi
+      if [ -n "${ENABLE}" ]; then
+        LINT_ARGS+=" --enable ${ENABLE}";
+      fi
+      if [ -n "${NEW_FROM_REV}" ]; then
+        LINT_ARGS+=" --new-from-rev ${NEW_FROM_REV}";
+      fi
+      if [ "${PRESETS}" != "none" ]; then
+        LINT_ARGS+=" --presets ${PRESETS}";
+      fi
+      if [ -n "${SKIP_DIRS}" ]; then
+        LINT_ARGS+=" --skip-dirs ${SKIP_DIRS}";
+      fi
+      if [ -n "${SKIP_FILES}" ]; then
+        LINT_ARGS+=" --skip-files ${SKIP_FILES}";
+      fi
+      if [ "${VERBOSE}" = "true" ]; then
+        LINT_ARGS+=" -v";
+      fi
+      echo "Running: golangci-lint run $LINT_ARGS"
+      golangci-lint run $LINT_ARGS

--- a/src/executors/go-lint.yaml
+++ b/src/executors/go-lint.yaml
@@ -1,0 +1,2 @@
+docker:
+    - image: quay.io/giantswarm/golangci-lint:v1.23.6

--- a/src/jobs/go-lint.yaml
+++ b/src/jobs/go-lint.yaml
@@ -1,0 +1,47 @@
+description: "Runs golanglint-ci against the codebase."
+parameters:
+  disable:
+    default: ""
+    description: "The names of default linting modules to skip."
+    type: "string"
+  disable-all:
+    default: false
+    description: "If set, will disable all linters (except those included by '--enable')."
+    type: "boolean"
+  enable:
+    default: ""
+    description: "The names of additional linting modules to run."
+    type: "string"
+  new-from-rev:
+    default: ""
+    description: "Show only new issues created after git revision REV."
+    type: "string"
+  presets:
+    default: "none"
+    description: "Enable preset list of linters (bugs|complexity|format|performance|style|unused)."
+    type: "enum"
+    enum: ["bugs", "complexity", "format", "performance", "style", "unused", "none"]
+  skip-dirs:
+    default: ""
+    description: "Regular expressions for folder paths which should be skipped."
+    type: "string"
+  skip-files:
+    default: ""
+    description: "Regular expressions for file paths which should be skipped."
+    type: "string"
+  verbose:
+    default: false
+    description: "If set, will print verbose output."
+    type: "boolean"
+executor: go-lint
+steps:
+  - checkout
+  - go-lint:
+      disable: << parameters.disable >>
+      disable-all: << parameters.disable-all >>
+      enable: << parameters.enable >>
+      new-from-rev: << parameters.new-from-rev >>
+      presets: << parameters.presets >>
+      skip-dirs: << parameters.skip-dirs >>
+      skip-files: << parameters.skip-files >>
+      verbose: << parameters.verbose >>


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8901 https://github.com/giantswarm/giantswarm/issues/7658

Adds `go-lint` job which can run multiple configurable linters.

## Checklist

- [x] Update changelog in CHANGELOG.md.
