### PR TITLE
Run conftest to helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Use `conftest` to validate helm template using `rego` policies.
+
 ### Changed
 
 - Validate templated charts using `architect helm template` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Use `conftest` to validate helm template using `rego` policies.
+- Use `conftest` to validate helm template using `rego` policies in `push-to-app-catalog` job.
 
 
 ## [0.8.5] - 2020-03-30

--- a/docs/push_to_app_catalog_job.md
+++ b/docs/push_to_app_catalog_job.md
@@ -1,5 +1,19 @@
 # push-to-app-catalog job
 
+This job pushes the app to the specified catalog.
+Before doing that, it runs some validations.
+
+## Validations
+
+### conftest
+
+We use [`conftest`](https://www.conftest.dev/) to validate that the manifests inside the Helm chart don't use features
+that will be deprecated on future kubernetes releases.
+This is done using these [rego policies](https://github.com/swade1987/deprek8ion).
+
+The policies are evaluated using the **rendered kubernetes manifests in the Helm chart**.
+If there are values files in the `ci` folder of the chart, they will be used to render the chart templates.
+
 ## Parameters
 
 ### attach_workspace (optional boolean, default=false)

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -18,7 +18,7 @@ steps:
           conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.20-deprek8ion.rego
       fi
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
-        for t in $(ls ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -; done
+        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -; done
       else
         helm template helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -
       fi

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -17,4 +17,9 @@ steps:
           conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego
           conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.20-deprek8ion.rego
       fi
-      helm template helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -
+      if [ -d "ci" ]; then
+        for t in $(ls ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -; done
+      else
+        helm template helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -
+      fi
+

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -17,7 +17,7 @@ steps:
           conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego
           conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.20-deprek8ion.rego
       fi
-      if [ -d "<<parameters.chart>>/ci" ]; then
+      if [ -d "helm/<<parameters.chart>>/ci" ]; then
         for t in $(ls ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -; done
       else
         helm template helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -1,0 +1,8 @@
+---
+parameters:
+  chart:
+    type: "string"
+description: Test conftest policies
+steps:
+  - run: |
+      conftest -p /etc/policies/ "helm/<<parameters.chart>>"

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -6,8 +6,8 @@ description: Test conftest policies
 steps:
   - run: |
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
-        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') - ; done
+        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17,1.18,1.19}-deprek8ion.rego} | tr ' ' ',') - ; done
       else
-        helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') -
+        helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17,1.18,1.19}-deprek8ion.rego} | tr ' ' ',') -
       fi
 

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -9,12 +9,7 @@ parameters:
 description: Test conftest policies
 steps:
   - run: |
-      echo ${PWD}
-      ls -lah
-      ls -lah << parameters.policy_path >>
       helm template helm/<<parameters.chart>> | \
           conftest test \
               --update https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego \
               --policy << parameters.policy_path >> -
-      cat << parameters.policy_path >>/my-policy.rego
-      ls -lah << parameters.policy_path >>

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -5,4 +5,4 @@ parameters:
 description: Test conftest policies
 steps:
   - run: |
-      conftest -p /etc/policies/ "helm/<<parameters.chart>>"
+      conftest test -p /etc/policies/ "helm/<<parameters.chart>>"

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -5,4 +5,5 @@ parameters:
 description: Test conftest policies
 steps:
   - run: |
-      test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego helm/<<parameters.chart>>
+      helm template helm/<<parameters.chart>> --values helm/<<parameters.chart>>/ci/default-values.yaml | \
+      conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -13,6 +13,8 @@ steps:
       ls -lah
       ls -lah << parameters.policy_path >>
       helm template helm/<<parameters.chart>> | \
-          conftest test --policy << parameters.policy_path >> \
-              --update https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego -
+          conftest test \
+              --update https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego \
+              --policy << parameters.policy_path >> -
+      cat << parameters.policy_path >>/my-policy.rego
       ls -lah << parameters.policy_path >>

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -17,7 +17,7 @@ steps:
           conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego
           conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.20-deprek8ion.rego
       fi
