### PR TITLE
Our helm client requires Helm v2.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `integration-test-install-tools`: installs Helm 2.16.1.
+
 ## [0.8.16] - 2020-05-21
 
 ### Added
 
-- `integration-test-install-tools` now installs Helm 2.16.7.
+- `integration-test-install-tools`: installs Helm 2.16.7.
 
 ## [0.8.15] - 2020-05-14
 

--- a/src/commands/integration-test-install-tools.yaml
+++ b/src/commands/integration-test-install-tools.yaml
@@ -21,7 +21,7 @@ steps:
   - run:
       name: "architect/integration-test-install-tools: Install Helm"
       command: |
-        curl -L https://get.helm.sh/helm-v2.16.7-linux-amd64.tar.gz >./helm.tar.gz
+        curl -L https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz >./helm.tar.gz
         tar xzvf helm.tar.gz
         chmod u+x linux-amd64/helm
         sudo mv linux-amd64/helm /usr/local/bin/


### PR DESCRIPTION
If we don't install this exact version our Helm client fails.

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [ ] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
