### PR TITLE
Remove docker layer caching from remote docker setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed Docker layer caching from remote docker setup (affects push-to-docker and push-to-docker-legacy)
+
 ## [0.7.0] 2020-02-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Removed
 
 - Removed Docker layer caching from remote docker setup (affects push-to-docker and push-to-docker-legacy)
 

--- a/src/jobs/push-to-docker-legacy.yaml
+++ b/src/jobs/push-to-docker-legacy.yaml
@@ -17,8 +17,7 @@ parameters:
     default: "master"
 steps:
   - checkout
-  - setup_remote_docker:
-      docker_layer_caching: true
+  - setup_remote_docker
   - attach_workspace:
       at: .
   - push-to-docker-legacy:

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -17,8 +17,7 @@ parameters:
     default: "master"
 steps:
   - checkout
-  - setup_remote_docker:
-      docker_layer_caching: true
+  - setup_remote_docker
   - attach_workspace:
       at: .
   - push-to-docker:


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/9240

Removes docker layer caching from remote docker jobs

## Checklist

- [x] Update changelog in CHANGELOG.md.
