### PR TITLE
Make ldflags compatible with go modules with versions >= 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `go-test` command takes into consideration go modules when generating flags to inject values into the binary.
 
 ## [0.8.12] - 2020-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `go-build` command will fail if it fails to compile.
+
 ### Fixed
 
 - The `go-test` command takes into consideration go modules when generating flags to inject values into the binary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - The `go-test` command takes into consideration go modules when generating flags to inject values into the binary.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `go-build` command will fail if it fails to compile.
+- `go-build` job will fail if it fails to compile.
 
 ### Fixed
 
-- The `go-test` command takes into consideration go modules when generating flags to inject values into the binary.
+- The `go-test` job takes into consideration go modules when generating flags to inject values into the binary.
 
 ## [0.8.12] - 2020-04-22
 

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -9,6 +9,6 @@ parameters:
 steps:
   - go-test
   - run: |
-      CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -o << parameters.binary >> . || true
+      CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -o << parameters.binary >> .
   - run: |
       [[ "<< parameters.os >>" == "linux" ]] && ./<< parameters.binary >> version || true

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -1,16 +1,12 @@
-parameters:
-  pkg:
-    default: "github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pkg/project"
-    type: "string"
 steps:
   - run: |
       go mod tidy && git diff --exit-code
   - run: |
       echo -n "-w -linkmode 'auto' -extldflags '-static'" > .ldflags
   - run: |
-      echo -n " -X '<< parameters.pkg >>.buildTimestamp=$(date --utc '+%FT%TZ')'" >> .ldflags
+      echo -n " -X '$(go list .)/pkg/project.buildTimestamp=$(date --utc '+%FT%TZ')'" >> .ldflags
   - run: |
-      echo -n " -X '<< parameters.pkg >>.gitSHA=${CIRCLE_SHA1}'" >> .ldflags
+      echo -n " -X '$(go list .)/pkg/project.gitSHA=${CIRCLE_SHA1}'" >> .ldflags
   - run: |
       echo "\"$(cat .ldflags)\""
   - run:


### PR DESCRIPTION
## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
