### PR TITLE
Bump app build suite to v0.2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.10.0
+  architect: giantswarm/architect@3.0.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use version 0.2.3 of app-build-suite for `app-build-suite` executor.
+
 ## [3.0.0] - 2021-05-21
 
 ### Changed
 
 - :warning: Push Argo Application CRs instead of Giant Swarm App CRs to collections'
   /helm directory. This is a breaking change.
-  
+
 ### Removed
 
 - :warning: Remove all `user_configmap*` and `user_secret*` parameters from `push-to-app-collection` job. This is a breaking change.

--- a/docs/job/run-tests-with-abs.md
+++ b/docs/job/run-tests-with-abs.md
@@ -40,14 +40,14 @@ For git tags, the same container tag of app-build-suite will be used.
 **Attention:** For git commits or branches, `latest` will be used as container tag.
 This can be circumvented by also setting the parameter [`app-build-suite_container_tag`](#app-build-suite_container_tag).
 
-(Default: "v0.2.2")
+(Default: "v0.2.3")
 
 ### app-build-suite_container_tag
 
 Container tag of app-build-suite to use (check [quay.io/giantswarm/app-build-suite](https://quay.io/giantswarm/app-build-suite)).
 This parameter allows to specify the used container tag of app-build-suite.
 
-(Default: "0.2.2")
+(Default: "0.2.3")
 
 ### additional_app-build-suite_flags
 

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/app-build-suite:0.2.2-circleci
+    image: quay.io/giantswarm/app-build-suite:0.2.3-circleci

--- a/src/jobs/run-tests-with-abs.yaml
+++ b/src/jobs/run-tests-with-abs.yaml
@@ -5,11 +5,11 @@ parameters:
   app-build-suite_version:
     description: "Version of app-build-suite dabs.sh container wrapper to use (git tag or commit)"
     type: string
-    default: "v0.2.2"
+    default: "v0.2.3"
   app-build-suite_container_tag:
     description: "Container tag of app-build-suite to use (check quay.io/giantswarm/app-build-suite)"
     type: string
-    default: "0.2.2"
+    default: "0.2.3"
   additional_app-build-suite_flags:
     description: "Additional app-build-suite flags to use"
     type: string


### PR DESCRIPTION
Bump app-build-suite to [v0.2.3](https://github.com/giantswarm/app-build-suite/releases/tag/v0.2.3) ([Changelog](https://github.com/giantswarm/app-build-suite/blob/master/CHANGELOG.md#023---2021-05-24))

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
