### PR TITLE
Bump app build suite version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@1.1.0
+  architect: giantswarm/architect@1.1.1
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Use version 0.1.5 of app-build-suite for `app-build-suite` executor.
-- Added `run-tests-with-abs` job for test execution using app-build-suite.
+- Use version 0.1.7 of app-build-suite for `app-build-suite` executor.
+- Added experimental `run-tests-with-abs` job for test execution using app-build-suite.
 
 ## [1.1.1] - 2021-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Use version 0.1.3 of app-build-suite for `app-build-suite` executor.
+- Added `run-tests-with-abs` job for test execution using app-build-suite.
+
 ## [1.1.1] - 2021-01-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Use version 0.1.3 of app-build-suite for `app-build-suite` executor.
+- Use version 0.1.4 of app-build-suite for `app-build-suite` executor.
 - Added `run-tests-with-abs` job for test execution using app-build-suite.
 
 ## [1.1.1] - 2021-01-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Use version 0.1.4 of app-build-suite for `app-build-suite` executor.
+- Use version 0.1.5 of app-build-suite for `app-build-suite` executor.
 - Added `run-tests-with-abs` job for test execution using app-build-suite.
 
 ## [1.1.1] - 2021-01-07

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@
 - [push-to-docker-legacy](job/push-to-docker-legacy.md)
 - [push-to-docker](job/push-to-docker.md)
 - [run-kat-tests](job/run-kat-tests.md)
+- [run-tests-with-abs](job/run-tests-with-abs.ms) (Experimental)

