### PR TITLE
Add some parameters to push-to-docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.15.1
+  architect: giantswarm/architect@0.17.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `build-context`, `dockerfile` and `tag-suffix` parameters to `push-to-docker`.
+- Added names to steps in `push-to-docker` command.
+
 ## [0.17.0] - 2020-11-06
 
 ### Added

--- a/docs/job/push-to-docker.md
+++ b/docs/job/push-to-docker.md
@@ -2,7 +2,7 @@
 
 This job builds a docker image and pushes it to a registry.
 It uses the Dockerfile at the root of the workspace directory and the root directory as build context by default.
-Otherwise, it is possible to specify the used Dockerfile and build context by specifying `dockerfile` and `build-context` arguments.
+Otherwise, it is possible to specify the Dockerfile and build context to use with `dockerfile` and `build-context` arguments respectively.
 
 **NOTE**: docker registry username and password are read from environment variables which default to `ARCHITECT_DOCKER_REGISTRY_USERNAME` and `ARCHITECT_DOCKER_REGISTRY_PASSWORD` respectively. This can be changed via `username_var` and `password_var` arguments.
 **NOTE**: The docker image will be tagged with the version found by `architect project version` command.

--- a/docs/job/push-to-docker.md
+++ b/docs/job/push-to-docker.md
@@ -1,10 +1,13 @@
 # push-to-docker
 
 This job builds a docker image and pushes it to a registry.
-It requires the build context and Dockefile to be present at the root of worksapce directory.
+It uses the Dockerfile at the root of the workspace directory and the root directory as build context by default.
+Otherwise, it is possible to specify the used Dockerfile and build context by specifying `dockerfile` and `build-context` arguments.
 
-**NOTE**: docker registry username and password are read from environement variables which default to `ARCHITECT_DOCKER_REGISTRY_USERNAME` and `ARCHITECT_DOCKER_REGISTRY_PASSWORD` respectively. This can be changed via `username_var` and `password_var` arguments.
+**NOTE**: docker registry username and password are read from environment variables which default to `ARCHITECT_DOCKER_REGISTRY_USERNAME` and `ARCHITECT_DOCKER_REGISTRY_PASSWORD` respectively. This can be changed via `username_var` and `password_var` arguments.
 **NOTE**: The docker image will be tagged with the version found by `architect project version` command.
+
+Argument `tag-suffix` allows to specify a special suffix to be added after the generated container tag.
 
 Example usage
 
@@ -22,6 +25,9 @@ workflows:
           image: "quay.io/giantswarm/REPOSITORY"
           username_envar: "QUAY_USERNAME"
           password_envar: "QUAY_PASSWORD"
+          build-context: "."
+          dockerfile: "./Dockerfile"
+          tag-suffix: ""
           requires:
             # Make sure binary is built.
             - go-build-REPOSITORY

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -7,16 +7,37 @@ parameters:
     type: "string"
   tag-latest-branch:
     type: "string"
+  build-context:
+    type: "string"
+    default: "."
+  dockerfile:
+    type: "string"
+    default: "./Dockerfile"
+  tag-suffix:
+    type: "string"
+    default: ""
 steps:
-  - run: |
-      echo -n "<<parameters.image>>:$(architect project version)" > .docker_image_name
-  - run: |
-      echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "$(echo -n '<<parameters.image>>' | cut -d/ -f1)"
-  - run: |
-      docker build -t "$(cat .docker_image_name)" .
-  - run: |
-      docker push "$(cat .docker_image_name)"
-  - run: |
-      ! [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && echo "skip" || docker tag "$(cat .docker_image_name)" "<<parameters.image>>:latest"
-  - run: |
-      ! [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && echo "skip" || docker push "<<parameters.image>>:latest"
+  - run:
+      name: Generate container tag from 'architect project version' and tag-suffix parameter
+      command: |
+        echo -n "<<parameters.image>>:$(architect project version)<<parameters.tag-suffix>>" > .docker_image_name
+  - run:
+      name: Authenticate to container registry
+      command: |
+        echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "$(echo -n '<<parameters.image>>' | cut -d/ -f1)"
+  - run:
+      name: Build the container image using 'docker build'
+      command: |
+        docker build -f "<<parameters.dockerfile>>" -t "$(cat .docker_image_name)" "<<parameters.build-context>>"
+  - run:
+      name: Push the container image using 'docker push'
+      command: |
+        docker push "$(cat .docker_image_name)"
+  - run:
+      name: "When parameter 'tag-latest-branch' matches this branch: Retag the image as 'latest'"
+      command: |
+        ! [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && echo "skip" || docker tag "$(cat .docker_image_name)" "<<parameters.image>>:latest<<parameters.tag-suffix>>"
+  - run:
+      name: "When parameter 'tag-latest-branch' matches this branch: Push the 'latest' image to the container registry"
+      command: |
+        ! [[ "<<parameters.tag-latest-branch>>" == "${CIRCLE_BRANCH}" ]] && echo "skip" || docker push "<<parameters.image>>:latest<<parameters.tag-suffix>>"

--- a/src/jobs/push-to-docker.yaml
+++ b/src/jobs/push-to-docker.yaml
@@ -22,6 +22,15 @@ parameters:
         for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
+  build-context:
+    type: "string"
+    default: "."
+  dockerfile:
+    type: "string"
+    default: "./Dockerfile"
+  tag-suffix:
+    type: "string"
+    default: ""
 executor: "architect"
 resource_class: "<< parameters.resource_class >>"
 steps:
@@ -34,3 +43,6 @@ steps:
       tag-latest-branch: <<parameters.tag-latest-branch>>
       password_envar: <<parameters.password_envar>>
       username_envar: <<parameters.username_envar>>
+      build-context: <<parameters.build-context>>
+      dockerfile: <<parameters.dockerfile>>
+      tag-suffix: <<parameters.tag-suffix>>


### PR DESCRIPTION
This PR adds parameters `build-context`, `dockerfile` and `tag-suffix` to the `push-to-docker` jobs.

I want to push a container image built from a custom Dockerfile to the same container repo with a custom tag suffix.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
