### PR TITLE
Relax chart parameter validation in push-to-app-catalog job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow `chart` parameter value of job `push-to-app-catalog` to be
+"name of repository with optional -app suffix".
+
 ## [1.0.0] - 2020-12-04
 
 ### Added

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -56,6 +56,7 @@ If there are values files in the `ci` folder of the chart, they will be used to 
 - [common parameters](common.md#parameters) shared in all jobs.
 - [attach_workspace](#attach_workspace) (optional boolean, default=false)
 - [executor](#executor) (optional, either `architect` or `app-build-suite`, default=`architect`)
+- [chart](#chart) name of the directory containing the chart in `helm/`
 
 ### attach_workspace
 
@@ -75,6 +76,11 @@ Enables users to select the executor and control whether metadata should be gene
 Selecting `app-build-suite` will execute chart linting, validating and packaging using
 [app-build-suite](https://github.com/giantswarm/app-build-suite). This also enables
 generation and publishing of metadata into the catalog.
+
+### chart
+
+Name of the directory containing the helm chart in the `helm/` directory. This should match
+the name of the repository with an optional `-app` suffix.
 
 ## Example
 

--- a/src/commands/package-and-push-with-abs.yaml
+++ b/src/commands/package-and-push-with-abs.yaml
@@ -30,7 +30,8 @@ steps:
   - run:
       name: Verify chart parameters
       command: |
-        [[ << parameters.chart >> == ${CIRCLE_PROJECT_REPONAME}* ]] && exit 0 || echo "chart parameter value must start with ${CIRCLE_PROJECT_REPONAME}" ; exit 1
+        CHART_NAME="<< parameters.chart >>"
+        [[ ${CHART_NAME%-app} == ${CIRCLE_PROJECT_REPONAME%-app} ]] && exit 0 || echo "chart parameter value should match ${CIRCLE_PROJECT_REPONAME%-app} or ${CIRCLE_PROJECT_REPONAME%-app}-app" ; exit 1
   - run:
       name: Execute App Build Suite
       command: |

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -30,7 +30,8 @@ steps:
   - run:
       name: Verify chart parameters
       command: |
-        [[ << parameters.chart >> == ${CIRCLE_PROJECT_REPONAME}* ]] && exit 0 || echo "chart parameter value must start with ${CIRCLE_PROJECT_REPONAME}" ; exit 1
+        CHART_NAME="<< parameters.chart >>"
+        [[ ${CHART_NAME%-app} == ${CIRCLE_PROJECT_REPONAME%-app} ]] && exit 0 || echo "chart parameter value should match ${CIRCLE_PROJECT_REPONAME%-app} or ${CIRCLE_PROJECT_REPONAME%-app}-app" ; exit 1
   - run:
       name: Clone app catalog repo
       command: |


### PR DESCRIPTION
Towards giantswarm/giantswarm#9815

This PR loosens the chart name validation to allow both `repository-name` and `repository-name-app`.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
