### PR TITLE
Add nancy - scans for vulnerabilities in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Scan for Go dependency vulnerabilities with `nancy`.
+
 ## [0.10.2] - 2020-08-11
 
 ### Added

--- a/src/commands/go-test-legacy.yaml
+++ b/src/commands/go-test-legacy.yaml
@@ -47,11 +47,6 @@ steps:
         cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
         CGO_ENABLED=0 golangci-lint run -E gosec -E goconst -E unparam
   - run:
-      name: "architect/go-test-legacy: Running nancy vulnerability scan"
-      command: |
-        cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-        CGO_ENABLED=0 GO111MODULE=on nancy -quiet /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/Gopkg.lock
-  - run:
       name: "architect/go-test-legacy: Running go test"
       command: |
         cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}

--- a/src/commands/go-test-legacy.yaml
+++ b/src/commands/go-test-legacy.yaml
@@ -47,6 +47,11 @@ steps:
         cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
         CGO_ENABLED=0 golangci-lint run -E gosec -E goconst -E unparam
   - run:
+      name: "architect/go-test-legacy: Running nancy vulnerability scan"
+      command: |
+        cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
+        CGO_ENABLED=0 go list -json -m all | nancy -quiet
+  - run:
       name: "architect/go-test-legacy: Running go test"
       command: |
         cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}

--- a/src/commands/go-test-legacy.yaml
+++ b/src/commands/go-test-legacy.yaml
@@ -50,7 +50,7 @@ steps:
       name: "architect/go-test-legacy: Running nancy vulnerability scan"
       command: |
         cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-        CGO_ENABLED=0 nancy -quiet Gopkg.lock
+        CGO_ENABLED=0 GO111MODULE=on nancy -quiet /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/Gopkg.lock
   - run:
       name: "architect/go-test-legacy: Running go test"
       command: |

--- a/src/commands/go-test-legacy.yaml
+++ b/src/commands/go-test-legacy.yaml
@@ -50,7 +50,7 @@ steps:
       name: "architect/go-test-legacy: Running nancy vulnerability scan"
       command: |
         cd /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-        CGO_ENABLED=0 go list -json -m all | nancy -quiet
+        CGO_ENABLED=0 nancy -quiet Gopkg.lock
   - run:
       name: "architect/go-test-legacy: Running go test"
       command: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -20,4 +20,6 @@ steps:
   - run: |
       CGO_ENABLED=0 golangci-lint run -E gosec -E goconst
   - run: |
+      CGO_ENABLED=0 go list -json -m all | nancy -quiet
+  - run: |
       CGO_ENABLED=0 go test  -ldflags "$(cat .ldflags)" ./...

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:2.1.5-42bfff29d2528861a24b78ada0eb0c1ff225addd
+    image: quay.io/giantswarm/architect:2.1.6

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect: 2.1.5-42bfff29d2528861a24b78ada0eb0c1ff225addd
+    image: quay.io/giantswarm/architect:2.1.5-42bfff29d2528861a24b78ada0eb0c1ff225addd

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:2.1.3
+    image: quay.io/giantswarm/architect: 2.1.5-42bfff29d2528861a24b78ada0eb0c1ff225addd


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8901

Adds `nancy` to scan for vulnerable Go dependencies

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
