### PR TITLE
Bump architect (and go)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.0.0
+  architect: giantswarm/architect@4.2.0
   orb-tools: circleci/orb-tools@8.27.6
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update `architect` version to [`v5.2.0`](https://github.com/giantswarm/architect/releases/tag/v5.2.0).
+  - Updates Go version to 1.17.1
+- Update Go version used in `machine-install` command to 1.17.1.
+
 ## [4.2.0] - 2021-08-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `architect` version to [`v5.2.0`](https://github.com/giantswarm/architect/releases/tag/v5.2.0).
   - Updates Go version to 1.17.1
+  - Updated `golangci-lint` to v1.42.1
 - Update Go version used in `machine-install` command to 1.17.1.
 
 ## [4.2.0] - 2021-08-25

--- a/src/commands/machine-install-go.yaml
+++ b/src/commands/machine-install-go.yaml
@@ -1,3 +1,10 @@
+parameters:
+  go_version:
+    type: "string"
+    default: "1.17.1"
+  archive_sha:
+    type: "string"
+    default: "dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef"
 steps:
   - run:
       name: "architect/machine-install-go: Remove old Go"
@@ -6,15 +13,15 @@ steps:
   - run:
       name: "architect/machine-install-go: Download Go"
       command: |
-        wget https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz
+        wget https://dl.google.com/go/go<< parameters.go_version >>.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Check downloaded Go checksum"
       command: |
-        [[ "$(sha256sum go1.16.2.linux-amd64.tar.gz | cut -d ' ' -f 1)" == "542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8" ]]
+        [[ "$(sha256sum go<< parameters.go_version >>.linux-amd64.tar.gz | cut -d ' ' -f 1)" == "<< parameters.archive_sha >>" ]]
   - run:
       name: "architect/machine-install-go: Install Go"
       command: |
-        sudo tar -C /usr/local -xzf go1.16.2.linux-amd64.tar.gz
+        sudo tar -C /usr/local -xzf go<< parameters.go_version >>.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Set Go environment"
       command: |
@@ -22,7 +29,7 @@ steps:
   - run:
       name: "architect/machine-install-go: Remove downloaded Go files"
       command: |
-        rm go1.16.2.linux-amd64.tar.gz
+        rm go<< parameters.go_version >>.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Check Go version"
       command: |

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:5.1.0-d39b9f51819e3d4b9faa2dbb2d94475ff3c8ea1a
+    image: quay.io/giantswarm/architect:5.2.0

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:5.1.0-b3479e2a432131d3c0e96ec25e9744af35dc2abd
+    image: quay.io/giantswarm/architect:5.1.0-d39b9f51819e3d4b9faa2dbb2d94475ff3c8ea1a

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:5.1.0
+    image: quay.io/giantswarm/architect:5.1.0-38fa449180407b6764041ba12db758ed145f1c65

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:5.1.0-38fa449180407b6764041ba12db758ed145f1c65
+    image: quay.io/giantswarm/architect:5.1.0-b3479e2a432131d3c0e96ec25e9744af35dc2abd


### PR DESCRIPTION
This PR updates the used architect version to 5.2.0 to make use of Go 1.17.1 in CI builds.

I'll merge this on monday. Afterwards I'll update the github automation.

## Checklist

- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
