### PR TITLE
Update Go version used in integration test to 1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Go version used in integration tests to 1.15.2.
+
 ## [0.12.0] - 2020-09-28
 
 ### Added

--- a/src/commands/machine-install-go.yaml
+++ b/src/commands/machine-install-go.yaml
@@ -6,15 +6,15 @@ steps:
   - run:
       name: "architect/machine-install-go: Download Go"
       command: |
-        wget https://dl.google.com/go/go1.14.1.linux-amd64.tar.gz
+        wget https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Check downloaded Go checksum"
       command: |
-        [[ "$(sha256sum go1.14.1.linux-amd64.tar.gz | cut -d ' ' -f 1)" == "2f49eb17ce8b48c680cdb166ffd7389702c0dec6effa090c324804a5cac8a7f8" ]]
+        [[ "$(sha256sum go1.15.2.linux-amd64.tar.gz | cut -d ' ' -f 1)" == "b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552" ]]
   - run:
       name: "architect/machine-install-go: Install Go"
       command: |
-        sudo tar -C /usr/local -xzf go1.14.1.linux-amd64.tar.gz
+        sudo tar -C /usr/local -xzf go1.15.2.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Set Go environment"
       command: |
@@ -22,7 +22,7 @@ steps:
   - run:
       name: "architect/machine-install-go: Remove downloaded Go files"
       command: |
-        rm go1.14.1.linux-amd64.tar.gz
+        rm go1.15.2.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Check Go version"
       command: |


### PR DESCRIPTION
Current architect-orb v0.12.0 uses architect v3.0.0 https://github.com/giantswarm/architect-orb/blob/master/CHANGELOG.md#0120---2020-09-28

Architect v3.0.0 was updated to go v1.15.2 https://github.com/giantswarm/architect/blob/master/CHANGELOG.md#300---2020-09-24

This PR aligns go version used in architect-orb's machine-install-go command (used in integration-test job) to v1.15.2.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
