### PR TITLE
Install kind by binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Install `kind` as a binary file.
+
 ## [0.10.0] - 2020-07-03
 
 ### Changed

--- a/src/commands/integration-test-install-tools.yaml
+++ b/src/commands/integration-test-install-tools.yaml
@@ -5,7 +5,9 @@ steps:
   - run:
       name: "architect/integration-test-install-tools: Install kind"
       command: |
-        CGO_ENABLED=0 GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
+        curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.7.0/kind-$(uname)-amd64"
+        chmod +x ./kind
+        mv ./kind /usr/local/bin
   - run:
       name: "architect/integration-test-install-tools: Download kubectl"
       command: |

--- a/src/commands/integration-test-install-tools.yaml
+++ b/src/commands/integration-test-install-tools.yaml
@@ -7,7 +7,7 @@ steps:
       command: |
         curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.7.0/kind-$(uname)-amd64"
         chmod +x ./kind
-        mv ./kind /usr/local/bin
+        sudo mv ./kind /usr/local/bin
   - run:
       name: "architect/integration-test-install-tools: Download kubectl"
       command: |


### PR DESCRIPTION
Installing `kind` from go modules affects `go.mod` in the project. 
We could rather do it from the different directory but I think installing binary files is much cleaner.  

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
