### PR TITLE
set default verions for kind, helm and kubectl in run-kat-tests job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set defaults for 'helm-version' (2.16.5), 'kind-version' (0.7.0) and 'kubectl-version' (1.18.0) in 'run-kat-tests' job.
+
 ## [0.15.0] - 2020-10-26
 
 ### Added

--- a/src/jobs/run-kat-tests.yaml
+++ b/src/jobs/run-kat-tests.yaml
@@ -14,10 +14,13 @@ parameters:
   kind-version:
     description: "Version of kind used for cluster_type: kind tests"
     type: string
+    default: "0.7.0"
   helm-version:
     type: string
+    default: "2.16.5"
   kubectl-version:
     type: string
+    default: "1.18.0"
   kube-app-testing-version:
     description: "Version of kube-app-testing to use"
     type: string


### PR DESCRIPTION
@piontec You were right in #191. It seems the job also needs the defaults

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
