### PR TITLE
jobs: add resource_class parameters to all jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `resource_class` parameter to all jobs (excluding legacy jobs).
+
+
+
 ## [0.8.7] - 2020-04-08
 
 ### Added

--- a/docs/common.md
+++ b/docs/common.md
@@ -1,0 +1,17 @@
+# Common
+
+This page contains documentation for common parts of all jobs defined in
+architect orb.
+
+## Parameters
+
+### resource_class
+
+Allows specifying [CircleCI `resource_class`] for the job if the default is not
+sufficient. Note that it differs between docker and machine executors. Details
+can be found there:
+
+- https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+- https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux
+
+[resource_class]: https://circleci.com/docs/2.0/configuration-reference/#resource_class

--- a/docs/common.md
+++ b/docs/common.md
@@ -5,7 +5,7 @@ architect orb.
 
 ## Parameters
 
-### resource_class
+### resource_class (optional string, default="medium")
 
 Allows specifying [CircleCI `resource_class`] for the job if the default is not
 sufficient. Note that it differs between docker and machine executors. Details

--- a/docs/integration_test_job.md
+++ b/docs/integration_test_job.md
@@ -1,5 +1,5 @@
 # integration-test job
- 
+
 - Runs an integration test by creating a [KIND] cluster and executing it as a Go test.
 - Runs in a Circle VM because KIND uses Docker in Docker and this doesn't work
 with the Circle Docker executor.
@@ -7,8 +7,6 @@ with the Circle Docker executor.
   controlled by us. Since the preinstalled Go is very outdated.
 
 ## Example usage
-
-The only required parameter is the `test-dir` containing the integration test.
 
 ```yaml
 version: 2.1
@@ -25,7 +23,14 @@ workflows:
 
 ## Parameters
 
-These optional parameters allow configuring the test.
+- [common parameters](common.md#parameters) shared in all jobs.
+- [test-dir](#attach_workspace) (required string)
+- [env-file](#env-file) (optional string, default="")
+- [kind-config](#kind-config) (optional string, default="")
+- [kubernetes-version](#kubernetes-version) (optional string, default="v1.16.3")
+- [setup-script](#setup-script) (optional string, default="")
+- [test-dir](#test-dir) (required string)
+- [test-timeout](#test-timeout) (optional string, default="20m")
 
 ### env-file
 
@@ -107,6 +112,10 @@ the next orb release.
 # Delete coredns resources
 kubectl delete deployment coredns -n kube-system
 ```
+
+### test-dir
+
+The directory containing the integration test.
 
 ### test-timeout
 

--- a/docs/push_to_app_catalog_job.md
+++ b/docs/push_to_app_catalog_job.md
@@ -16,7 +16,10 @@ If there are values files in the `ci` folder of the chart, they will be used to 
 
 ## Parameters
 
