### PR TITLE
Update versions in integration test job and remove obsolete code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Update kubernetes in integration-test job to v1.17.11.
+- Update kind in integration-test job to v0.9.0.
+- Update helm CLI in integration-test job to v3.4.0.
+
+### Fixed
+
+- Remove copying code to GOPATH in integration-test job since migration to
+Go modules is complete.
+
 ## [0.16.0] - 2020-10-27
 
 ### Added

--- a/src/commands/integration-test-create-cluster.yaml
+++ b/src/commands/integration-test-create-cluster.yaml
@@ -17,7 +17,7 @@ steps:
         - run:
             name: "architect/integration-test-create-cluster: Prepare default kind config"
             command: |
-                printf "kind: Cluster\napiVersion: kind.sigs.k8s.io/v1alpha3\n" > kind-config
+                printf "kind: Cluster\napiVersion: kind.x-k8s.io/v1alpha4\n" > kind-config
   - run:
       name: "architect/integration-test-create-cluster: Create cluster"
       command: |

--- a/src/commands/integration-test-go-test.yaml
+++ b/src/commands/integration-test-go-test.yaml
@@ -21,14 +21,6 @@ steps:
             command: |
                 touch .env
   - run:
-      name: "architect/integration-test-go-test: Move code to $GOPATH"
-      command: |
-        # TODO remove this after switch to Go modules.
-        mkdir -p $(go env GOPATH | cut -d ':' -f 1)/src/github.com/${CIRCLE_PROJECT_USERNAME}
-        mv ~/project $(go env GOPATH | cut -d ':' -f 1)/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-  - run:
       name: "architect/integration-test-go-test: Run test"
       command: |
-        # TODO remove `cd` line after switch to Go modules.
-        cd  $(go env GOPATH | cut -d ':' -f 1)/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
         source .env && CGO_ENABLED=0 E2E_KUBECONFIG=~/.kube/config go test -tags k8srequired -timeout << parameters.test-timeout >> -v ./<< parameters.test-dir >>

--- a/src/commands/integration-test-install-tools.yaml
+++ b/src/commands/integration-test-install-tools.yaml
@@ -5,7 +5,7 @@ steps:
   - run:
       name: "architect/integration-test-install-tools: Install kind"
       command: |
-        curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.7.0/kind-$(uname)-amd64"
+        curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.9.0/kind-$(uname)-amd64"
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin
   - run:

--- a/src/commands/integration-test-install-tools.yaml
+++ b/src/commands/integration-test-install-tools.yaml
@@ -23,7 +23,7 @@ steps:
   - run:
       name: "architect/integration-test-install-tools: Install Helm"
       command: |
-        curl -L https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz >./helm.tar.gz
+        curl -L https://get.helm.sh/helm-v3.4.0-linux-amd64.tar.gz >./helm.tar.gz
         tar xzvf helm.tar.gz
         chmod u+x linux-amd64/helm
         sudo mv linux-amd64/helm /usr/local/bin/

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -16,7 +16,7 @@ parameters:
     description: "Path to kind config file."
     type: string
   kubernetes-version:
-    default: "v1.16.3"
+    default: "v1.17.11"
     description: "Kubernetes version for kind cluster."
     type: string
   setup-script:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13206

The job hasn't been updated in a while. This gets it sorted and is prep for adding support for using `apptestctl bootstrap`.

## Checklist

- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
