### PR TITLE
Make integration test timeout customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4]
+
+### Added
+
+- New parameter `test-timeout` for the `integration-test-go-test` command and 
+  `integration-test` job which allows to define the timeout for the test execution.
+  It defaults to the value that was already in use.
+
 ## [0.8.3] - 2020-03-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.4]
+## [0.8.4] - 2020-03-24
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.4] - 2020-03-24
-
 ### Added
 
 - New parameter `test-timeout` for the `integration-test-go-test` command and 

--- a/docs/integration_test_job.md
+++ b/docs/integration_test_job.md
@@ -108,6 +108,20 @@ the next orb release.
 kubectl delete deployment coredns -n kube-system
 ```
 
+### test-timeout
+
+If a test runs longer than this value it will panic.
+If it's 0, the timeout is disabled.
+The default is "20m" (20 minutes).
+
+```yaml
+    jobs:
+      - architect/integration-test:
+        name: basic-integration-test
+        test-timeout: "35m"
+        test-dir: "integration/test/basic"
+```
+
 [KIND]: https://kind.sigs.k8s.io
 [KIND docs]: https://kind.sigs.k8s.io/docs/user/configuration/
 [machine executor]: https://circleci.com/docs/2.0/executor-types/#using-machine

--- a/src/commands/integration-test-go-test.yaml
+++ b/src/commands/integration-test-go-test.yaml
@@ -3,6 +3,8 @@ parameters:
     type: string
   test-dir:
     type: string
+  test-timeout:
+    type: string
 steps:
   - when:
       condition: << parameters.env-file >>
@@ -29,4 +31,4 @@ steps:
       command: |
         # TODO remove `cd` line after switch to Go modules.
         cd  $(go env GOPATH | cut -d ':' -f 1)/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-        source .env && CGO_ENABLED=0 E2E_KUBECONFIG=~/.kube/config go test -tags k8srequired -timeout 20m -v ./<< parameters.test-dir >>
+        source .env && CGO_ENABLED=0 E2E_KUBECONFIG=~/.kube/config go test -tags k8srequired -timeout << parameters.test-timeout >> -v ./<< parameters.test-dir >>

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -27,6 +27,10 @@ parameters:
   test-dir:
     description: "Tested package directory."
     type: string
+  test-timeout:
+    default: "20m"
+    description: "If a tests runs longer than this it will panic."
+    type: string
 steps:
   - checkout
   - attach_workspace:

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -46,4 +46,5 @@ steps:
   - integration-test-go-test:
       env-file: << parameters.env-file >>
       test-dir: << parameters.test-dir >>
+      test-timeout: << parameters.test-timeout >>
   - integration-test-export-logs


### PR DESCRIPTION
We are running tests with a 20m timeout, but since this can be used to run e2e tests, the timeout should be customizable. Our e2e tests for azure-operator take 45 mins in some cases.

## Checklist

- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
