### PR TITLE
Update orb-tools to 8.27.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   architect: giantswarm/architect@dev:lint-changelog
-  orb-tools: circleci/orb-tools@8.3.0
+  orb-tools: circleci/orb-tools@8.27.6
 
 workflows:
   catalog_build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce `integration-test` job for running `Go` integration tests in a `KIND`
   cluster.
 
+### Changed
+
+- Update CircleCI config to use `orb-tools@8.27.6`.
+
 ### Removed
 
-- Removed Docker layer caching from remote docker setup (affects push-to-docker and push-to-docker-legacy)
+- Remove Docker layer caching from remote docker setup (affects push-to-docker and push-to-docker-legacy)
 
 ## [0.7.0] - 2020-02-26
 


### PR DESCRIPTION
There was [a bug in the `orb-tools` orb](https://circleci.com/gh/giantswarm/architect-orb/1327) which caused checkouts of repo tags (instead of branches) to fail (in short--checkout requires `git` and `ssh` to be present in image, doesn't find it and uses fallback old version of git which can't checkout repos at tags). The fix https://github.com/CircleCI-Public/orb-tools-orb/pull/46 was released in [8.27.4](https://github.com/CircleCI-Public/orb-tools-orb/compare/v8.27.3...v8.27.4). We're still on 8.3.0 which was released over a year ago. I think this will be sufficient to fix our `architect-orb` build on tag issue which is blocking the [0.8.0 release](https://github.com/giantswarm/architect-orb/pull/88).

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] After the release update architect orb version in .circleci/config.yml.
