### PR TITLE
Update go to 1.16.2 and architect to 3.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.2.0
+  architect: giantswarm/architect@2.3.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update Go version used in `machine-install` command to 1.16.2.
-- Bump architect to 3.4.0.
+- Bump architect to [3.4.0](https://github.com/giantswarm/architect/releases/tag/v3.4.0).
   - Update `go` version to `v1.16.2`.
   - Update `helm` version to `v3.5.3`.
   - Update `alpine` version to `3.13`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Go version used in `machine-install` command to 1.16.2.
 - Bump architect to 3.4.0.
+  - Update `go` version to `v1.16.2`.
+  - Update `helm` version to `v3.5.3`.
+  - Update `alpine` version to `3.13`.
+  - Update `conftest` version to `v0.21.0`.
+  - Update `golangci-lint` version to `v1.38.0`.
+  - Update `nancy` version to `v1.0.16`.
+  - Update `helm-chart-testing` to `v3.3.1`.
 
 ## [2.3.0] - 2021-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Go version used in `machine-install` command to 1.16.2.
+- Bump architect to 3.4.0.
+
 ## [2.3.0] - 2021-03-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `alpine` version to `3.13`.
   - Update `conftest` version to `v0.21.0`.
   - Update `golangci-lint` version to `v1.38.0`.
-  - Update `nancy` version to `v1.0.16`.
+  - Update `nancy` version to `v1.0.17`.
   - Update `helm-chart-testing` to `v3.3.1`.
 
 ## [2.3.0] - 2021-03-12

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -20,6 +20,6 @@ steps:
   - run: |
       CGO_ENABLED=0 golangci-lint run -E gosec -E goconst
   - run: |
-      CGO_ENABLED=0 go list -json -m all | nancy -quiet
+      CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet
   - run: |
       CGO_ENABLED=0 go test -ldflags "$(cat .ldflags)" ./...

--- a/src/commands/machine-install-go.yaml
+++ b/src/commands/machine-install-go.yaml
@@ -6,15 +6,15 @@ steps:
   - run:
       name: "architect/machine-install-go: Download Go"
       command: |
-        wget https://dl.google.com/go/go1.16.1.linux-amd64.tar.gz
+        wget https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Check downloaded Go checksum"
       command: |
-        [[ "$(sha256sum go1.16.1.linux-amd64.tar.gz | cut -d ' ' -f 1)" == "3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769" ]]
+        [[ "$(sha256sum go1.16.2.linux-amd64.tar.gz | cut -d ' ' -f 1)" == "542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8" ]]
   - run:
       name: "architect/machine-install-go: Install Go"
       command: |
-        sudo tar -C /usr/local -xzf go1.16.1.linux-amd64.tar.gz
+        sudo tar -C /usr/local -xzf go1.16.2.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Set Go environment"
       command: |
@@ -22,7 +22,7 @@ steps:
   - run:
       name: "architect/machine-install-go: Remove downloaded Go files"
       command: |
-        rm go1.16.1.linux-amd64.tar.gz
+        rm go1.16.2.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Check Go version"
       command: |

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:3.3.1-d5fbb838540744dd8b2d344fffc4f79041422bbe
+    image: quay.io/giantswarm/architect:3.3.1-64f412d3d944f68df3230c2b69f503ee7acf3804

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:3.3.1-64f412d3d944f68df3230c2b69f503ee7acf3804
+    image: quay.io/giantswarm/architect:3.3.1-39c1cf5eb00bd7d45fe3116d18f5a41e44904811

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:3.3.1-39c1cf5eb00bd7d45fe3116d18f5a41e44904811
+    image: quay.io/giantswarm/architect:3.4.0

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:3.3.1
+    image: quay.io/giantswarm/architect:3.4.0

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:3.4.0
+    image: quay.io/giantswarm/architect:3.3.1-d5fbb838540744dd8b2d344fffc4f79041422bbe


### PR DESCRIPTION
Together with https://github.com/giantswarm/architect/pull/592,

this upgrades the used go version to 1.16.2 and architect to 3.4.0

From architect-changelog:

```
- Update `go` version to `v1.16.2`.
- Update `helm` version to `v3.5.3`.
- Update `alpine` version to `3.13`.
- Update `conftest` version to `v0.21.0`.
- Update `golangci-lint` version to `v1.38.0`.
- Update `nancy` version to `v1.0.17`.
- Update `helm-chart-testing` to `v3.3.1`.
```

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
