### PR TITLE
Upgrade app-build-suite executor to use 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Use version 0.2.1 of app-build-suite for `app-build-suite` executor.
+
 ### Changed
 
 - Allow chart name mismatch for `push-to-app-catalog` by setting `explicit_allow_chart_name_mismatch` to `true`.

--- a/docs/job/run-tests-with-abs.md
+++ b/docs/job/run-tests-with-abs.md
@@ -40,14 +40,14 @@ For git tags, the same container tag of app-build-suite will be used.
 **Attention:** For git commits or branches, `latest` will be used as container tag.
 This can be circumvented by also setting the parameter [`app-build-suite_container_tag`](#app-build-suite_container_tag).
 
-(Default: "v0.1.7")
+(Default: "v0.2.1")
 
 ### app-build-suite_container_tag
 
 Container tag of app-build-suite to use (check [quay.io/giantswarm/app-build-suite](https://quay.io/giantswarm/app-build-suite)).
 This parameter allows to specify the used container tag of app-build-suite.
 
-(Default: "0.1.7")
+(Default: "v0.2.1")
 
 ### additional_app-build-suite_flags
 

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/app-build-suite:0.1.7-circleci
+    image: quay.io/giantswarm/app-build-suite:0.2.1-circleci

--- a/src/jobs/run-tests-with-abs.yaml
+++ b/src/jobs/run-tests-with-abs.yaml
@@ -5,11 +5,11 @@ parameters:
   app-build-suite_version:
     description: "Version of app-build-suite dabs.sh container wrapper to use (git tag or commit)"
     type: string
-    default: "v0.1.7"
+    default: "v0.2.1"
   app-build-suite_container_tag:
     description: "Container tag of app-build-suite to use (check quay.io/giantswarm/app-build-suite)"
     type: string
-    default: "0.1.7"
+    default: "0.2.1"
   additional_app-build-suite_flags:
     description: "Additional app-build-suite flags to use"
     type: string


### PR DESCRIPTION
Upgrade app-build-suite executor to use 0.2.1

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
