### PR TITLE
Remove all parameters except config

### DIFF
--- a/src/commands/gitleaks.yaml
+++ b/src/commands/gitleaks.yaml
@@ -1,28 +1,13 @@
 parameters:
-  commit-to:
-    description: "Commit to stop audit (rev. SHA). This is the oldest commit to audit. Default is the root commit. \
-    In CircleCI, you can use << pipeline.git.base_revision >> to scan only since the parent commit."
-    type: "string"
   config:
-    description: "Path to a config file to use for gitleaks configuration."
-    type: "string"
-  files-at-commit:
-    description: "Scan all files as they are in this commit (rev. SHA)."
+    description: "(Optional) Path to a config file to use for gitleaks configuration."
     type: "string"
 steps:
   - run: |
-      COMMIT_TO="<< parameters.commit-to >>"
       CONFIG="<< parameters.config >>"
-      FILES_AT_COMMIT="<< parameters.files-at-commit >>"
       LINT_ARGS=" "
-      if [ -n "${COMMIT_TO}" ]; then
-        LINT_ARGS+=" --commit-to=${COMMIT_TO}";
-      fi
       if [ -n "${CONFIG}" ]; then
         LINT_ARGS+=" --config=${CONFIG}";
-      fi
-      if [ -n "${FILES_AT_COMMIT}" ]; then
-        LINT_ARGS+=" --files-at-commit=${FILES_AT_COMMIT}";
       fi
       echo "Running gitleaks $LINT_ARGS --redact -v --pretty -r ./"
       gitleaks $LINT_ARGS --redact -v --pretty -r ./

--- a/src/commands/gitleaks.yaml
+++ b/src/commands/gitleaks.yaml
@@ -1,13 +1,4 @@
 parameters:
-  branch:
-    description: "The branch to audit."
-    type: "string"
-  commit:
-    description: "Scan all files changed by this commit (rev. SHA)."
-    type: "string"
-  commit-from:
-    description: "Commit to start audit from (rev. SHA). This is the most recent commit to audit. Default is the latest."
-    type: "string"
   commit-to:
     description: "Commit to stop audit (rev. SHA). This is the oldest commit to audit. Default is the root commit. \
     In CircleCI, you can use << pipeline.git.base_revision >> to scan only since the parent commit."
@@ -15,99 +6,23 @@ parameters:
   config:
     description: "Path to a config file to use for gitleaks configuration."
     type: "string"
-  debug:
-    description: "If true, will print debug messages."
-    type: "boolean"
-  depth:
-    description: "Number of commits to audit."
-    type: "integer"
   files-at-commit:
-    description: "Scan all files as they are in this commit (rev. SHA), even if they did not change."
+    description: "Scan all files as they are in this commit (rev. SHA)."
     type: "string"
-  pretty:
-    description: "If true, pretty-prints json output (if output is being printed with -v. Default: true)."
-    type: "boolean"
-  redact:
-    description: "If true, redact secrets from log messages and leaks (default: false)."
-    type: "boolean"
-  report:
-    description: "Path to write json leaks file."
-    type: "string"
-  report-format:
-    description: "Format report as json or csv (default: json)."
-    type: "enum"
-    enum: ["json", "csv"]
-  threads:
-    description: "Maximum number of threads gitleaks spawns."
-    type: "integer"
-  timeout:
-    description: "Time allowed per audit. E.g. 10us, 30s, 1m, 1h10m1s."
-    type: "string"
-  verbose:
-    description: "If true, will print verbose output."
-    type: "boolean"
 steps:
   - run: |
-      BRANCH="<< parameters.branch >>"
-      COMMIT="<< parameters.commit >>"
-      COMMIT_FROM="<< parameters.commit-from >>"
       COMMIT_TO="<< parameters.commit-to >>"
       CONFIG="<< parameters.config >>"
-      DEBUG="<< parameters.debug >>"
-      DEPTH="<< parameters.depth >>"
       FILES_AT_COMMIT="<< parameters.files-at-commit >>"
-      PRETTY="<< parameters.pretty >>"
-      REDACT="<< parameters.redact >>"
-      REPORT="<< parameters.report >>"
-      REPORT_FORMAT="<< parameters.report-format >>"
-      THREADS="<< parameters.threads >>"
-      TIMEOUT="<< parameters.timeout >>"
-      VERBOSE="<< parameters.verbose >>"
       LINT_ARGS=" "
-      if [ -n "${BRANCH}" ]; then
-        LINT_ARGS+=" --branch=${BRANCH}";
-      fi
-      if [ -n "${COMMIT}" ]; then
-        LINT_ARGS+=" --commit=${COMMIT}";
-      fi
-      if [ -n "${COMMIT_FROM}" ]; then
-        LINT_ARGS+=" --commit-from=${COMMIT_FROM}";
-      fi
       if [ -n "${COMMIT_TO}" ]; then
         LINT_ARGS+=" --commit-to=${COMMIT_TO}";
       fi
       if [ -n "${CONFIG}" ]; then
         LINT_ARGS+=" --config=${CONFIG}";
       fi
-      if [ "${DEBUG}" = "true" ]; then
-        LINT_ARGS+=" --debug";
-      fi
-      if [ -n "${DEPTH}" ]; then
-        LINT_ARGS+=" --depth=${DEPTH}";
-      fi
       if [ -n "${FILES_AT_COMMIT}" ]; then
         LINT_ARGS+=" --files-at-commit=${FILES_AT_COMMIT}";
       fi
