### PR TITLE
Allow chart name mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.0.0
+  architect: giantswarm/architect@2.1.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow chart name mismatch for `push-to-app-catalog` by setting `explicit_allow_chart_name_mismatch` to `true`.
+
 ## [2.1.0] - 2021-02-24
 
 ### Changed

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -82,6 +82,11 @@ generation and publishing of metadata into the catalog.
 Name of the directory containing the helm chart in the `helm/` directory. This should match
 the name of the repository with an optional `-app` suffix.
 
+### explicit_allow_chart_name_mismatch
+
+Should be used to allow chart name validation. Set to `true` to explicitly disable checking against the name of the repository with optional `-app` suffix.
+This can be the case if the chart directory is generated during CI runs or when multiple charts reside in a single repository.
+
 ## Example
 
 ```yaml

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -55,8 +55,10 @@ If there are values files in the `ci` folder of the chart, they will be used to 
 
 - [common parameters](common.md#parameters) shared in all jobs.
 - [attach_workspace](#attach_workspace) (optional boolean, default=false)
-- [executor](#executor) (optional, either `architect` or `app-build-suite`, default=`architect`)
+- [executor](#executor-optional-either-architect-or-app-build-suite-defaultarchitect) (optional, either `architect` or `app-build-suite`, default=`architect`)
 - [chart](#chart) name of the directory containing the chart in `helm/`
+- [on_tag](#on_tag-optional-boolean-defaulttrue) only push tagged commits to `app_catalog`
+- [explicit_allow_chart_name_mismatch](#explicit_allow_chart_name_mismatch-optional-boolean-defaultfalse)
 
 ### attach_workspace
 
@@ -82,10 +84,12 @@ generation and publishing of metadata into the catalog.
 Name of the directory containing the helm chart in the `helm/` directory. This should match
 the name of the repository with an optional `-app` suffix.
 
-### explicit_allow_chart_name_mismatch
+### explicit_allow_chart_name_mismatch (optional boolean, default=false)
 
 Should be used to allow chart name validation. Set to `true` to explicitly disable checking against the name of the repository with optional `-app` suffix.
 This can be the case if the chart directory is generated during CI runs or when multiple charts reside in a single repository.
+
+Does not have any effect if `executor: app-build-suite` is set.
 
 ## Example
 

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -12,6 +12,13 @@ parameters:
       When this is `false`, commits to `master` will be pushed to `app_catalog` instead of `app_catalog_test`.
       Set this to `false` for deployments that follow a a master branch for production releases rather than
       using tags (the default).
+  explicit_allow_chart_name_mismatch:
+    type: boolean
+    default: false
+    description: |
+      If 'explicit_allow_chart_name_mismatch' is set to true, the name of the chart can be anything.
+      Otherwise the name set in the 'chart' parameter must start with the repository name and optionally continue with '-app'.
+      Does not have any effect for 'executor: app-build-suite'.
 steps:
   - when:
       condition: << parameters.on_tag >>
@@ -27,11 +34,14 @@ steps:
             name: "architect/package-and-push: Determine target app catalog based on branch name"
             command: |
               [[ ${CIRCLE_BRANCH} == master ]] && echo -n '<< parameters.app_catalog >>' | tee .app_catalog_name || echo -n '<< parameters.app_catalog_test >>' | tee .app_catalog_name
-  - run:
-      name: Verify chart parameters
-      command: |
-        CHART_NAME="<< parameters.chart >>"
-        [[ ${CHART_NAME%-app} == ${CIRCLE_PROJECT_REPONAME%-app} ]] && exit 0 || echo "chart parameter value should match ${CIRCLE_PROJECT_REPONAME%-app} or ${CIRCLE_PROJECT_REPONAME%-app}-app" ; exit 1
+  - unless:
+      condition: << parameters.explicit_allow_chart_name_mismatch >>
+      steps:
+        - run:
+            name: Verify chart parameters
+            command: |
+              CHART_NAME="<< parameters.chart >>"
+              [[ ${CHART_NAME%-app} == ${CIRCLE_PROJECT_REPONAME%-app} ]] && exit 0 || echo "chart parameter value should match ${CIRCLE_PROJECT_REPONAME%-app} or ${CIRCLE_PROJECT_REPONAME%-app}-app" ; exit 1
   - run:
       name: Clone app catalog repo
       command: |

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -12,6 +12,13 @@ parameters:
   chart:
     description: "Name of the chart inside helm directory to push to the App Catalog."
     type: "string"
+  explicit_allow_chart_name_mismatch:
+    type: boolean
+    default: false
+    description: |
+      If 'explicit_allow_chart_name_mismatch' is set to true, the name of the chart can be anything.
+      Otherwise the name set in the 'chart' parameter must start with the repository name and optionally continue with '-app'.
+      Does not have any effect for 'executor: app-build-suite'.
   ct_config:
     description: "Chart Testing Config file path"
     type: "string"
@@ -67,6 +74,7 @@ steps:
             app_catalog_test: << parameters.app_catalog_test >>
             chart: << parameters.chart >>
             on_tag: << parameters.on_tag >>
+            explicit_allow_chart_name_mismatch: << parameters.explicit_allow_chart_name_mismatch >>
   - when:
       condition:
         equal: ["<< parameters.executor >>", "app-build-suite"]


### PR DESCRIPTION
This PR adds parameter `explicit_allow_chart_name_mismatch` to allow disabling chart name check in `push-to-app-catalog`

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
