### PR TITLE
add `kubeval` validation to `push-to-app-catalog` job.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `helm diff upgrade` validation step for duplicate chart resources in `push-to-app-catalog` job.
+
 ## [4.4.0] - 2021-09-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `helm diff upgrade` validation step for duplicate chart resources in `push-to-app-catalog` job.
+- Add `kubeval` validation step for duplicate chart resources in `push-to-app-catalog` job.
 
 ## [4.4.0] - 2021-09-24
 

--- a/src/commands/helm-diff.yaml
+++ b/src/commands/helm-diff.yaml
@@ -1,0 +1,16 @@
+---
+parameters:
+  chart:
+    type: "string"
+description: Test helm diff upgrade
+steps:
+  - run:
+      name: helm-diff-upgrade
+      command: |
+        if [ -d "helm/<<parameters.chart>>/ci" ]; then
+          for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do
+            helm diff upgrade --debug --dry-run --detailed-exitcode --no-color test helm/<<parameters.chart>> --values $t
+          done
+        else
+          helm diff upgrade --debug --dry-run --detailed-exitcode --no-color test helm/<<parameters.chart>>
+        fi

--- a/src/commands/kubeval.yaml
+++ b/src/commands/kubeval.yaml
@@ -8,13 +8,6 @@ steps:
       name: kubeval
       command: |
         if [ -d "helm/<<parameters.chart>>/ci" ]; then
-          for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do
-            helm diff upgrade --debug --dry-run --detailed-exitcode --no-color test helm/<<parameters.chart>> --values $t
-          done
-        else
-          helm diff upgrade --debug --dry-run --detailed-exitcode --no-color test helm/<<parameters.chart>>
-        fi
-        if [ -d "helm/<<parameters.chart>>/ci" ]; then
           for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | kubeval --ignore-missing-schemas - ; done
         else
           helm template helm/<<parameters.chart>> | kubeval --ignore-missing-schemas -

--- a/src/commands/kubeval.yaml
+++ b/src/commands/kubeval.yaml
@@ -2,10 +2,10 @@
 parameters:
   chart:
     type: "string"
-description: Test helm diff upgrade
+description: Validate Kubernetes resources.
 steps:
   - run:
-      name: helm-diff-upgrade
+      name: kubeval
       command: |
         if [ -d "helm/<<parameters.chart>>/ci" ]; then
           for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do
@@ -13,4 +13,9 @@ steps:
           done
         else
           helm diff upgrade --debug --dry-run --detailed-exitcode --no-color test helm/<<parameters.chart>>
+        fi
+        if [ -d "helm/<<parameters.chart>>/ci" ]; then
+          for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | kubeval --ignore-missing-schemas - ; done
+        else
+          helm template helm/<<parameters.chart>> | kubeval --ignore-missing-schemas -
         fi

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:5.2.0-776828b12fd25618f418c3d73a427b9932eb45ed
+    image: quay.io/giantswarm/architect:5.3.0

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:5.2.0
+    image: quay.io/giantswarm/architect:5.2.0-50d892dc8a060b641cb60508c252f262b1614fd7

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:5.2.0-50d892dc8a060b641cb60508c252f262b1614fd7
+    image: quay.io/giantswarm/architect:5.2.0-776828b12fd25618f418c3d73a427b9932eb45ed

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -78,7 +78,7 @@ steps:
         - helm-lint:
             chart: "<< parameters.chart >>"
             ct_config: "<< parameters.ct_config >>"
-        - helm-diff:
+        - kubeval:
             chart: << parameters.chart >>
         - unless:
             condition: << parameters.skip_conftest_deprek8ion >>

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -78,6 +78,8 @@ steps:
         - helm-lint:
             chart: "<< parameters.chart >>"
             ct_config: "<< parameters.ct_config >>"
+        - helm-diff:
+            chart: << parameters.chart >>
         - unless:
             condition: << parameters.skip_conftest_deprek8ion >>
             steps:


### PR DESCRIPTION
Towards: giantswarm/giantswarm#18975

The goal here is to ensure we do not have conflicting/overlapping files in the helm chart which would overwrite at deploy time, see https://github.com/giantswarm/giantswarm/issues/18975#issuecomment-928042528.