### PR TITLE
Make additional ldflags configurable in go jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `go-gen-ldflags` command to generate ldflags. This has been extracted from the `go-test` command.
+
 ### Changed
 
 - Change download URL of `dats.sh` wrapper to use raw.githubusercontent.com to be able to run pre-release versions of app-test-suite in `run-tests-with-ats` job.
+
+### Removed
+
+- Remove unused `pkg` parameter in `go-build` command.
 
 ## [4.6.0] - 2021-10-04
 

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -3,10 +3,8 @@ parameters:
     type: "string"
   os:
     type: "string"
-  pkg:
-    default: "github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pkg/project"
-    type: "string"
 steps:
+  - go-gen-ldflags
   - go-test
   - run: |
       CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -o << parameters.binary >> .

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -4,7 +4,6 @@ parameters:
   os:
     type: "string"
 steps:
-  - go-gen-ldflags
   - go-test
   - run: |
       CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -o << parameters.binary >> .

--- a/src/commands/go-gen-ldflags.yaml
+++ b/src/commands/go-gen-ldflags.yaml
@@ -1,0 +1,9 @@
+steps:
+  - run: |
+      echo -n "-w -linkmode 'auto' -extldflags '-static'" > .ldflags
+  - run: |
+      echo -n " -X '$(go list .)/pkg/project.buildTimestamp=$(date --utc '+%FT%TZ')'" >> .ldflags
+  - run: |
+      echo -n " -X '$(go list .)/pkg/project.gitSHA=${CIRCLE_SHA1}'" >> .ldflags
+  - run: |
+      echo "\"$(cat .ldflags)\""

--- a/src/commands/go-gen-ldflags.yaml
+++ b/src/commands/go-gen-ldflags.yaml
@@ -18,6 +18,6 @@ steps:
         - run:
             name: "Include additional ldflags '<< parameters.additional_ldflags >>' in final ldflags"
             command: |
-                echo -n " parameters.additional_ldflags >>" >> .ldflags
+                echo -n " << parameters.additional_ldflags >>" >> .ldflags
   - run: |
       echo "\"$(cat .ldflags)\""

--- a/src/commands/go-gen-ldflags.yaml
+++ b/src/commands/go-gen-ldflags.yaml
@@ -1,3 +1,10 @@
+parameters:
+  additional_ldflags:
+    default: ""
+    type: "string"
+    description: |
+      Allows to specify additional ldflags to be included
+      in go-test and go-build.
 steps:
   - run: |
       echo -n "-w -linkmode 'auto' -extldflags '-static'" > .ldflags
@@ -5,5 +12,12 @@ steps:
       echo -n " -X '$(go list .)/pkg/project.buildTimestamp=$(date --utc '+%FT%TZ')'" >> .ldflags
   - run: |
       echo -n " -X '$(go list .)/pkg/project.gitSHA=${CIRCLE_SHA1}'" >> .ldflags
+  - when:
+      condition: << parameters.additional_ldflags >>
+      steps:
+        - run:
+            name: "Include additional ldflags '<< parameters.additional_ldflags >>' in final ldflags"
+            command: |
+                echo -n " parameters.additional_ldflags >>" >> .ldflags
   - run: |
       echo "\"$(cat .ldflags)\""

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -1,14 +1,8 @@
 steps:
-  - run: |
+  - go-gen-ldflags
+  - name: Check if go.mod & go.sum are up to date
+    run: |
       go mod tidy && git diff --exit-code
-  - run: |
-      echo -n "-w -linkmode 'auto' -extldflags '-static'" > .ldflags
-  - run: |
-      echo -n " -X '$(go list .)/pkg/project.buildTimestamp=$(date --utc '+%FT%TZ')'" >> .ldflags
-  - run: |
-      echo -n " -X '$(go list .)/pkg/project.gitSHA=${CIRCLE_SHA1}'" >> .ldflags
-  - run: |
-      echo "\"$(cat .ldflags)\""
   - run:
       name: Check if imports are properly sorted
       command: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -1,8 +1,9 @@
 steps:
   - go-gen-ldflags
-  - name: Check if go.mod & go.sum are up to date
-    run: |
-      go mod tidy && git diff --exit-code
+  - run:
+      name: Check if go.mod & go.sum are up to date
+      command: |
+        go mod tidy && git diff --exit-code
   - run:
       name: Check if imports are properly sorted
       command: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -1,5 +1,4 @@
 steps:
-  - go-gen-ldflags
   - run:
       name: Check if go.mod & go.sum are up to date
       command: |

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -23,12 +23,20 @@ parameters:
         for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
+  additional_ldflags:
+    default: ""
+    type: "string"
+    description: |
+      Allows to specify additional ldflags to be included
+      in go-test and go-build.
 executor: "architect"
 resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - tools-info
   - go-cache-restore
+  - go-gen-ldflags:
+      additional_ldflags: << parameters.additional_ldflags >>
   - go-build:
       binary: << parameters.binary >>
       os: << parameters.os >>

--- a/src/jobs/go-test.yaml
+++ b/src/jobs/go-test.yaml
@@ -16,11 +16,19 @@ parameters:
         for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
+  additional_ldflags:
+    default: ""
+    type: "string"
+    description: |
+      Allows to specify additional ldflags to be included
+      in go-test and go-build.
 executor: "architect"
 resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - tools-info
   - go-cache-restore
+  - go-gen-ldflags:
+      additional_ldflags: << parameters.additional_ldflags >>
   - go-test
   - go-cache-save


### PR DESCRIPTION
This PR attempts to make golang `-ldflags` configurable to allow to include timezone data

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [ ] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
