### PR TITLE
Disable Helm version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix GOPATH problem in `integration-test` job.
+- Disable version bump check for Helm lint
 
 ## [0.8.1] - 2020-03-09
 

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -2,4 +2,4 @@
 description: Lint Helm charts
 steps:
   - run: |
-      ct lint --validate-maintainers=false --chart-dirs helm
+      ct lint --validate-maintainers=false --check-version-increment=false --chart-dirs helm


### PR DESCRIPTION
Since we use architect to bump the version of Helm chart, this check isn't
needed. It can in fact lead to false failures as it fails to understand the last
version.


:wrench: Please make sure to familiarize yourself with [Development section of README.md](https://github.com/giantswarm/architect-orb/blob/master/README.md#development) before releasing a PR to this repository.

:warning: If you want to **create a new release** of this orb please read [Releases section of README.md](https://github.com/giantswarm/architect-orb/blob/master/README.md#releases) carefully :exclamation:

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] After the release update architect orb version in .circleci/config.yml.