-### attach_workspace (optional boolean, default=false)
+- [common parameters](common.md#parameters) shared in all jobs.
+- [attach_workspace](#attach_workspace) (optional boolean, default=false)
+
+### attach_workspace
 
 When this is `true`, the CircleCI `attach_workspace` command will be executed
 immediately after `checkout` into the working directory. Use this if files are

--- a/src/jobs/changelog-lint.yaml
+++ b/src/jobs/changelog-lint.yaml
@@ -1,7 +1,18 @@
 description: |
     It checks if CHANGELOG.md file is in format described in
     https://keepachangelog.com/en/1.0.0/.
-executor: architect
+
+parameters:
+  resource_class:
+    default: "small"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+        for details.
+    type: "enum"
+    enum: ["small", "medium", "medium+", "large", "xlarge"]
+executor: "architect"
+resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - changelog-lint

--- a/src/jobs/gitleaks.yaml
+++ b/src/jobs/gitleaks.yaml
@@ -4,7 +4,16 @@ parameters:
     default: ""
     description: "(Optional) Path to a config file to use for gitleaks configuration."
     type: "string"
-executor: gitleaks
+  resource_class:
+    default: "small"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+        for details.
+    type: "enum"
+    enum: ["small", "medium", "medium+", "large", "xlarge"]
+executor: "gitleaks"
+resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - gitleaks:

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -15,7 +15,16 @@ parameters:
     description: "The target Operating System for the binary. Must be one of \"linux\", \"darwin\"."
     type: enum
     enum: ["linux", "darwin"]
-executor: architect
+  resource_class:
+    default: "medium"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+        for details.
+    type: "enum"
+    enum: ["small", "medium", "medium+", "large", "xlarge"]
+executor: "architect"
+resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - tools-info

--- a/src/jobs/go-test.yaml
+++ b/src/jobs/go-test.yaml
@@ -6,7 +6,16 @@ description: |
   - "buildTimestamp" in RFC-3339 format in UTC time zone.
   - "gitSHA" SHA of the built commit.
   - "version" produced by `architect project version` command.
-executor: architect
+  resource_class:
+    default: "medium"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+        for details.
+    type: "enum"
+    enum: ["small", "medium", "medium+", "large", "xlarge"]
+executor: "architect"
+resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - tools-info

--- a/src/jobs/go-test.yaml
+++ b/src/jobs/go-test.yaml
@@ -6,6 +6,8 @@ description: |
   - "buildTimestamp" in RFC-3339 format in UTC time zone.
   - "gitSHA" SHA of the built commit.
   - "version" produced by `architect project version` command.
+
+parameters:
   resource_class:
     default: "medium"
     description: |

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -6,7 +6,6 @@ description: |
   controlled by us since the preinstalled Go is very outdated.
 
   See [docs](docs/integration_test.md) for more details.
-executor: machine
 parameters:
   env-file:
     default: ""
@@ -31,6 +30,16 @@ parameters:
     default: "20m"
     description: "If a tests runs longer than this it will panic."
     type: string
+  resource_class:
+    default: "medium"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux
+        for details.
+    type: "enum"
+    enum: ["medium", "large", "xlarge", "2xlarge"]
+executor: "machine"
+resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - attach_workspace:

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -1,4 +1,3 @@
-executor: architect
 parameters:
   app_catalog:
     description: "Name of the Github repository inside giantswarm organization hosting the App Catalog for tagged builds."
@@ -20,6 +19,16 @@ parameters:
       When this is `false`, commits to `master` will be pushed to `app_catalog` instead of `app_catalog_test`.
       Set this to `false` for deployments that follow a a master branch for production releases rather than
       using tags (the default).
+  resource_class:
+    default: "small"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+        for details.
+    type: "enum"
+    enum: ["small", "medium", "medium+", "large", "xlarge"]
+executor: "architect"
+resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - when:

--- a/src/jobs/push-to-app-collection.yaml
+++ b/src/jobs/push-to-app-collection.yaml
@@ -3,7 +3,6 @@ description: >
   Note: version will be detected automatically by architect.
 
 
-executor: architect
 parameters:
   app_name:
     description: "Name of the application."
@@ -23,6 +22,16 @@ parameters:
     description: "Whether the previous App versions in the collection should be replaced with this one. Any non-empty string means true. This is useful when only one (usually latest) version of the app should be installed at a time. E.g. OPA gatekeeper."
     type: "string"
     default: ""
+  resource_class:
+    default: "small"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+        for details.
+    type: "enum"
+    enum: ["small", "medium", "medium+", "large", "xlarge"]
+executor: "architect"
+resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - prepare-catalogbot-git-ssh

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -1,4 +1,3 @@
-executor: architect
 parameters:
   image:
     description: "Name of the docker image, without tag. e.g. \"quay.io/my-org/my-repo\"."
@@ -15,6 +14,16 @@ parameters:
     description: "Name of the branch on which the image will be additionally tagged as \"latest\"."
     type: "string"
     default: "master"
+  resource_class:
+    default: "small"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+        for details.
+    type: "enum"
+    enum: ["small", "medium", "medium+", "large", "xlarge"]
+executor: "architect"
+resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - setup_remote_docker


### PR DESCRIPTION
While switching to architect orb within Go modules work we discovered
that some codebases require more resources for particular jobs. The
problem we hit was aws-operator requiring more memory for building the
binary.

This change adds `resource_class` parameter to all (excluding legacy)
jobs. If not specified in CircleCI the default value is always "medium"
for both machine and docker executors. For some jobs the default is
changed to "small" to save some money.

CircleCI pricing table: https://circleci.com/pricing/#compute-options-table

- [x] src/jobs/changelog-lint.yaml - small by default.
- [x] src/jobs/gitleaks.yaml - small by default.
- [x] src/jobs/go-build.yaml - medium by default.
- [x] src/jobs/go-test.yaml - medium by default.
- [x] src/jobs/integration-test.yaml - medium by default.
- [x] src/jobs/push-to-app-catalog.yaml - small by default.
- [x] src/jobs/push-to-app-collection.yaml - small by default.
- [x] src/jobs/push-to-docker.yaml - small by default.
- [x] src/jobs/go-architect-legacy.yaml **SKIP** legacy job.
- [x] src/jobs/go-test-legacy.yaml **SKIP** legacy job.
- [x] src/jobs/push-to-docker-legacy.yaml **SKIP** legacy job.


## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).