### PR TITLE
commands/push-to-app-collection: retry the push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `push-to-app-collection`: retry the push up to 4 times to better handle transient errors
+
 ## [0.8.13] - 2020-04-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 Exited with code 1
 ```
 
-It is an rare case so triggering again the build should solve the issue.
+Integrating the remote changes and the push is already retried a couple of times so this should be very rare, but in case it does happen triggering the build again should solve the issue.
 
 [architect]: https://github.com/giantswarm/architect
 [architect-executor]: https://github.com/giantswarm/architect-orb/blob/master/src/executors/architect.yaml

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -61,9 +61,14 @@ steps:
         while ! git push; do
           attempt+=1
           if ((attempt >= 4)); then
-            echo "giving up after $attempt failures"
+            printf '%s\n' \
+              "Error pushing app to the collection. See known errors in:" \
+              "https://github.com/giantswarm/architect-orb/blob/master/README.md#push-to-app-collection" \
+              "Giving up after $attempt failures." \
+              >&2
             exit 1
           fi
+          git pull --rebase --autostash
           sleep 5
         done
   - run: |

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -68,8 +68,8 @@ steps:
               >&2
             exit 1
           fi
-          git pull --rebase --autostash
           sleep 5
+          git pull --rebase --autostash
         done
   - run: |
         rm .cr_name .version .app_file_name .git_commit_message

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -56,7 +56,16 @@ steps:
   - run: |
         cd .app-collection && git commit -m "$(cat ../.git_commit_message)"
   - run: |
-        cd .app-collection && git push || (echo "Error pushing app to the collection. See known errors in https://github.com/giantswarm/architect-orb/blob/master/README.md#push-to-app-collection" && exit 1)
+        cd .app-collection && \
+        declare -i attempt=0 && \
+        while ! git push; do
+          attempt+=1
+          if ((attempt >= 4)); then
+            echo "giving up after $attempt failures"
+            exit 1
+          fi
+          sleep 5
+        done
   - run: |
         rm .cr_name .version .app_file_name .git_commit_message
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10423.

Retry the `git push` up to 4 times with some wait times in between in
case it fails, in order to cope with transient errors better.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
