### PR TITLE
push-to-app-catalog: retry git push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `push-to-app-catalog`: retry the push up to 4 times to better handle transient errors.
+
 ## [0.8.14] - 2020-05-11
 
-### Changed
+### Fixed
 
-- `push-to-app-collection`: retry the push up to 4 times to better handle transient errors
+- `push-to-app-collection`: retry the push up to 4 times to better handle transient errors.
 
 ## [0.8.13] - 2020-04-24
 

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -43,5 +43,21 @@ steps:
       cd .app_catalog && git add -A
   - run: |
       cd .app_catalog && git commit -m "add $(git status --porcelain | cut -c4- | grep << parameters.chart >>)"
-  - run: |
-      cd .app_catalog && git push || (echo "Error pushing app to the catalog. See known errors in https://github.com/giantswarm/architect-orb/blob/master/README.md#push-to-app-catalog" && exit 1)
+  - run:
+      name: Push to app catalog repo
+      command: |
+          cd .app_catalog && \
+          declare -i attempt=0 && \
+          while ! git push; do
+            attempt+=1
+            if ((attempt >= 4)); then
+              printf '%s\n' \
+                "Error pushing app to the catalog. See known errors in:" \
+                "https://github.com/giantswarm/architect-orb/blob/master/README.md#push-to-app-catalog" \
+                "Giving up after $attempt failures." \
+                >&2
+              exit 1
+            fi
+            sleep 5
+            git pull --rebase --autostash
+          done

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -55,22 +55,24 @@ steps:
         cd .app-collection && git add helm/<<parameters.app_collection_repo>>-chart/templates/$(cat ../.app_file_name)
   - run: |
         cd .app-collection && git commit -m "$(cat ../.git_commit_message)"
-  - run: |
-        cd .app-collection && \
-        declare -i attempt=0 && \
-        while ! git push; do
-          attempt+=1
-          if ((attempt >= 4)); then
-            printf '%s\n' \
-              "Error pushing app to the collection. See known errors in:" \
-              "https://github.com/giantswarm/architect-orb/blob/master/README.md#push-to-app-collection" \
-              "Giving up after $attempt failures." \
-              >&2
-            exit 1
-          fi
-          sleep 5
-          git pull --rebase --autostash
-        done
+  - run:
+      name: Push to app collection repo
+      command: |
+          cd .app-collection && \
+          declare -i attempt=0 && \
+          while ! git push; do
+            attempt+=1
+            if ((attempt >= 4)); then
+              printf '%s\n' \
+                "Error pushing app to the collection. See known errors in:" \
+                "https://github.com/giantswarm/architect-orb/blob/master/README.md#push-to-app-collection" \
+                "Giving up after $attempt failures." \
+                >&2
+              exit 1
+            fi
+            sleep 5
+            git pull --rebase --autostash
+          done
   - run: |
         rm .cr_name .version .app_file_name .git_commit_message
 


### PR DESCRIPTION
I just copied @mig4 work from https://github.com/giantswarm/architect-orb/pull/140 and adjusted to catalog.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).