### PR TITLE
Make 'package-and-push' more readable

### DIFF
--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -27,8 +27,10 @@ steps:
             name: "architect/package-and-push: Determine target app catalog based on branch name"
             command: |
               [[ ${CIRCLE_BRANCH} == master ]] && echo -n '<< parameters.app_catalog >>' | tee .app_catalog_name || echo -n '<< parameters.app_catalog_test >>' | tee .app_catalog_name
-  - run: |
-      [[ << parameters.chart >> == ${CIRCLE_PROJECT_REPONAME}* ]] && exit 0 || echo "chart parameter value must start with ${CIRCLE_PROJECT_REPONAME}" ; exit 1
+  - run:
+      name: Verify chart parameters
+      command: |
+        [[ << parameters.chart >> == ${CIRCLE_PROJECT_REPONAME}* ]] && exit 0 || echo "chart parameter value must start with ${CIRCLE_PROJECT_REPONAME}" ; exit 1
   - run:
       name: Clone app catalog repo
       command: |

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -29,12 +29,16 @@ steps:
               [[ ${CIRCLE_BRANCH} == master ]] && echo -n '<< parameters.app_catalog >>' | tee .app_catalog_name || echo -n '<< parameters.app_catalog_test >>' | tee .app_catalog_name
   - run: |
       [[ << parameters.chart >> == ${CIRCLE_PROJECT_REPONAME}* ]] && exit 0 || echo "chart parameter value must start with ${CIRCLE_PROJECT_REPONAME}" ; exit 1
-  - run: |
-      git clone -q --depth=1 --single-branch -b master "git@github.com:giantswarm/$(cat .app_catalog_name).git" .app_catalog
-  - run: |
-      mkdir build && helm package ./helm/<< parameters.chart >> --destination ./build
   - run:
-      name: Push to app catalog repo
+      name: Clone app catalog repo
+      command: |
+        git clone -q --depth=1 --single-branch -b master "git@github.com:giantswarm/$(cat .app_catalog_name).git" .app_catalog
+  - run:
+      name: Package the chart archive
+      command: |
+        mkdir build && helm package ./helm/<< parameters.chart >> --destination ./build
+  - run:
+      name: Push chart archive to app catalog repo
       command: |
           readonly app_catalog_name="$(cat .app_catalog_name)"
 


### PR DESCRIPTION
This PR adds some step names to the `package-and-push` action/workflow/whatever the term is.

The goal here is to make the CI steps easier to interpret for developers who didn't author architect-orb.

## Before

![image](https://user-images.githubusercontent.com/273727/96416819-cfbc9d00-11f0-11eb-963e-b2fd1c97b6a4.png)


## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [ ] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
