### PR TITLE
Add support for apptestctl bootstrap to integration-test job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `install-app-platform` param to integration-test job that runs
+`apptestctl bootstrap` to add support for using app CRs in tests.
 - Update kubernetes in integration-test job to v1.17.11.
 - Update kind in integration-test job to v0.9.0.
 - Update helm CLI in integration-test job to v3.4.0.

--- a/docs/job/integration-test.md
+++ b/docs/job/integration-test.md
@@ -18,6 +18,7 @@ workflows:
     jobs:
       - architect/integration-test:
         name: basic-integration-test
+        install-app-platform: true
         test-dir: "integration/test/basic"
 ```
 
@@ -25,12 +26,18 @@ workflows:
 
 - [common parameters](common.md#parameters) shared in all jobs.
 - [test-dir](#attach_workspace) (required string)
+- [apptestctl-version](#apptestctl-version) (optional string, default="v0.4.1")
 - [env-file](#env-file) (optional string, default="")
+- [install-app-platform](#install-app-platform) (optional boolean, default=false)
 - [kind-config](#kind-config) (optional string, default="")
-- [kubernetes-version](#kubernetes-version) (optional string, default="v1.16.3")
+- [kubernetes-version](#kubernetes-version) (optional string, default="v1.17.11")
 - [setup-script](#setup-script) (optional string, default="")
 - [test-dir](#test-dir) (required string)
 - [test-timeout](#test-timeout) (optional string, default="20m")
+
+### apptestctl-version
+
+- Version of [apptestctl] to use if `install-app-platform` is true.
 
 ### env-file
 
@@ -51,6 +58,12 @@ e.g.
 FOO=bar
 BAR=foo
 ```
+
+### install-app-platform
+
+- If true then [apptestctl] is installed and `apptestctl bootstrap` is run.
+- This enables using app CRs to install components in tests. For Go tests the
+[apptest] library can be used to create the app CRs.
 
 ### kind-config
 
@@ -131,6 +144,8 @@ The default is "20m" (20 minutes).
         test-dir: "integration/test/basic"
 ```
 
+[apptest]: https://github.com/giantswarm/apptest
+[apptestctl]: https://github.com/giantswarm/apptestctl
 [KIND]: https://kind.sigs.k8s.io
 [KIND docs]: https://kind.sigs.k8s.io/docs/user/configuration/
 [machine executor]: https://circleci.com/docs/2.0/executor-types/#using-machine

--- a/src/commands/integration-test-install-app-platform.yaml
+++ b/src/commands/integration-test-install-app-platform.yaml
@@ -1,0 +1,20 @@
+parameters:
+  apptestctl-version:
+    type: string
+  install-app-platform:
+    type: boolean
+steps:
+  - when:
+      condition: << parameters.install-app-platform >>
+      steps:
+        - run:
+            name: "architect/integration-test-install-app-platform: Install apptestctl"
+            command: |
+              curl -L https://github.com/giantswarm/apptestctl/releases/download/<< parameters.apptestctl-version >>/apptestctl-<< parameters.apptestctl-version >>-linux-amd64.tar.gz > ./apptestctl.tar.gz
+              tar xzvf apptestctl.tar.gz
+              chmod u+x apptestctl-<< parameters.apptestctl-version >>-linux-amd64/apptestctl
+              sudo mv apptestctl-<< parameters.apptestctl-version >>-linux-amd64/apptestctl /usr/local/bin
+        - run:
+            name: "architect/integration-test-install-app-platform: Run apptestctl bootstrap"
+            command: |
+              apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)"

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -7,10 +7,20 @@ description: |
 
   See [docs](docs/integration_test.md) for more details.
 parameters:
+  apptestctl-version:
+    default: "v0.4.1"
+    description: "apptestctl version for bootstrapping app platform."
+    type: string
   env-file:
     default: ""
     description: "File of environment variables to set."
     type: string
+  install-app-platform:
+    type: boolean
+    default: false
+    description: |
+      When true the apptestctl bootstrap command is used to add support for
+      installing components in tests via app CRs.
   kind-config:
     default: ""
     description: "Path to kind config file."
@@ -45,6 +55,9 @@ steps:
   - attach_workspace:
       at: .
   - machine-install-go
+  - integration-test-install-app-platform:
+      apptestctl-version:  << parameters.apptestctl-version >>
+      install-app-platform:  << parameters.install-app-platform >>
   - integration-test-install-tools:
       kubernetes-version:  << parameters.kubernetes-version >>
   - integration-test-create-cluster:

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -55,14 +55,14 @@ steps:
   - attach_workspace:
       at: .
   - machine-install-go
-  - integration-test-install-app-platform:
-      apptestctl-version:  << parameters.apptestctl-version >>
-      install-app-platform:  << parameters.install-app-platform >>
   - integration-test-install-tools:
       kubernetes-version:  << parameters.kubernetes-version >>
   - integration-test-create-cluster:
       kind-config: << parameters.kind-config >>
       kubernetes-version:  << parameters.kubernetes-version >>
+  - integration-test-install-app-platform:
+      apptestctl-version:  << parameters.apptestctl-version >>
+      install-app-platform:  << parameters.install-app-platform >>
   - integration-test-setup:
       setup-script: << parameters.setup-script >>
   - integration-test-go-test:


### PR DESCRIPTION
Towards giantswarm/giantswarm#13206

Tested in https://github.com/giantswarm/metrics-server-app/pull/36/

## Checklist

- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).

