### PR TITLE
Remove params

### DIFF
--- a/src/commands/go-lint.yaml
+++ b/src/commands/go-lint.yaml
@@ -1,64 +1,15 @@
 parameters:
-  # Many additional parameters are supported by golanglint-ci.
-  disable:
-    description: "The names of default linting modules to skip."
-    type: "string"
-  disable-all:
-    description: "If set, will disable all linters (except those included by '--enable')."
-    type: "boolean"
-  enable:
-    description: "The names of additional linting modules to run."
-    type: "string"
   new-from-rev:
     description: "Show only new issues created after git revision REV."
     type: "string"
-  presets:
-    description: "Enable preset list of linters (bugs|complexity|format|performance|style|unused)."
-    type: "enum"
-    enum: ["bugs", "complexity", "format", "performance", "style", "unused", "none"]
-  skip-dirs:
-    description: "Regular expressions for folder paths which should be skipped."
-    type: "string"
-  skip-files:
-    description: "Regular expressions for file paths which should be skipped."
-    type: "string"
-  verbose:
-    description: "If set, will print verbose output."
-    type: "boolean"
 steps:
   - run: |
-      DISABLE="<< parameters.disable >>"
-      DISABLE_ALL="<< parameters.disable-all >>"
-      ENABLE="<< parameters.enable >>"
       NEW_FROM_REV="<< parameters.new-from-rev >>"
-      PRESETS="<< parameters.presets >>"
-      SKIP_DIRS="<< parameters.skip-dirs >>"
-      SKIP_FILES="<< parameters.skip-files >>"
-      VERBOSE="<< parameters.verbose >>"
-      LINT_ARGS="--out-format json"
-      if [ -n "${DISABLE}" ]; then
-        LINT_ARGS+=" --disable ${DISABLE}";
-      fi
-      if [ "${DISABLE_ALL}" = "true" ]; then
-        LINT_ARGS+=" --disable-all";
-      fi
-      if [ -n "${ENABLE}" ]; then
-        LINT_ARGS+=" --enable ${ENABLE}";
-      fi
+      # Enable some additional linters
+      ENABLED=" -E gosec -E goconst -E unparam"
+      LINT_ARGS=" "
       if [ -n "${NEW_FROM_REV}" ]; then
         LINT_ARGS+=" --new-from-rev ${NEW_FROM_REV}";
       fi
-      if [ "${PRESETS}" != "none" ]; then
-        LINT_ARGS+=" --presets ${PRESETS}";
-      fi
-      if [ -n "${SKIP_DIRS}" ]; then
-        LINT_ARGS+=" --skip-dirs ${SKIP_DIRS}";
-      fi
-      if [ -n "${SKIP_FILES}" ]; then
-        LINT_ARGS+=" --skip-files ${SKIP_FILES}";
-      fi
-      if [ "${VERBOSE}" = "true" ]; then
-        LINT_ARGS+=" -v";
-      fi
-      echo "Running: golangci-lint run $LINT_ARGS"
-      golangci-lint run $LINT_ARGS
+      echo "Running: golangci-lint run $ENABLED $LINT_ARGS"
+      golangci-lint run $ENABLED $LINT_ARGS

--- a/src/commands/go-lint.yaml
+++ b/src/commands/go-lint.yaml
@@ -1,5 +1,3 @@
 steps:
   - run: |
-      # Enable some additional linters
-      echo "Running: golangci-lint run -E gosec -E goconst -E unparam"
       golangci-lint run -E gosec -E goconst -E unparam

--- a/src/commands/go-lint.yaml
+++ b/src/commands/go-lint.yaml
@@ -1,15 +1,5 @@
-parameters:
-  new-from-rev:
-    description: "Show only new issues created after git revision REV."
-    type: "string"
 steps:
   - run: |
-      NEW_FROM_REV="<< parameters.new-from-rev >>"
       # Enable some additional linters
-      ENABLED=" -E gosec -E goconst -E unparam"
-      LINT_ARGS=" "
-      if [ -n "${NEW_FROM_REV}" ]; then
-        LINT_ARGS+=" --new-from-rev ${NEW_FROM_REV}";
-      fi
-      echo "Running: golangci-lint run $ENABLED $LINT_ARGS"
-      golangci-lint run $ENABLED $LINT_ARGS
+      echo "Running: golangci-lint run -E gosec -E goconst -E unparam"
+      golangci-lint run -E gosec -E goconst -E unparam

--- a/src/jobs/go-lint.yaml
+++ b/src/jobs/go-lint.yaml
@@ -1,11 +1,5 @@
 description: "Runs golanglint-ci against the codebase."
-parameters:
-  new-from-rev:
-    default: ""
-    description: "Show only new issues created after git revision REV."
-    type: "string"
 executor: go-lint
 steps:
   - checkout
-  - go-lint:
-      new-from-rev: << parameters.new-from-rev >>
+  - go-lint

--- a/src/jobs/go-lint.yaml
+++ b/src/jobs/go-lint.yaml
@@ -1,47 +1,11 @@
 description: "Runs golanglint-ci against the codebase."
 parameters:
-  disable:
-    default: ""
-    description: "The names of default linting modules to skip."
-    type: "string"
-  disable-all:
-    default: false
-    description: "If set, will disable all linters (except those included by '--enable')."
-    type: "boolean"
-  enable:
-    default: ""
-    description: "The names of additional linting modules to run."
-    type: "string"
   new-from-rev:
     default: ""
     description: "Show only new issues created after git revision REV."
     type: "string"
-  presets:
-    default: "none"
-    description: "Enable preset list of linters (bugs|complexity|format|performance|style|unused)."
-    type: "enum"
-    enum: ["bugs", "complexity", "format", "performance", "style", "unused", "none"]
-  skip-dirs:
-    default: ""
-    description: "Regular expressions for folder paths which should be skipped."
-    type: "string"
-  skip-files:
-    default: ""
-    description: "Regular expressions for file paths which should be skipped."
-    type: "string"
-  verbose:
-    default: false
-    description: "If set, will print verbose output."
-    type: "boolean"
 executor: go-lint
 steps:
   - checkout
   - go-lint:
-      disable: << parameters.disable >>
-      disable-all: << parameters.disable-all >>
-      enable: << parameters.enable >>
       new-from-rev: << parameters.new-from-rev >>
-      presets: << parameters.presets >>
-      skip-dirs: << parameters.skip-dirs >>
-      skip-files: << parameters.skip-files >>
-      verbose: << parameters.verbose >>


### PR DESCRIPTION
new-from-rev is suggested so we don't have to re-lint the whole repo on every change, but this could also be removed. The name wouldn't be my first choice, but I want to keep consistency with the upstream tool

Towards https://github.com/giantswarm/giantswarm/issues/8901 and https://github.com/giantswarm/giantswarm/issues/7658

## Checklist

~~- [ ] Update changelog in CHANGELOG.md.~~ - no change
