### PR TITLE
Allow skipping ct lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow skipping helm chart linting during `push-to-app-catalog` by setting `skip_helm_chart_linting`.
+
 ## [2.4.2] - 2021-03-24
 
 ### Fixed

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -59,6 +59,7 @@ If there are values files in the `ci` folder of the chart, they will be used to 
 - [chart](#chart) name of the directory containing the chart in `helm/`
 - [on_tag](#on_tag-optional-boolean-defaulttrue) only push tagged commits to `app_catalog`
 - [explicit_allow_chart_name_mismatch](#explicit_allow_chart_name_mismatch-optional-boolean-defaultfalse)
+- [skip_helm_chart_linting](#skip_helm_chart_linting-optional-boolean-defaultfalse)
 
 ### attach_workspace
 
@@ -90,6 +91,11 @@ Should be used to allow chart name validation. Set to `true` to explicitly disab
 This can be the case if the chart directory is generated during CI runs or when multiple charts reside in a single repository.
 
 Does not have any effect if `executor: app-build-suite` is set.
+
+### skip_helm_chart_linting (optional boolean, default=false)
+
+If `skip_helm_chart_linting` is set to `true`, the helm chart will not be checked with `ct lint` or `conftest`.
+This flag is intended _only_ for apps which have non-standard resources to apply which can not be validated this way, such as the `ClusterPolicy` resources contained in [`clusterpolicies`](https://github.com/giantswarm/clusterpolicies).
 
 ## Example
 

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -19,6 +19,12 @@ parameters:
       If 'explicit_allow_chart_name_mismatch' is set to true, the name of the chart can be anything.
       Otherwise the name set in the 'chart' parameter must start with the repository name and optionally continue with '-app'.
       Does not have any effect for 'executor: app-build-suite'.
+  skip_helm_chart_linting:
+    type: boolean
+    default: false
+    description: |
+      If 'skip_helm_chart_linting' is set to true, the helm chart will not be checked for errors.
+      This flag is intended only for apps which have non-standard resources to apply which can't be validated with helm.
 steps:
   - when:
       condition: << parameters.on_tag >>

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -47,6 +47,12 @@ parameters:
         for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
+  skip_helm_chart_linting:
+    type: boolean
+    default: false
+    description: |
+      If 'skip_helm_chart_linting' is set to true, the helm chart will not be checked for errors.
+      This flag is intended only for apps which have non-standard resources to apply which can't be validated with helm.
 executor: "<< parameters.executor >>"
 resource_class: "<< parameters.resource_class >>"
 steps:
@@ -64,9 +70,12 @@ steps:
         - prepare-catalogbot-git-ssh
         - helm-chart-template:
             chart: << parameters.chart >>
-        - helm-lint:
-            chart: "<< parameters.chart >>"
-            ct_config: "<< parameters.ct_config >>"
+        - unless:
+            condition: << parameters.skip_helm_chart_linting >>
+            steps:
+            - helm-lint:
+                chart: "<< parameters.chart >>"
+                ct_config: "<< parameters.ct_config >>"
         - helm-conftest:
             chart: "<< parameters.chart >>"
         - package-and-push:

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -76,8 +76,8 @@ steps:
             - helm-lint:
                 chart: "<< parameters.chart >>"
                 ct_config: "<< parameters.ct_config >>"
-        - helm-conftest:
-            chart: "<< parameters.chart >>"
+            - helm-conftest:
+                chart: "<< parameters.chart >>"
         - package-and-push:
             app_catalog: << parameters.app_catalog >>
             app_catalog_test: << parameters.app_catalog_test >>


### PR DESCRIPTION
This is not ideal, but is going to be the most developer-friendly for the short term.

When building `clusterpolicies`, we need to package `ClusterPolicy` CRs, which use a very specific notation used by kyverno. Helm [does not like this notation](https://app.circleci.com/pipelines/github/giantswarm/clusterpolicies/20/workflows/7e4381ab-0363-451e-8261-a513710e1dc2/jobs/29). Additionally, kustomize mangles the policies by rearranging keys and changing quotations, which are also meaningful to the kyverno policy parser.

The long-term fix to this might be
- ask kyverno to add schema and linting config for policies
- package and [deploy policies](https://github.com/giantswarm/cert-manager-app/blob/master/helm/cert-manager-app/templates/crd-install/crd-job.yaml) from [inside ConfigMaps](https://github.com/giantswarm/cert-manager-app/blob/master/helm/cert-manager-app/templates/crd-install/crd-configmap.yaml), like cert-manager (possibly generating with kustomize or Go)
- deploy policies with our own operator, as discussed in the [original kyverno spec considerations](https://github.com/giantswarm/giantswarm/pull/16324/)

https://github.com/giantswarm/giantswarm/issues/16458 has been opened to explore a nicer long-term solution.

But for now, to avoid forcing developers to write a policy, which then is copied into a ConfigMap, which then is deployed by a Job, it would be nice to override the linting.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
