### PR TITLE
Options to disable and make helm lint less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix GOPATH problem in `integration-test` job.
 - Disable version bump check for Helm lint
+- Add options to make Helm linting less strict and to completely disable helm lint
 
 ## [0.8.1] - 2020-03-09
 

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -1,11 +1,11 @@
 ---
 parameters:
-  lenient:
-    description: "Use more lenient lint rules"
-    type: "boolean"
-    default: false
   disable:
     description: "Disable linting alogether"
+    type: "boolean"
+    default: false
+  lenient:
+    description: "Use more lenient lint rules"
     type: "boolean"
     default: false
 description: Lint Helm charts

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -1,5 +1,25 @@
 ---
+parameters:
+  lenient:
+    description: "Use more lenient lint rules"
+    type: "boolean"
+    default: false
+  disable:
+    description: "Disable linting alogether"
+    type: "boolean"
+    default: false
 description: Lint Helm charts
 steps:
-  - run: |
-      ct lint --validate-maintainers=false --check-version-increment=false --chart-dirs helm
+  - unless:
+      condition: <<parameters.disable>>
+      steps:
+        - when:
+            condition: <<parameters.lenient>>
+            steps:
+              - run: |
+                  ct lint --validate-maintainers=false --check-version-increment=false --validate-chart-schema=false --chart-dirs helm
+        - unless:
+            condition: <<parameters.lenient>>
+            steps:
+              - run: |
+                  ct lint --validate-maintainers=false --check-version-increment=false --chart-dirs helm

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -13,6 +13,14 @@ parameters:
   chart:
     description: "Name of the chart inside helm directory to push to the App Catalog."
     type: "string"
+  lenient-lint:
+    description: "Use more lenient lint rules"
+    type: "boolean"
+    default: false
+  disable-lint:
+    description: "Disable linting alogether"
+    type: "boolean"
+    default: false
 steps:
   - checkout
   - when:
@@ -24,7 +32,9 @@ steps:
   - prepare-catalogbot-git-ssh
   - helm-chart-template:
       chart: <<parameters.chart>>
-  - helm-lint
+  - helm-lint:
+      lenient: <<parameters.lenient-lint>>
+      disable: <<parameters.disable-lint>>
   - package-and-push:
       app_catalog: <<parameters.app_catalog>>
       app_catalog_test: <<parameters.app_catalog_test>>

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -13,12 +13,12 @@ parameters:
   chart:
     description: "Name of the chart inside helm directory to push to the App Catalog."
     type: "string"
-  lenient-lint:
-    description: "Use more lenient lint rules"
-    type: "boolean"
-    default: false
   disable-lint:
     description: "Disable linting alogether"
+    type: "boolean"
+    default: false
+  lenient-lint:
+    description: "Use more lenient lint rules"
     type: "boolean"
     default: false
 steps:


### PR DESCRIPTION
There are cases where existing apps (not managed apps) will have a minimal Chart
file. In these cases, give the developers an option to make the check less
strict or completely disable.

Disabling might be useful where templates deliberately reference empty or non
existing values (in cases where values are taken from installations repo). It is
possible to create dummy values, but I think giving the option to disable
creates less of an impediment to development.

In both cases (lenient and disable), the default is false.

:wrench: Please make sure to familiarize yourself with [Development section of README.md](https://github.com/giantswarm/architect-orb/blob/master/README.md#development) before releasing a PR to this repository.

:warning: If you want to **create a new release** of this orb please read [Releases section of README.md](https://github.com/giantswarm/architect-orb/blob/master/README.md#releases) carefully :exclamation:

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] After the release update architect orb version in .circleci/config.yml.
