### PR TITLE
Update to architect-orb v0.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:lint-changelog
+  architect: giantswarm/architect@0.8.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:


### PR DESCRIPTION
Follow-up PR for step 2 in the release checklist of https://github.com/giantswarm/architect-orb/pull/88. I'm using the latest released architect-orb version in the architect-orb CircleCI config.