### PR TITLE
Run go-lint as part of go-test command for legacy and modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add changelog-lint job.
+- Enables linting during go-test command
 - Introduce `integration-test` job for running `Go` integration tests in a `KIND`
   cluster.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Enables linting during go-test command
+- Add changelog-lint job.
 - Introduce `integration-test` job for running `Go` integration tests in a `KIND`
   cluster.
+- Enables linting during go-test command.
 
 ### Removed
 

--- a/src/commands/go-lint.yaml
+++ b/src/commands/go-lint.yaml
@@ -1,3 +1,0 @@
-steps:
-  - run: |
-      golangci-lint run -E gosec -E goconst -E unparam

--- a/src/commands/go-test-legacy.yaml
+++ b/src/commands/go-test-legacy.yaml
@@ -42,6 +42,11 @@ steps:
         cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
         CGO_ENABLED=0 go vet ./...
   - run:
+      name: "architect/go-test-legacy: Running golangci-lint"
+      command: |
+        cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
+        CGO_ENABLED=0 golangci-lint run -E gosec -E goconst -E unparam
+  - run:
       name: "architect/go-test-legacy: Running go test"
       command: |
         cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -22,4 +22,6 @@ steps:
   - run: |
       CGO_ENABLED=0 go vet ./...
   - run: |
+      CGO_ENABLED=0 golangci-lint run -E gosec -E goconst -E unparam
+  - run: |
       CGO_ENABLED=0 go test  -ldflags "$(cat .ldflags)" ./...

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:0.0.0-0670068376661ce04ff6f6285bb1f740d64120c0
+    image: quay.io/giantswarm/architect:latest

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:latest
+    image: quay.io/giantswarm/architect:0.0.0-0670068376661ce04ff6f6285bb1f740d64120c0

--- a/src/executors/go-lint.yaml
+++ b/src/executors/go-lint.yaml
@@ -1,2 +1,0 @@
-docker:
-    - image: quay.io/giantswarm/golangci-lint:v1.23.6

--- a/src/jobs/go-lint.yaml
+++ b/src/jobs/go-lint.yaml
@@ -1,5 +1,0 @@
-description: "Runs golanglint-ci against the codebase."
-executor: go-lint
-steps:
-  - checkout
-  - go-lint


### PR DESCRIPTION
Runs golangci-lint as part of the existing go-test and go-test-legacy commands instead of setting up separate environment and using separate executor.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] After the release update architect orb version in .circleci/config.yml.
