### PR TITLE
Update Kubernetes to 1.21.1 and KIND to 0.11.0 in integration-test job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Kubernetes version in integration-test job to 1.21.1.
+- Update KinD version in integration-test job to 0.11.0.
+- Update Helm version in integration-test job to 3.5.4.
+
 ## [2.9.0] - 2021-05-18
 
 ### Added

--- a/src/commands/integration-test-install-tools.yaml
+++ b/src/commands/integration-test-install-tools.yaml
@@ -5,7 +5,7 @@ steps:
   - run:
       name: "architect/integration-test-install-tools: Install kind"
       command: |
-        curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.10.0/kind-$(uname)-amd64"
+        curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.11.0/kind-$(uname)-amd64"
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin
   - run:
@@ -23,7 +23,7 @@ steps:
   - run:
       name: "architect/integration-test-install-tools: Install Helm"
       command: |
-        curl -L https://get.helm.sh/helm-v3.5.3-linux-amd64.tar.gz >./helm.tar.gz
+        curl -L https://get.helm.sh/helm-v3.5.4-linux-amd64.tar.gz >./helm.tar.gz
         tar xzvf helm.tar.gz
         chmod u+x linux-amd64/helm
         sudo mv linux-amd64/helm /usr/local/bin/

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -26,7 +26,7 @@ parameters:
     description: "Path to kind config file."
     type: string
   kubernetes-version:
-    default: "v1.20.2"
+    default: "v1.21.1"
     description: "Kubernetes version for kind cluster."
     type: string
   setup-script:


### PR DESCRIPTION
## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
