### PR TITLE
helm-chart-template: verify chart version in tagged operator builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for optionally attaching the persisted workspace in the `push-to-app-catalog` job.
 - Introduce Helm Chart testing and linting in `push-to-app-catalog` job.
-- Add changelog-lint job.
+- Add `changelog-lint` job.
 - Introduce `integration-test` job for running `Go` integration tests in a `KIND`
   cluster.
+- Verify chart, operator and tag versions while packing helm chart on tagged
+  operator build in `push-to-app-collection` job.
 
 ### Changed
 

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -5,7 +5,8 @@ parameters:
 steps:
   - run:
       name: "architect/helm-chart-template: Template chart"
-      command: architect helm template --dir ./helm/<<parameters.chart>>
+      command: |
+          architect helm template --dir ./helm/<<parameters.chart>>
   - run:
       name: "architect/helm-chart-template: Check if build is triggered by a tagged operator"
       command: |

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -16,8 +16,14 @@ steps:
       name: "architect/helm-chart-template: For tagged operator build extract version in Chart.yaml"
       command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || grep  -E 'version:' helm/${CIRCLE_PROJECT_REPONAME}/Chart.yaml | cut -d '"' -f 2 | tee .helm-chart-template-chart-version
   - run:
+      name: "architect/helm-chart-template: For tagged operator build extract version from the build tag"
+      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || echo "${CIRCLE_TAG#v}" | tee .helm-chart-template-tag-version
+  - run:
       name: "architect/helm-chart-template: For tagged operator build verify operator version and chart version are the same"
       command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-chart-version
+  - run:
+      name: "architect/helm-chart-template: For tagged operator build verify operator version and tag version are the same"
+      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-tag-version
   - run:
       name: "architect/helm-chart-template: Cleanup"
       command: rm .helm-chart-template-*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -22,7 +22,7 @@ steps:
       name: "architect/helm-chart-template: For tagged operator build extract the version in Chart.yaml"
       command: |
           [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
-          grep  -E 'version:' helm/<<parameters.chart>>/Chart.yaml | cut -d '"' -f 2 | tee .helm_chart_template_chart_version
+          grep  -E 'version:' helm/<<parameters.chart>>/Chart.yaml | cut -d ' ' -f 2 | tee .helm_chart_template_chart_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the version from the build tag"
       command: |

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -7,23 +7,37 @@ steps:
       name: "architect/helm-chart-template: Template chart"
       command: architect helm template --dir ./helm/<<parameters.chart>>
   - run:
-      name: "architect/helm-chart-template: Check if build is triggered by tagged operator"
-      command: ! ([ -f pkg/project/project.go ] && [ ! -z $CIRCLE_TAG ]) && echo "skip" || touch .helm-chart-template-tagged-operator-build
+      name: "architect/helm-chart-template: Check if build is triggered by a tagged operator"
+      command: |
+          [ ! -f pkg/project/project.go ] && echo "skip: not operator build" && exit 0
+          [ -z $CIRCLE_TAG ]) && echo "skip: not tag build" && exit 0
+          touch .helm-chart-template-tagged-operator-build
   - run:
-      name: "architect/helm-chart-template: For tagged operator build extract operator version"
-      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || grep  -E 'version\s+= ".*' pkg/project/project.go | cut -d '"' -f 2 | tee .helm-chart-template-operator-version
+      name: "architect/helm-chart-template: For tagged operator build extract the operator version"
+      command: |
+          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
+          grep  -E 'version\s+= ".*' pkg/project/project.go | cut -d '"' -f 2 | tee .helm-chart-template-operator-version
   - run:
-      name: "architect/helm-chart-template: For tagged operator build extract version in Chart.yaml"
-      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || grep  -E 'version:' helm/${CIRCLE_PROJECT_REPONAME}/Chart.yaml | cut -d '"' -f 2 | tee .helm-chart-template-chart-version
+      name: "architect/helm-chart-template: For tagged operator build extract the version in Chart.yaml"
+      command: |
+          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
+          grep  -E 'version:' helm/${CIRCLE_PROJECT_REPONAME}/Chart.yaml | cut -d '"' -f 2 | tee .helm-chart-template-chart-version
   - run:
