### PR TITLE
Fix helm chart template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't run cleanup for helm chart template command on non-tagged builds.
+
 ## [0.8.2] - 2020-03-10
 
 ### Changed

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -42,4 +42,4 @@ steps:
       name: "architect/helm-chart-template: Cleanup"
       command: |
           [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
-          rm -v .build_*
+          rm -rv .build_*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -41,5 +41,4 @@ steps:
   - run:
       name: "architect/helm-chart-template: Cleanup"
       command: |
-          [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
           rm -fv .build_*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -41,4 +41,5 @@ steps:
   - run:
       name: "architect/helm-chart-template: Cleanup"
       command: |
+          [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
           rm -v .build_*

--- a/src/commands/helm-chart-template.yaml
+++ b/src/commands/helm-chart-template.yaml
@@ -42,4 +42,4 @@ steps:
       name: "architect/helm-chart-template: Cleanup"
       command: |
           [ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
-          rm -rv .build_*
+          rm -fv .build_*


### PR DESCRIPTION
Fixes problem with cleanup command on non-tagged builds.  We should skip in this case.

```
#!/bin/bash -eo pipefail
rm -v .build_*
rm: can't remove '.build_*': No such file or directory
```

e.g. https://circleci.com/gh/giantswarm/chart-operator/9000?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link


## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
