### PR TITLE
Update catalog index base hosts to giantswarm.github.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@1.1.2
+  architect: giantswarm/architect@2.0.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change app catalog base domain to `giantswarm.github.io` because of upstream redirect deprecation.
+
 ## [2.0.0] - 2021-02-19
 
 ### Changed

--- a/src/commands/package-and-push-with-abs.yaml
+++ b/src/commands/package-and-push-with-abs.yaml
@@ -66,8 +66,8 @@ steps:
             echo "====> Attempt $i: Running: git pull --rebase"
             git pull --rebase
 
-            echo "====> Attempt $i: Running: helm repo index --url https://giantswarm.github.com/$app_catalog_name --merge index.yaml ../build"
-            helm repo index --url https://giantswarm.github.com/$app_catalog_name --merge index.yaml ../build
+            echo "====> Attempt $i: Running: helm repo index --url https://giantswarm.github.io/$app_catalog_name --merge index.yaml ../build"
+            helm repo index --url https://giantswarm.github.io/$app_catalog_name --merge index.yaml ../build
 
             echo "====> Attempt $i: Running: cp ../build/* ."
             cp -r ../build/* .

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -58,8 +58,8 @@ steps:
             echo "====> Attempt $i: Running: git pull --rebase"
             git pull --rebase
 
-            echo "====> Attempt $i: Running: helm repo index --url https://giantswarm.github.com/$app_catalog_name --merge index.yaml ../build"
-            helm repo index --url https://giantswarm.github.com/$app_catalog_name --merge index.yaml ../build
+            echo "====> Attempt $i: Running: helm repo index --url https://giantswarm.github.io/$app_catalog_name --merge index.yaml ../build"
+            helm repo index --url https://giantswarm.github.io/$app_catalog_name --merge index.yaml ../build
 
             echo "====> Attempt $i: Running: cp ../build/* ."
             cp ../build/* .


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15898

This PR updates the app-catalog base domain to giantswarm.github.io because the redirect from .com to .io will be shut off in 2021-04-15

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
