### PR TITLE
re-generate public ssh key after setting up catalog bot private key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.5.0
+  architect: giantswarm/architect@2.6.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Regenerate ssh public key in `push-to-app-catalog` and `push-to-app-collection` to match given private catalogbot ssh key.
+
 ## [2.6.0] - 2021-04-07
 
 ### Changed

--- a/src/commands/prepare-catalogbot-git-ssh.yaml
+++ b/src/commands/prepare-catalogbot-git-ssh.yaml
@@ -11,6 +11,7 @@ steps:
         mkdir -p ~/.ssh
         echo "${CATALOGBOT_SSH_KEY_PRIVATE_BASE64}" | base64 -d > ~/.ssh/id_rsa
         chmod 0600 ~/.ssh/id_rsa
+        ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
   - run:
       name: "architect/prepare-catalogbot-git-ssh: Configure git"
       command: |


### PR DESCRIPTION
This PR adds a command for setting up the catalogbot public ssh key from its private key

This is required because it seems circle CI changed something how they set up the read-only deploy ssh keys.

Here is what I think happens:
- CircleCI starts the container
- Uses the deploy key to clone the code, the public and private ssh key ends up in the ssh-agent
- We overwrite only the private key file. The public key file is the old one
- We try to push into the catalog repo, but the key from the agent is used

After this PR gets merged and released, `ssh-keygen` is used to refresh the public ssh key from the already overwritten private key.

I tested this for both `architect` and `app-build-suite` based builds of `push-to-app-catalog`.

Related Slack thread:

https://gigantic.slack.com/archives/C3C7ZQXC1/p1617811021034800

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