--- a/docs/job/run-tests-with-abs.md
+++ b/docs/job/run-tests-with-abs.md
@@ -1,0 +1,55 @@
+# run-tests-with-abs
+
+**Experimental!!!** Only use this if you know what you're doing!
+
+Use this job to execute managed apps using [app-build-suite](https://github.com/giantswarm/app-build-suite).
+
+Example usage
+
+```yaml
+version: 2.1
+orbs:
+  architect: giantswarm/architect@VERSION
+
+workflows:
+  my-workflow:
+    jobs:
+       - architect/run-tests-with-abs:
+          name: execute chart tests
+          chart_dir: "./helm/my-beautiful-app"
+```
+
+## Parameters
+
+- [common parameters](common.md#parameters) shared in all jobs.
+- [chart_dir](#chart_dir)
+- [app-build-suite_version](#app-build-suite_version)
+- [app-build-suite_container_tag](#app-build-suite_container_tag)
+- [additional_app-build-suite_flags](#additional_app-build-suite_flags)
+
+### chart_dir
+
+Directory in which the chart resides. Usually starts with `./helm`
+
+### app-build-suite_version
+
+Version of app-build-suite `dabs.sh` container wrapper to use (git tag or commit).
+Use this parameter if you have some changes lined up in `dabs.sh` which is not released yet.
+For git tags, the same container tag of app-build-suite will be used.
+
+**Attention:** For git commits or branches, `latest` will be used as container tag.
+This can be circumvented by also setting the parameter [`app-build-suite_container_tag`](#app-build-suite_container_tag).
+
+(Default: "v0.1.7")
+
+### app-build-suite_container_tag
+
+Container tag of app-build-suite to use (check [quay.io/giantswarm/app-build-suite](https://quay.io/giantswarm/app-build-suite)).
+This parameter allows to specify the used container tag of app-build-suite.
+
+(Default: "0.1.7")
+
+### additional_app-build-suite_flags
+
+Allows to add additional flags to the execution of app-build-suite.
+If possible, specify your configuration using the `.abs/main.yaml` configuration file.

--- a/src/commands/run-tests-with-abs.yaml
+++ b/src/commands/run-tests-with-abs.yaml
@@ -1,0 +1,22 @@
+parameters:
+  chart_dir:
+    type: string
+  app-build-suite_version:
+    description: "Version of app-build-suite to use"
+    type: string
+    default: "0.1.3"
+  additional_app-build-suite_flags:
+    description: "Additional app-build-suite flags to use"
+    type: string
+    default: ""
+steps:
+  - run:
+      name: "download dabs.sh script"
+      command: |
+        requested_version="<< parameters.app-build-suite_version >>"
+        wget https://github.com/giantswarm/app-build-suite/releases/download/v${requested_version#v}/dabs.sh
+        chmod +x dabs.sh
+  - run:
+      name: "execute app-build-suite with dabs.sh wrapper"
+      command: |
+        ./dabs.sh -c << parameters.chart_dir >> << parameters.additional_app-build-suite_flags >>

--- a/src/commands/run-tests-with-abs.yaml
+++ b/src/commands/run-tests-with-abs.yaml
@@ -2,7 +2,10 @@ parameters:
   chart_dir:
     type: string
   app-build-suite_version:
-    description: "Version of app-build-suite to use"
+    description: "Version of app-build-suite dabs.sh container wrapper to use (git tag or commit)"
+    type: string
+  app-build-suite_container_tag:
+    description: "Container tag of app-build-suite to use (check quay.io/giantswarm/app-build-suite)"
     type: string
   additional_app-build-suite_flags:
     description: "Additional app-build-suite flags to use"
@@ -12,10 +15,10 @@ steps:
   - run:
       name: "download dabs.sh script"
       command: |
-        requested_version="<< parameters.app-build-suite_version >>"
-        wget https://github.com/giantswarm/app-build-suite/releases/download/v${requested_version#v}/dabs.sh
+        wget "https://raw.githubusercontent.com/giantswarm/app-build-suite/<< parameters.app-build-suite_version >>/dabs.sh"
         chmod +x dabs.sh
   - run:
       name: "execute app-build-suite with dabs.sh wrapper"
       command: |
+        export DABS_TAG=<< parameters.app-build-suite_container_tag >>
         ./dabs.sh -c << parameters.chart_dir >> << parameters.additional_app-build-suite_flags >>

--- a/src/commands/run-tests-with-abs.yaml
+++ b/src/commands/run-tests-with-abs.yaml
@@ -4,7 +4,7 @@ parameters:
   app-build-suite_version:
     description: "Version of app-build-suite to use"
     type: string
-    default: "0.1.3"
+    default: "0.1.4"
   additional_app-build-suite_flags:
     description: "Additional app-build-suite flags to use"
     type: string

--- a/src/commands/run-tests-with-abs.yaml
+++ b/src/commands/run-tests-with-abs.yaml
@@ -4,7 +4,6 @@ parameters:
   app-build-suite_version:
     description: "Version of app-build-suite to use"
     type: string
-    default: "0.1.4"
   additional_app-build-suite_flags:
     description: "Additional app-build-suite flags to use"
     type: string

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/app-build-suite:0.1.4-circleci
+    image: quay.io/giantswarm/app-build-suite:0.1.5-circleci

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/app-build-suite:0.1.5-566d296f0c6c1326b5a6676b43b253b976f23ec9-circleci
+    image: quay.io/giantswarm/app-build-suite:0.1.7-circleci

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/app-build-suite:0.1.3-circleci
+    image: quay.io/giantswarm/app-build-suite:0.1.4-circleci

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/app-build-suite:0.1.5-circleci
+    image: quay.io/giantswarm/app-build-suite:0.1.5-566d296f0c6c1326b5a6676b43b253b976f23ec9-circleci

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/app-build-suite:0.1.2-circleci
+    image: quay.io/giantswarm/app-build-suite:0.1.3-circleci

--- a/src/jobs/run-tests-with-abs.yaml
+++ b/src/jobs/run-tests-with-abs.yaml
@@ -5,7 +5,7 @@ parameters:
   app-build-suite_version:
     description: "Version of app-build-suite to use"
     type: string
-    default: "0.1.4"
+    default: "0.1.5"
   additional_app-build-suite_flags:
     description: "Additional app-build-suite flags to use"
     type: string

--- a/src/jobs/run-tests-with-abs.yaml
+++ b/src/jobs/run-tests-with-abs.yaml
@@ -5,11 +5,11 @@ parameters:
   app-build-suite_version:
     description: "Version of app-build-suite dabs.sh container wrapper to use (git tag or commit)"
     type: string
-    default: "v0.1.5"
+    default: "v0.1.7"
   app-build-suite_container_tag:
     description: "Container tag of app-build-suite to use (check quay.io/giantswarm/app-build-suite)"
     type: string
-    default: "0.1.5"
+    default: "0.1.7"
   additional_app-build-suite_flags:
     description: "Additional app-build-suite flags to use"
     type: string

--- a/src/jobs/run-tests-with-abs.yaml
+++ b/src/jobs/run-tests-with-abs.yaml
@@ -5,7 +5,7 @@ parameters:
   app-build-suite_version:
     description: "Version of app-build-suite to use"
     type: string
-    default: "0.1.3"
+    default: "0.1.4"
   additional_app-build-suite_flags:
     description: "Additional app-build-suite flags to use"
     type: string

--- a/src/jobs/run-tests-with-abs.yaml
+++ b/src/jobs/run-tests-with-abs.yaml
@@ -22,7 +22,7 @@ executor: "machine"
 resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
-  - abs-run-tests:
+  - run-tests-with-abs:
       chart_dir: << parameters.chart_dir >>
       app-build-suite_version: << parameters.app-build-suite_version >>
       additional_app-build-suite_flags: << parameters.additional_app-build-suite_flags >>

--- a/src/jobs/run-tests-with-abs.yaml
+++ b/src/jobs/run-tests-with-abs.yaml
@@ -1,0 +1,28 @@
+parameters:
+  chart_dir:
+    description: "Directory in which the chart resides. Usually starts with ./helm"
+    type: string
+  app-build-suite_version:
+    description: "Version of app-build-suite to use"
+    type: string
+    default: "0.1.3"
+  additional_app-build-suite_flags:
+    description: "Additional app-build-suite flags to use"
+    type: string
+    default: ""
+  resource_class:
+    default: "medium"
+    description: |
+        Configures amount CPU and RAM for the job. See
+        https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux
+        for details.
+    type: "enum"
+    enum: ["medium", "large", "xlarge", "2xlarge"]
+executor: "machine"
+resource_class: "<< parameters.resource_class >>"
+steps:
+  - checkout
+  - abs-run-tests:
+      chart_dir: << parameters.chart_dir >>
+      app-build-suite_version: << parameters.app-build-suite_version >>
+      additional_app-build-suite_flags: << parameters.additional_app-build-suite_flags >>

--- a/src/jobs/run-tests-with-abs.yaml
+++ b/src/jobs/run-tests-with-abs.yaml
@@ -3,7 +3,11 @@ parameters:
     description: "Directory in which the chart resides. Usually starts with ./helm"
     type: string
   app-build-suite_version:
-    description: "Version of app-build-suite to use"
+    description: "Version of app-build-suite dabs.sh container wrapper to use (git tag or commit)"
+    type: string
+    default: "v0.1.5"
+  app-build-suite_container_tag:
+    description: "Container tag of app-build-suite to use (check quay.io/giantswarm/app-build-suite)"
     type: string
     default: "0.1.5"
   additional_app-build-suite_flags:
@@ -25,4 +29,5 @@ steps:
   - run-tests-with-abs:
       chart_dir: << parameters.chart_dir >>
       app-build-suite_version: << parameters.app-build-suite_version >>
+      app-build-suite_container_tag: << parameters.app-build-suite_container_tag >>
       additional_app-build-suite_flags: << parameters.additional_app-build-suite_flags >>


### PR DESCRIPTION
This PR bumps the app-build-suite version in the app-build-suite executor

It also adds an experimental `run-tests-with-abs` job.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
