### PR TITLE
Remove option to skip helm chart linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `skip_helm_chart_linting` option introduced in [#256](https://github.com/giantswarm/architect-orb/pull/256).
+
 ## [3.1.0] - 2021-05-26
 
 ### Changed

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -59,7 +59,6 @@ If there are values files in the `ci` folder of the chart, they will be used to 
 - [chart](#chart) name of the directory containing the chart in `helm/`
 - [on_tag](#on_tag-optional-boolean-defaulttrue) only push tagged commits to `app_catalog`
 - [explicit_allow_chart_name_mismatch](#explicit_allow_chart_name_mismatch-optional-boolean-defaultfalse)
-- [skip_helm_chart_linting](#skip_helm_chart_linting-optional-boolean-defaultfalse)
 
 ### attach_workspace
 
@@ -91,11 +90,6 @@ Should be used to allow chart name validation. Set to `true` to explicitly disab
 This can be the case if the chart directory is generated during CI runs or when multiple charts reside in a single repository.
 
 Does not have any effect if `executor: app-build-suite` is set.
-
-### skip_helm_chart_linting (optional boolean, default=false)
-
-If `skip_helm_chart_linting` is set to `true`, the helm chart will not be checked with `ct lint` or `conftest`.
-This flag is intended _only_ for apps which have non-standard resources to apply which can not be validated this way, such as the `ClusterPolicy` resources contained in [`clusterpolicies`](https://github.com/giantswarm/clusterpolicies).
 
 ## Example
 

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -19,12 +19,6 @@ parameters:
       If 'explicit_allow_chart_name_mismatch' is set to true, the name of the chart can be anything.
       Otherwise the name set in the 'chart' parameter must start with the repository name and optionally continue with '-app'.
       Does not have any effect for 'executor: app-build-suite'.
-  skip_helm_chart_linting:
-    type: boolean
-    default: false
-    description: |
-      If 'skip_helm_chart_linting' is set to true, the helm chart will not be checked for errors.
-      This flag is intended only for apps which have non-standard resources to apply which can't be validated with helm.
 steps:
   - when:
       condition: << parameters.on_tag >>

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -47,12 +47,6 @@ parameters:
         for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
-  skip_helm_chart_linting:
-    type: boolean
-    default: false
-    description: |
-      If 'skip_helm_chart_linting' is set to true, the helm chart will not be checked for errors.
-      This flag is intended only for apps which have non-standard resources to apply which can't be validated with helm.
 executor: "<< parameters.executor >>"
 resource_class: "<< parameters.resource_class >>"
 steps:
@@ -70,14 +64,11 @@ steps:
         - prepare-catalogbot-git-ssh
         - helm-chart-template:
             chart: << parameters.chart >>
-        - unless:
-            condition: << parameters.skip_helm_chart_linting >>
-            steps:
-            - helm-lint:
-                chart: "<< parameters.chart >>"
-                ct_config: "<< parameters.ct_config >>"
-            - helm-conftest:
-                chart: "<< parameters.chart >>"
+        - helm-lint:
+            chart: "<< parameters.chart >>"
+            ct_config: "<< parameters.ct_config >>"
+        - helm-conftest:
+            chart: "<< parameters.chart >>"
         - package-and-push:
             app_catalog: << parameters.app_catalog >>
             app_catalog_test: << parameters.app_catalog_test >>


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/17650

This option was added to support deploying kyverno policies with release-operator. This is no longer needed. AFAICT this was only ever used by kyverno-policies, and it has been removed https://github.com/giantswarm/kyverno-policies/pull/33

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [ ] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
