### PR TITLE
Bump architect-orb to 2.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.5.0
+  architect: giantswarm/architect@2.5.0 #
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.4.2
+  architect: giantswarm/architect@2.5.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.5.0 #
+  architect: giantswarm/architect@2.5.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:


### PR DESCRIPTION
Bumping the orb version after the release, per instructions https://github.com/giantswarm/architect-orb/pull/256