-      name: "architect/helm-chart-template: For tagged operator build extract version from the build tag"
-      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || echo "${CIRCLE_TAG#v}" | tee .helm-chart-template-tag-version
+      name: "architect/helm-chart-template: For tagged operator build extract the version from the build tag"
+      command: |
+          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
+          echo "${CIRCLE_TAG#v}" | tee .helm-chart-template-tag-version
   - run:
-      name: "architect/helm-chart-template: For tagged operator build verify operator version and chart version are the same"
-      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-chart-version
+      name: "architect/helm-chart-template: For tagged operator build verify the operator version and the chart version are the same"
+      command: |
+          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
+          git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-chart-version
   - run:
-      name: "architect/helm-chart-template: For tagged operator build verify operator version and tag version are the same"
-      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-tag-version
+      name: "architect/helm-chart-template: For tagged operator build verify the operator version and the tag version are the same"
+      command: |
+          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
+          git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-tag-version
   - run:
       name: "architect/helm-chart-template: Cleanup"
-      command: rm .helm-chart-template-*
+      command: |
+          rm .helm-chart-template-*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -4,4 +4,20 @@ parameters:
     type: string
 steps:
   - run:
+      name: "architect/helm-chart-template: Template chart"
       command: architect helm template --dir ./helm/<<parameters.chart>>
+  - run:
+      name: "architect/helm-chart-template: Check if build is triggered by tagged operator"
+      command: ! ([ -f pkg/project/project.go ] && [ ! -z $CIRCLE_TAG ]) && echo "skip" || touch .helm-chart-template-tagged-operator-build
+  - run:
+      name: "architect/helm-chart-template: For tagged operator build extract operator version"
+      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || grep  -E 'version\s+= ".*' pkg/project/project.go | cut -d '"' -f 2 | tee .helm-chart-template-operator-version
+  - run:
+      name: "architect/helm-chart-template: For tagged operator build extract version in Chart.yaml"
+      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || grep  -E 'version:' helm/${CIRCLE_PROJECT_REPONAME}/Chart.yaml | cut -d '"' -f 2 | tee .helm-chart-template-chart-version
+  - run:
+      name: "architect/helm-chart-template: For tagged operator build verify operator version and chart version are the same"
+      command: ! [ -f .helm-chart-template-tagged-operator-build ] && echo "skip" || git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-chart-version
+  - run:
+      name: "architect/helm-chart-template: Cleanup"
+      command: rm .helm-chart-template-*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -12,33 +12,33 @@ steps:
       command: |
           [ ! -f pkg/project/project.go ] && echo "skip: not operator build" && exit 0
           [ -z $CIRCLE_TAG ] && echo "skip: not tag build" && exit 0
-          touch .helm-chart-template-tagged-operator-build
+          touch .helm_chart_template_tagged_operator_build
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the operator version"
       command: |
-          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
-          grep  -E 'version\s+= ".*' pkg/project/project.go | cut -d '"' -f 2 | tee .helm-chart-template-operator-version
+          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          grep  -E 'version\s+= ".*' pkg/project/project.go | cut -d '"' -f 2 | tee .helm_chart_template_operator_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the version in Chart.yaml"
       command: |
-          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
-          grep  -E 'version:' helm/<<parameters.chart>>/Chart.yaml | cut -d '"' -f 2 | tee .helm-chart-template-chart-version
+          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          grep  -E 'version:' helm/<<parameters.chart>>/Chart.yaml | cut -d '"' -f 2 | tee .helm_chart_template_chart_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the version from the build tag"
       command: |
-          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
-          echo "${CIRCLE_TAG#v}" | tee .helm-chart-template-tag-version
+          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          echo "${CIRCLE_TAG#v}" | tee .helm_chart_template_tag_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build verify the operator version and the chart version are the same"
       command: |
-          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
-          git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-chart-version
+          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          git diff --exit-code --no-index .helm_chart_template_operator_version .helm_chart_template_chart_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build verify the operator version and the tag version are the same"
       command: |
