### PR TITLE
Bump helm version in run-kat-tests job to 2.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.17.0
+  architect: giantswarm/architect@1.1.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump helm version in `run-kat-tests` job
+
 ## [1.1.0] - 2020-12-22
 
 ### Changed

--- a/src/commands/kat-tests-install-tools.yaml
+++ b/src/commands/kat-tests-install-tools.yaml
@@ -4,7 +4,7 @@ parameters:
     default: "0.7.0"
   helm-version:
     type: string
-    default: "2.16.5"
+    default: "2.17.0"
   kubectl-version:
     type: string
     default: "1.18.0"
@@ -24,7 +24,7 @@ steps:
       command: |
         mkdir /tmp/bin || true
   - restore_cache:
-      key: bin-{{ checksum "/tmp/kube-app-testing.sh" }}
+      key: bin-<< parameters.kube-app-testing-version >>-<< parameters.kind-version >>-<< parameters.helm-version >>-<< parameters.kubectl-version >>
   - run:
       name: "install kind"
       command: |
@@ -38,6 +38,6 @@ steps:
       command: |
         if [[ ! -f /tmp/bin/kubectl ]]; then curl -Lo /tmp/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v<< parameters.kubectl-version >>/bin/linux/amd64/kubectl && chmod +x /tmp/bin/kubectl; fi
   - save_cache:
-      key: bin-{{ checksum "/tmp/kube-app-testing.sh" }}
+      key: bin-<< parameters.kube-app-testing-version >>-<< parameters.kind-version >>-<< parameters.helm-version >>-<< parameters.kubectl-version >>
       paths:
         - /tmp/bin

--- a/src/jobs/run-kat-tests.yaml
+++ b/src/jobs/run-kat-tests.yaml
@@ -16,7 +16,7 @@ parameters:
     default: "0.7.0"
   helm-version:
     type: string
-    default: "2.16.5"
+    default: "2.17.0"
   kubectl-version:
     type: string
     default: "1.18.0"


### PR DESCRIPTION
This PR bumps the default helm version used by `run-kat-tests` job to 2.17.0.

This should resolve errors recently surfaced (`Error: error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden`)

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
