### PR TITLE
Update deprek8ion rules to check for deprecated manifests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@3.2.0
+  architect: giantswarm/architect@4.0.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update [deprek8ion](https://github.com/swade1987/deprek8ion) policies to include checking for deprecated manifests of kubernetes releases 1.16, 1.17, 1.18, 1.19 and 1.20
+
 ## [4.0.0] - 2021-07-12
 
 ### Changed

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -51,6 +51,9 @@ This is done using these [rego policies](https://github.com/swade1987/deprek8ion
 The policies are evaluated using the **rendered kubernetes manifests in the Helm chart**.
 If there are values files in the `ci` folder of the chart, they will be used to render the chart templates.
 
+In case you don't want to check for deprecated manifests, it is possible to skip `conftest` checking by setting parameter
+`skip_conftest` to `true`.
+
 ## Parameters
 
 - [common parameters](common.md#parameters) shared in all jobs.
@@ -59,6 +62,7 @@ If there are values files in the `ci` folder of the chart, they will be used to 
 - [chart](#chart) name of the directory containing the chart in `helm/`
 - [on_tag](#on_tag-optional-boolean-defaulttrue) only push tagged commits to `app_catalog`
 - [explicit_allow_chart_name_mismatch](#explicit_allow_chart_name_mismatch-optional-boolean-defaultfalse)
+- [skip_conftest_deprek8ion](#skip_conftest_deprek8ion-optional-boolean-defaultfalse)
 
 ### attach_workspace
 
@@ -90,6 +94,10 @@ Should be used to allow chart name validation. Set to `true` to explicitly disab
 This can be the case if the chart directory is generated during CI runs or when multiple charts reside in a single repository.
 
 Does not have any effect if `executor: app-build-suite` is set.
+
+### skip_conftest_deprek8ion (optional boolean, default=false)
+
+Disable checking manifests against deprecated apiVersions using [deprek8ion](https://github.com/swade1987/deprek8ion) rules.
 
 ## Example
 

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -52,7 +52,7 @@ The policies are evaluated using the **rendered kubernetes manifests in the Helm
 If there are values files in the `ci` folder of the chart, they will be used to render the chart templates.
 
 In case you don't want to check for deprecated manifests, it is possible to skip `conftest` checking by setting parameter
-`skip_conftest` to `true`.
+[`skip_conftest_deprek8ion`](#skip_conftest_deprek8ion-optional-boolean-defaultfalse) to `true`.
 
 ## Parameters
 

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -7,8 +7,13 @@ steps:
   - run:
       name: Test conftest policies
       command: |
+        sha=4885005d95418aa13a578fe9de232808d1b3adcd
+        policies=$(echo https://raw.githubusercontent.com/swade1987/deprek8ion/${sha}/policies/kubernetes-{1.16,1.17,1.18,1.19,1.20}.rego | tr ' ' ',')
+        policies="${policies},https://raw.githubusercontent.com/swade1987/deprek8ion/${sha}/policies/_cert-manager.rego"
+        policies="${policies},https://raw.githubusercontent.com/swade1987/deprek8ion/${sha}/policies/_service-account.rego"
+
         if [ -d "helm/<<parameters.chart>>/ci" ]; then
-          for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17}-deprek8ion.rego | tr ' ' ',') - ; done
+          for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update "${policies}" - ; done
         else
-          helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17}-deprek8ion.rego | tr ' ' ',') -
+          helm template helm/<<parameters.chart>> | conftest test --update "${policies}" -
         fi

--- a/src/commands/package-and-push-with-abs.yaml
+++ b/src/commands/package-and-push-with-abs.yaml
@@ -12,6 +12,11 @@ parameters:
       When this is `false`, commits to `master` will be pushed to `app_catalog` instead of `app_catalog_test`.
       Set this to `false` for deployments that follow a a master branch for production releases rather than
       using tags (the default).
+  skip_conftest_deprek8ion:
+    type: boolean
+    default: false
+    description: |
+      When this is `false`, checking for deprecated manifest versions will be skipped.
 steps:
   - when:
       condition: << parameters.on_tag >>
@@ -36,14 +41,11 @@ steps:
       name: Execute App Build Suite
       command: |
         mkdir build && python -m app_build_suite --skip-steps test_all --chart-dir ./helm/<< parameters.chart >> --destination build --generate-metadata --catalog-base-url "https://giantswarm.github.io/$(cat .app_catalog_name)/" --keep-chart-changes
-  - run:
-      name: Test conftest policies
-      command: |
-        if [ -d "helm/<<parameters.chart>>/ci" ]; then
-          for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17}-deprek8ion.rego | tr ' ' ',') - ; done
-        else
-          helm template helm/<<parameters.chart>> | conftest test --update $(echo https://raw.githubusercontent.com/swade1987/deprek8ion/6b1c53db2d48c9361c61d73dab3594f01324f68a/policies/{1.16,1.17}-deprek8ion.rego | tr ' ' ',') -
-        fi
+  - unless:
+      condition: << parameters.skip_conftest_deprek8ion >>
+      steps:
+      - helm-conftest:
+          chart: "<< parameters.chart >>"
   - run:
       name: Clone app catalog repo
       command: |

--- a/src/commands/package-and-push-with-abs.yaml
+++ b/src/commands/package-and-push-with-abs.yaml
@@ -16,7 +16,7 @@ parameters:
     type: boolean
     default: false
     description: |
-      When this is `false`, checking for deprecated manifest versions will be skipped.
+      When this is `true`, checking for deprecated manifest versions will be skipped.
 steps:
   - when:
       condition: << parameters.on_tag >>

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -51,7 +51,7 @@ parameters:
     type: boolean
     default: false
     description: |
-      When this is `false`, checking for deprecated manifest versions will be skipped.
+      When this is `true`, checking for deprecated manifest versions will be skipped.
 executor: "<< parameters.executor >>"
 resource_class: "<< parameters.resource_class >>"
 steps:

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -47,6 +47,11 @@ parameters:
         for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
+  skip_conftest_deprek8ion:
+    type: boolean
+    default: false
+    description: |
+      When this is `false`, checking for deprecated manifest versions will be skipped.
 executor: "<< parameters.executor >>"
 resource_class: "<< parameters.resource_class >>"
 steps:
@@ -67,8 +72,11 @@ steps:
         - helm-lint:
             chart: "<< parameters.chart >>"
             ct_config: "<< parameters.ct_config >>"
-        - helm-conftest:
-            chart: "<< parameters.chart >>"
+        - unless:
+            condition: << parameters.skip_conftest_deprek8ion >>
+            steps:
+            - helm-conftest:
+                chart: "<< parameters.chart >>"
         - package-and-push:
             app_catalog: << parameters.app_catalog >>
             app_catalog_test: << parameters.app_catalog_test >>
@@ -89,3 +97,4 @@ steps:
             app_catalog_test: << parameters.app_catalog_test >>
             chart: << parameters.chart >>
             on_tag: << parameters.on_tag >>
+            skip_conftest_deprek8ion: << parameters.skip_conftest_deprek8ion >>


### PR DESCRIPTION
This PR updates the deprek8ion rules used in the `conftest` step executed by `push-to-app-catalog` job.

This will fail for outdated manifests deprecated in kubernetes 1.16 to 1.20

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
- [x] :warning: After the release update architect orb version in [.circleci/config.yml](https://github.com/giantswarm/architect-orb/tree/master/.circleci/config.yml).
