### PR TITLE
Use apptestctl v0.5.0 in integration-test job.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Use apptestctl v0.5.0 in `integration-test` job.
+
 ## [0.17.1] - 2020-11-24
 
 ### Added

--- a/src/commands/integration-test-install-app-platform.yaml
+++ b/src/commands/integration-test-install-app-platform.yaml
@@ -17,4 +17,4 @@ steps:
         - run:
             name: "architect/integration-test-install-app-platform: Run apptestctl bootstrap"
             command: |
-              apptestctl bootstrap --kubeconfig-path=/.kube/config
+              apptestctl bootstrap --kubeconfig-path=~/.kube/config

--- a/src/commands/integration-test-install-app-platform.yaml
+++ b/src/commands/integration-test-install-app-platform.yaml
@@ -17,4 +17,4 @@ steps:
         - run:
             name: "architect/integration-test-install-app-platform: Run apptestctl bootstrap"
             command: |
-              apptestctl bootstrap --kubeconfig="$(kind get kubeconfig)"
+              apptestctl bootstrap --kubeconfig-path=/.kube/config

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -8,7 +8,7 @@ description: |
   See [docs](docs/integration_test.md) for more details.
 parameters:
   apptestctl-version:
-    default: "v0.4.1"
+    default: "v0.5.0"
     description: "apptestctl version for bootstrapping app platform."
     type: string
   env-file:


### PR DESCRIPTION
## Checklist

New apptestctl release adds better kubeconfig support and we now wait for app platform components to start which makes the tests more reliable. 

https://github.com/giantswarm/apptestctl/blob/master/CHANGELOG.md#050---2020-11-27

- [x] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
