### PR TITLE
Support Chart testing config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `push-to-app-catalog`: retry the push up to 4 times to better handle transient errors.
+- `push-to-app-catalog` and `run-kat-tests`: Support providing Chart Testing (`ct`) configuration file
 
 ## [0.8.14] - 2020-05-11
 

--- a/docs/run_kat_tests.md
+++ b/docs/run_kat_tests.md
@@ -24,9 +24,8 @@ Parameters:
   and the only one supported right now.
 - `ct_config` - Path to configuration file for Chart Testing (`ct`). This is
   required, if the app relies on external dependencies. You would use this
-  config file to add additional Helm repositories. See
-  https://github.com/helm/chart-testing/tree/v2.4.1#using-private-chart-repositories.
-  Otherwise this parameter is optional
+  config file [to add additional Helm repositories](https://github.com/helm/chart-testing/tree/v2.4.1#using-private-chart-repositories).
+  Otherwise this parameter is optional.
 
 Example usage
 

--- a/docs/run_kat_tests.md
+++ b/docs/run_kat_tests.md
@@ -1,4 +1,3 @@
-
 # run-kat-tests
 
 This job installs all the required software to run
@@ -23,6 +22,11 @@ Parameters:
 - `chart` - the name of the chart to test in `/helm` directory
 - `cluster_type` - type of the cluster to create for test execution. `kind` is default
   and the only one supported right now.
+- `ct_config` - Path to configuration file for Chart Testing (`ct`). This is
+  required, if the app relies on external dependencies. You would use this
+  config file to add additional Helm repositories. See
+  https://github.com/helm/chart-testing/tree/v2.4.1#using-private-chart-repositories.
+  Otherwise this parameter is optional
 
 Example usage
 
@@ -37,6 +41,7 @@ workflows:
       - architect/run-kat-tests:
           name: "test the chart with kat"
           chart: "[CHART_NAME]"
+          ct_config: ".circleci/ct-config.yaml"
           filters:
             tags:
               only: /^v.*/

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -9,4 +9,4 @@ parameters:
 description: Lint Helm chart
 steps:
   - run: |
-      ct lint <<# parameters.ct_config >> << parameters.ct_config >> <</ parameters.ct_config >> --validate-maintainers=false --charts="helm/<<parameters.chart>>"
+      ct lint <<# parameters.ct_config >> --config << parameters.ct_config >> <</ parameters.ct_config >> --validate-maintainers=false --charts="helm/<<parameters.chart>>"

--- a/src/commands/helm-lint.yaml
+++ b/src/commands/helm-lint.yaml
@@ -2,7 +2,11 @@
 parameters:
   chart:
     type: "string"
+  ct_config:
+    description: Chart Testing Config file path
+    type: "string"
+    default: ""
 description: Lint Helm chart
 steps:
   - run: |
-      ct lint --validate-maintainers=false --charts="helm/<<parameters.chart>>"
+      ct lint <<# parameters.ct_config >> << parameters.ct_config >> <</ parameters.ct_config >> --validate-maintainers=false --charts="helm/<<parameters.chart>>"

--- a/src/commands/kat-tests-run.yaml
+++ b/src/commands/kat-tests-run.yaml
@@ -1,6 +1,9 @@
 parameters:
     chart:
         type: string
+    ct_config:
+        type: string
+        default: ""
 steps:
   - run:
       name: "initialize helm"
@@ -8,6 +11,8 @@ steps:
         /tmp/bin/helm init -c
   - run:
       name: "start kube-app-testing tool"
+      environment:
+        CT_CONFIG_FILE: << parameters.ct_config >>
       command: |
         PATH="/tmp/bin:$PATH" /tmp/kube-app-testing.sh -c << parameters.chart >>
   - run:

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -12,6 +12,10 @@ parameters:
   chart:
     description: "Name of the chart inside helm directory to push to the App Catalog."
     type: "string"
+  ct_config:
+    description: "Chart Testing Config file path"
+    type: "string"
+    default: ""
   on_tag:
     type: boolean
     default: true
@@ -42,6 +46,7 @@ steps:
       chart: << parameters.chart >>
   - helm-lint:
       chart: "<< parameters.chart >>"
+      ct_config: "<< parameters.ct_config >>"
   - helm-conftest:
       chart: "<< parameters.chart >>"
   - package-and-push:

--- a/src/jobs/run-kat-tests.yaml
+++ b/src/jobs/run-kat-tests.yaml
@@ -7,8 +7,13 @@ parameters:
     description: "Type of cluster to execute this test on"
     type: "string"
     default: "kind"
+  ct_config:
+    description: Chart Testing Config file path
+    type: "string"
+    default: ""
 steps:
   - checkout
   - kat-tests-install-tools
   - kat-tests-run:
       chart: << parameters.chart >>
+      ct_config: << parameters.ct_config >>


### PR DESCRIPTION
This is to support the use of additional Helm chart repositories.
Config file is needed for this option according to the docs
https://github.com/helm/chart-testing/tree/v2.4.1#using-private-chart-repositories

Additional repos are needed to satisfy Chart dependencies when testing. Maybe in
the future we can copy all dependencies to our own catalogs, then we won't need
to rely on external deps and we can just add our catalogs. But until that is
in place, we need a way to specify repos.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [ ] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