-      if [ "${PRETTY}" = "true" ]; then
-        LINT_ARGS+=" --pretty";
-      fi
-      if [ "${REDACT}" = "true" ]; then
-        LINT_ARGS+=" --redact";
-      fi
-      if [ -n "${REPORT}" ]; then
-        LINT_ARGS+=" --report=${REPORT}";
-        if [ -n "${REPORT_FORMAT}" ]; then
-          LINT_ARGS+=" --report-format=${REPORT_FORMAT}";
-        fi
-      fi
-      if [ -n "${THREADS}" ]; then
-        LINT_ARGS+=" --threads=${THREADS}";
-      fi
-      if [ -n "${TIMEOUT}" ]; then
-        LINT_ARGS+=" --timeout=${TIMEOUT}";
-      fi
-      if [ "${VERBOSE}" = "true" ]; then
-        LINT_ARGS+=" --verbose";
-      fi
-      echo "Running gitleaks $LINT_ARGS -r ./"
-      gitleaks $LINT_ARGS -r ./
+      echo "Running gitleaks $LINT_ARGS --redact -v --pretty -r ./"
+      gitleaks $LINT_ARGS --redact -v --pretty -r ./

--- a/src/commands/gitleaks.yaml
+++ b/src/commands/gitleaks.yaml
@@ -9,5 +9,4 @@ steps:
       if [ -n "${CONFIG}" ]; then
         LINT_ARGS+=" --config=${CONFIG}";
       fi
-      echo "Running gitleaks $LINT_ARGS --redact -v --pretty -r ./"
       gitleaks $LINT_ARGS --redact -v --pretty -r ./

--- a/src/jobs/gitleaks.yaml
+++ b/src/jobs/gitleaks.yaml
@@ -1,18 +1,5 @@
 description: "Runs the gitleaks tool to search for secrets contained in commits since the last revision."
 parameters:
-  branch:
-    default: ""
-    description: "The branch to audit. In CircleCI, you can use $CIRCLE_BRANCH to reference the current branch."
-    type: "string"
-  commit:
-    default: ""
-    description: "Scan all files changed by this commit (rev. SHA)."
-    type: "string"
-  # Commit-from and commit-to limit the scan to a specific range of commits https://github.com/zricethezav/gitleaks/issues/315
-  commit-from:
-    default: ""
-    description: "Commit to start audit from (rev. SHA). This is the most recent commit to audit. Default is the latest."
-    type: "string"
   commit-to:
     default: ""
     description: "Commit to stop audit (rev. SHA). This is the oldest commit to audit. Default is the root commit. \
@@ -22,63 +9,14 @@ parameters:
     default: ""
     description: "Path to a config file to use for gitleaks configuration."
     type: "string"
-  debug:
-    default: false
-    description: "If true, will print debug messages."
-    type: "boolean"
-  depth:
-    default: 0
-    description: "Number of commits to audit (default: 0 / all commits)."
-    type: "integer"
   files-at-commit:
     default: ""
-    description: "Scan all files as they are in this commit (rev. SHA), even if they did not change."
+    description: "Scan all files as they are in this commit (rev. SHA)."
     type: "string"
-  pretty:
-    default: true
-    description: "If true, pretty-prints json output (default: true)."
-    type: "boolean"
-  redact:
-    default: false
-    description: "If true, redact secrets from log messages and leaks (default: false)."
-    type: "boolean"
-  report:
-    default: ""
-    description: "Path to write json leaks file."
-    type: "string"
-  report-format:
-    default: "json"
-    description: "Format report as json or csv (default: json)."
-    type: "enum"
-    enum: ["json", "csv"]
-  threads:
-    default: 0
-    description: "Maximum number of threads gitleaks spawns (default: ALL - 1)."
-    type: "integer"
-  timeout:
-    default: ""
-    description: "Time allowed per audit. E.g. 10us, 30s, 1m, 1h10m1s."
-    type: "string"
-  verbose:
-    default: false
-    description: "If true, will print verbose output."
-    type: "boolean"
 executor: gitleaks
 steps:
   - checkout
   - gitleaks:
-      branch: << parameters.branch >>
-      commit: << parameters.commit >>
-      commit-from: << parameters.commit-from >>
       commit-to: << parameters.commit-to >>
       config: << parameters.config >>
-      debug: << parameters.debug >>
-      depth: << parameters.depth >>
       files-at-commit: << parameters.files-at-commit >>
-      pretty: << parameters.pretty >>
-      redact: << parameters.redact >>
-      report: << parameters.report >>
-      report-format: << parameters.report-format >>
-      threads: << parameters.threads >>
-      timeout: << parameters.timeout >>
-      verbose: << parameters.verbose >>

--- a/src/jobs/gitleaks.yaml
+++ b/src/jobs/gitleaks.yaml
@@ -1,22 +1,11 @@
 description: "Runs the gitleaks tool to search for secrets contained in commits since the last revision."
 parameters:
-  commit-to:
-    default: ""
-    description: "Commit to stop audit (rev. SHA). This is the oldest commit to audit. Default is the root commit. \
-    In CircleCI, you can use << pipeline.git.base_revision >> to scan only since the parent commit."
-    type: "string"
   config:
     default: ""
-    description: "Path to a config file to use for gitleaks configuration."
-    type: "string"
-  files-at-commit:
-    default: ""
-    description: "Scan all files as they are in this commit (rev. SHA)."
+    description: "(Optional) Path to a config file to use for gitleaks configuration."
     type: "string"
 executor: gitleaks
 steps:
   - checkout
   - gitleaks:
-      commit-to: << parameters.commit-to >>
       config: << parameters.config >>
-      files-at-commit: << parameters.files-at-commit >>


### PR DESCRIPTION
I think this would be minimal for us to work with. Keeps the ability to whitelist files and limit the scope to a single commit or changes since the last rev

Toward https://github.com/giantswarm/giantswarm/issues/8901

## Checklist

~~- [ ] Update changelog in CHANGELOG.md.~~ - no change
