### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Enables linting during go-test command.
+- Enable linting during go-test command.
 
 ## [0.8.0] - 2020-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.0] - 2020-03-09
+## [0.8.1] - 2020-03-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2020-03-09
+
+### Added
+
+- Enables linting during go-test command.
+
 ## [0.8.0] - 2020-03-05
 
 ### Added
@@ -16,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add changelog-lint job.
 - Introduce `integration-test` job for running `Go` integration tests in a `KIND`
   cluster.
-- Enables linting during go-test command.
 
 ### Changed
 


### PR DESCRIPTION
Incorrect merge in last PR - move lint changelog to 0.8.1, will release this version following this PR

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] After the release update architect orb version in .circleci/config.yml.
