### PR TITLE
helm-lint: use dockerized ct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update Go version used in integration tests to 1.14.1.
+- Update Go version to 1.14.1 in `integration-test` job.
+- Use dockerized `ct` in `push-to-app-catalog` job.
 
 
 

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -5,4 +5,4 @@ parameters:
 description: Lint Helm chart
 steps:
   - run: |
-      ct lint --validate-maintainers=false --charts="helm/<<parameters.chart>>"
+      docker run -it -v "$(pwd)/helm:/helm" quay.io/giantswarm/helm-chart-testing:v2.4.0 ct lint --validate-maintainers=false --charts="/helm/<< parameters.chart >>"

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -22,6 +22,7 @@ parameters:
       using tags (the default).
 steps:
   - checkout
+  - setup_remote_docker
   - when:
       condition: << parameters.attach_workspace >>
       steps:


### PR DESCRIPTION
The reason for that is to make it easier to copy/paste the command and test it locally.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).