### PR TITLE
go-build: use bigger resource_class (xlarge)

### DIFF
--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -16,6 +16,7 @@ parameters:
     type: enum
     enum: ["linux", "darwin"]
 executor: architect
+resource_class: "xlarge"
 steps:
   - checkout
   - tools-info


### PR DESCRIPTION
See:

- https://circleci.com/docs/2.0/configuration-reference/#docker-executor
- https://gigantic.slack.com/archives/C3C7ZQXC1/p1586256209080600

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [ ] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).