-          [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
-          git diff --exit-code --no-index .helm-chart-template-operator-version .helm-chart-template-tag-version
+          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          git diff --exit-code --no-index .helm_chart_template_operator_version .helm_chart_template_tag_version
   - run:
       name: "architect/helm-chart-template: Cleanup"
       command: |
-          rm -v .helm-chart-template*
+          rm -v .helm_chart_template*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -41,4 +41,4 @@ steps:
   - run:
       name: "architect/helm-chart-template: Cleanup"
       command: |
-          rm .helm-chart-template-*
+          rm -v .helm-chart-template*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -22,7 +22,7 @@ steps:
       name: "architect/helm-chart-template: For tagged operator build extract the version in Chart.yaml"
       command: |
           [ ! -f .helm-chart-template-tagged-operator-build ] && echo "skip: not tagged operator build" && exit 0
-          grep  -E 'version:' helm/${CIRCLE_PROJECT_REPONAME}/Chart.yaml | cut -d '"' -f 2 | tee .helm-chart-template-chart-version
+          grep  -E 'version:' helm/<<parameters.chart>>/Chart.yaml | cut -d '"' -f 2 | tee .helm-chart-template-chart-version
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the version from the build tag"
       command: |

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -12,33 +12,33 @@ steps:
       command: |
           [ ! -f pkg/project/project.go ] && echo "skip: not operator build" && exit 0
           [ -z $CIRCLE_TAG ] && echo "skip: not tag build" && exit 0
-          touch .helm_chart_template_tagged_operator_build
+          touch .build_tagged_operator_build
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the operator version"
       command: |
-          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
-          grep  -E 'version\s+= ".*' pkg/project/project.go | cut -d '"' -f 2 | tee .helm_chart_template_operator_version
+          [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          grep -E 'version\s+= ".*' pkg/project/project.go | cut -d '"' -f 2 | tee .build_operator_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the version in Chart.yaml"
       command: |
-          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
-          grep  -E 'version:' helm/<<parameters.chart>>/Chart.yaml | cut -d ' ' -f 2 | tee .helm_chart_template_chart_version
+          [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          grep -E 'version:' helm/<<parameters.chart>>/Chart.yaml | cut -d ' ' -f 2 | tee .build_chart_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the version from the build tag"
       command: |
-          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
-          echo "${CIRCLE_TAG#v}" | tee .helm_chart_template_tag_version
+          [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          echo "${CIRCLE_TAG#v}" | tee .build_tag_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build verify the operator version and the chart version are the same"
       command: |
-          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
-          git diff --exit-code --no-index .helm_chart_template_operator_version .helm_chart_template_chart_version
+          [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          git diff --exit-code --no-index .build_operator_version .build_chart_version
   - run:
       name: "architect/helm-chart-template: For tagged operator build verify the operator version and the tag version are the same"
       command: |
-          [ ! -f .helm_chart_template_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
-          git diff --exit-code --no-index .helm_chart_template_operator_version .helm_chart_template_tag_version
+          [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
+          git diff --exit-code --no-index .build_operator_version .build_tag_version
   - run:
       name: "architect/helm-chart-template: Cleanup"
       command: |
-          rm -v .helm_chart_template*
+          rm -v .build_*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -11,7 +11,7 @@ steps:
       name: "architect/helm-chart-template: Check if build is triggered by a tagged operator"
       command: |
           [ ! -f pkg/project/project.go ] && echo "skip: not operator build" && exit 0
-          [ -z $CIRCLE_TAG ]) && echo "skip: not tag build" && exit 0
+          [ -z $CIRCLE_TAG ] && echo "skip: not tag build" && exit 0
           touch .helm-chart-template-tagged-operator-build
   - run:
       name: "architect/helm-chart-template: For tagged operator build extract the operator version"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8635

Tests:
- operator and chart versions don't match https://circleci.com/gh/giantswarm/pawel-test/19
- operator and tag versions don't match https://circleci.com/gh/giantswarm/pawel-test/20
- operator, chart and tag versions match (build fails but the helm-chart-template passes with validation) https://circleci.com/gh/giantswarm/pawel-test/21 

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] After the release update architect orb version in .circleci/config.yml.