-      if [ -d "ci" ]; then
+      if [ -d "<<parameters.chart>>/ci" ]; then
         for t in $(ls ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -; done
       else
         helm template helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -6,4 +6,4 @@ description: Test conftest policies
 steps:
   - run: |
       helm template helm/<<parameters.chart>> | \
-      conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/policies/1.19-deprek8ion.rego -
+      conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -6,8 +6,8 @@ description: Test conftest policies
 steps:
   - run: |
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
-        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') - ; done
+        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') - ; done
       else
-        helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') -
+        helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') -
       fi
 

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -8,6 +8,6 @@ steps:
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
         for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') - ; done
       else
-        helm template helm/<<parameters.chart>> | conftest test --update conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') -
+        helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') -
       fi
 

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -2,8 +2,13 @@
 parameters:
   chart:
     type: "string"
+  policy_path:
+    description: Path to the Rego policy files directory.
+    type: string
+    default: policy
 description: Test conftest policies
 steps:
   - run: |
       helm template helm/<<parameters.chart>> | \
-      conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego -
+          conftest test --policy << parameters.policy_path >> \
+              --update https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -6,8 +6,8 @@ description: Test conftest policies
 steps:
   - run: |
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
-        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego azure-operator -; done
+        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') << parameters.chart >> - ; done
       else
-        helm template helm/<<parameters.chart>> | conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego azure-operator -
+        helm template helm/<<parameters.chart>> | conftest test --update conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') << parameters.chart >> -
       fi
 

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -8,6 +8,6 @@ steps:
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
         for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17,1.18,1.19}-deprek8ion.rego} | tr ' ' ',') - ; done
       else
-        helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17,1.18,1.19}-deprek8ion.rego} | tr ' ' ',') -
+        helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17,1.18,1.19}-deprek8ion.rego | tr ' ' ',') -
       fi
 

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -6,7 +6,7 @@ description: Test conftest policies
 steps:
   - run: |
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
-        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17,1.18,1.19}-deprek8ion.rego} | tr ' ' ',') - ; done
+        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17,1.18,1.19}-deprek8ion.rego | tr ' ' ',') - ; done
       else
         helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17,1.18,1.19}-deprek8ion.rego | tr ' ' ',') -
       fi

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -2,24 +2,12 @@
 parameters:
   chart:
     type: "string"
-  policy_path:
-    description: Path to the Rego policy files directory.
-    type: string
-    default: policy
 description: Test conftest policies
 steps:
   - run: |
-      if [ "<< parameters.policy_path >>" == "policy" ]; then
-          mkdir -p policy
-          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego
-          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego
-          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego
-          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego
-          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.20-deprek8ion.rego
-      fi
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
-        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -; done
+        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego azure-operator -; done
       else
-        helm template helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -
+        helm template helm/<<parameters.chart>> | conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego azure-operator -
       fi
 

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -6,4 +6,4 @@ description: Test conftest policies
 steps:
   - run: |
       helm template helm/<<parameters.chart>> | \
-      conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego -
+      conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/policies/1.19-deprek8ion.rego -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -5,5 +5,5 @@ parameters:
 description: Test conftest policies
 steps:
   - run: |
-      helm template helm/<<parameters.chart>> --values helm/<<parameters.chart>>/ci/default-values.yaml | \
+      helm template helm/<<parameters.chart>> | \
       conftest test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -6,8 +6,8 @@ description: Test conftest policies
 steps:
   - run: |
       if [ -d "helm/<<parameters.chart>>/ci" ]; then
-        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') << parameters.chart >> - ; done
+        for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') - ; done
       else
-        helm template helm/<<parameters.chart>> | conftest test --update conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') << parameters.chart >> -
+        helm template helm/<<parameters.chart>> | conftest test --update conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/master/{1.16-deprek8ion.rego,1.17-deprek8ion.rego,1.18-deprek8ion.rego,1.19-deprek8ion.rego} | tr ' ' ',') -
       fi
 

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -9,7 +9,10 @@ parameters:
 description: Test conftest policies
 steps:
   - run: |
