### PR TITLE
Use `charts` instead of `chart-dirs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix GOPATH problem in `integration-test` job.
 - Disable version bump check for Helm lint
+- Helm lint supports single chart rather than entire directory
 
 ## [0.8.1] - 2020-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix GOPATH problem in `integration-test` job.
 - Disable version bump check for Helm lint
-- Helm lint supports single chart rather than entire directory
+- Helm lint supports single chart rather than entire directory disabling version bump check.
 
 ## [0.8.1] - 2020-03-09
 

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -6,4 +6,4 @@ parameters:
 description: Lint Helm charts
 steps:
   - run: |
-      ct lint --validate-maintainers=false --charts <<parameters.charts>>
+      ct lint --validate-maintainers=false --charts="helm/<<parameters.charts>>"

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -2,7 +2,7 @@
 parameters:
   chart:
     type: "string"
-description: Lint Helm charts
+description: Lint Helm chart
 steps:
   - run: |
-      ct lint --validate-maintainers=false --charts="helm/<<parameters.charts>>"
+      ct lint --validate-maintainers=false --charts="helm/<<parameters.chart>>"

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -1,5 +1,9 @@
 ---
+parameters:
+  charts:
+    description: "Comma seperated list of charts to lint (relative path)"
+    type: "string"
 description: Lint Helm charts
 steps:
   - run: |
-      ct lint --validate-maintainers=false --check-version-increment=false --chart-dirs helm
+      ct lint --validate-maintainers=false --charts <<parameters.charts>>

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -1,7 +1,6 @@
 ---
 parameters:
-  charts:
-    description: "Comma seperated list of charts to lint (relative path)"
+  chart:
     type: "string"
 description: Lint Helm charts
 steps:

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -24,7 +24,8 @@ steps:
   - prepare-catalogbot-git-ssh
   - helm-chart-template:
       chart: <<parameters.chart>>
-  - helm-lint
+  - helm-lint:
+      charts: "helm/<< parameters.chart >>"
   - package-and-push:
       app_catalog: <<parameters.app_catalog>>
       app_catalog_test: <<parameters.app_catalog_test>>

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -25,7 +25,7 @@ steps:
   - helm-chart-template:
       chart: <<parameters.chart>>
   - helm-lint:
-      charts: "helm/<< parameters.chart >>"
+      chart: "<< parameters.chart >>"
   - package-and-push:
       app_catalog: <<parameters.app_catalog>>
       app_catalog_test: <<parameters.app_catalog_test>>


### PR DESCRIPTION
Using `charts` implies that version bump check is disabled, it is also better to
be precise as not all charts in a directory maybe templated correctly. For
example, `push-to-app-catalog` job only takes a single chart and will template
that.

The command can still support multiple charts if need be, but now we can
also specify a single chart.

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
