### PR TITLE
Expose architect project version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Expose architect project version for integration test purposes.
+
 ## [0.11.0] - 2020-08-20
 
 ### Added

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -50,6 +50,8 @@ steps:
   - integration-test-create-cluster:
       kind-config: << parameters.kind-config >>
       kubernetes-version:  << parameters.kubernetes-version >>
+  - go-architect-legacy:
+      command: "project version > architect-project-version"
   - integration-test-setup:
       setup-script: << parameters.setup-script >>
   - integration-test-go-test:


### PR DESCRIPTION
My use case is:
- `e2etest` checks deployment labels
- Output of `architect project version` is used in `helm.sh/chart` label value
- There is no other way to get project version value for projects with no `pkg/project/project.go`

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
