### PR TITLE
Remove .status field from App CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `.status` field from App CR before pushing into app-collection.
+
 ## [2.7.0] - 2021-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - Remove `.status` field from App CR before pushing into app-collection.
 

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -62,7 +62,7 @@ steps:
           --user-secret-name "<<parameters.user_secret_name>>" \
           -o yaml | tee .app.yaml
   - run:
-      name: "archotect/push-to-app-collection: Remove status field from app CR"
+      name: "architect/push-to-app-collection: Remove status field from app CR"
       command: |
         yq d -i .app.yaml 'status'
   - run:

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -62,6 +62,10 @@ steps:
           --user-secret-name "<<parameters.user_secret_name>>" \
           -o yaml | tee .app.yaml
   - run:
+      name: "archotect/push-to-app-collection: Remove status field from app CR"
+      command: |
+        yq d -i .app.yaml 'status'
+  - run:
       name: "architect/push-to-app-collection: Clone app collection repo"
       command: |
         if git ls-remote --exit-code --heads git@github.com:giantswarm/<<parameters.app_collection_repo>>.git main ; then

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:3.4.1
+    image: quay.io/giantswarm/architect:3.5.0


### PR DESCRIPTION
With Argo CD syncing App CRs from collection, we need to drop status field completely otherwise Argo tries to sync it with empty values we have inside the Github repo

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