-      helm template helm/<<parameters.chart>> | \
-          conftest test \
-              --update https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego \
-              --policy << parameters.policy_path >> -
+      mkdir -p policy
+      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego
+      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego
+      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego
+      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego
+      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.20-deprek8ion.rego
+      helm template helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -9,10 +9,12 @@ parameters:
 description: Test conftest policies
 steps:
   - run: |
-      mkdir -p policy
-      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego
-      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego
-      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego
-      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego
-      conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.20-deprek8ion.rego
+      if [ "<< parameters.policy_path >>" == "policy" ]; then
+          mkdir -p policy
+          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego
+          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego
+          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego
+          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego
+          conftest pull --policy policy https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.20-deprek8ion.rego
+      fi
       helm template helm/<<parameters.chart>> | conftest test --policy << parameters.policy_path >> -

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -9,6 +9,10 @@ parameters:
 description: Test conftest policies
 steps:
   - run: |
+      echo ${PWD}
+      ls -lah
+      ls -lah << parameters.policy_path >>
       helm template helm/<<parameters.chart>> | \
           conftest test --policy << parameters.policy_path >> \
               --update https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/1.19-deprek8ion.rego -
+      ls -lah << parameters.policy_path >>

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -5,4 +5,4 @@ parameters:
 description: Test conftest policies
 steps:
   - run: |
-      conftest test -p /etc/policies/ "helm/<<parameters.chart>>"
+      test --update https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.16-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.17-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.18-deprek8ion.rego,https://raw.githubusercontent.com/swade1987/deprek8ion/master/1.19-deprek8ion.rego helm/<<parameters.chart>>

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:0.0.0-baebf24ff6a0a67a92cfc803cb0ac55ace160f44
+    image: quay.io/giantswarm/architect:0.0.0-0931249c7984f1745070445482396fa27e2929fc

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:latest
+    image: quay.io/giantswarm/architect:0.0.0-baebf24ff6a0a67a92cfc803cb0ac55ace160f44

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:0.0.0-0931249c7984f1745070445482396fa27e2929fc
+    image: quay.io/giantswarm/architect:latest

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -20,6 +20,10 @@ parameters:
       When this is `false`, commits to `master` will be pushed to `app_catalog` instead of `app_catalog_test`.
       Set this to `false` for deployments that follow a a master branch for production releases rather than
       using tags (the default).
+  policy_path:
+    description: Path to the Rego policy files directory.
+    type: string
+    default: policy
 steps:
   - checkout
   - when:
@@ -35,6 +39,7 @@ steps:
       chart: "<< parameters.chart >>"
   - helm-conftest:
       chart: "<< parameters.chart >>"
+      policy_path: "<< parameters.policy_path >>"
   - package-and-push:
       app_catalog: << parameters.app_catalog >>
       app_catalog_test: << parameters.app_catalog_test >>

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -33,6 +33,8 @@ steps:
       chart: << parameters.chart >>
   - helm-lint:
       chart: "<< parameters.chart >>"
+  - helm-conftest:
+      chart: "<< parameters.chart >>"
   - package-and-push:
       app_catalog: << parameters.app_catalog >>
       app_catalog_test: << parameters.app_catalog_test >>

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -20,10 +20,6 @@ parameters:
       When this is `false`, commits to `master` will be pushed to `app_catalog` instead of `app_catalog_test`.
       Set this to `false` for deployments that follow a a master branch for production releases rather than
       using tags (the default).
-  policy_path:
-    description: Path to the Rego policy files directory.
-    type: string
-    default: policy
 steps:
   - checkout
   - when:
@@ -39,7 +35,6 @@ steps:
       chart: "<< parameters.chart >>"
   - helm-conftest:
       chart: "<< parameters.chart >>"
-      policy_path: "<< parameters.policy_path >>"
   - package-and-push:
       app_catalog: << parameters.app_catalog >>
       app_catalog_test: << parameters.app_catalog_test >>


### PR DESCRIPTION
`conftest` is used to check k8s deprecation policies against k8s manifests in the Helm chart.

Developers can pass their custom policies by specifying the `policy_path` parameter. That folder should contain `rego` policies. 

If no custom policies are passed using the `policy_path` parameter, the default k8s deprecation policies will be used.

- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
