### PR TITLE
Add tags parameter to go-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `tags` parameter to `go-build` job to allow specifying `-tags` flag when running `go build`.
+
 ### Changed
 
 - Change download URL of `dats.sh` wrapper to use raw.githubusercontent.com to be able to run pre-release versions of app-test-suite in `run-tests-with-ats` job.
+
+### Removed
+
+- Remove unused `pkg` parameter in `go-build` command.
 
 ## [4.6.0] - 2021-10-04
 

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -3,12 +3,12 @@ parameters:
     type: "string"
   os:
     type: "string"
-  pkg:
-    default: "github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pkg/project"
+  tags:
+    default: ""
     type: "string"
 steps:
   - go-test
   - run: |
-      CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -o << parameters.binary >> .
+      CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -tags "<< parameters.tags >>" -o << parameters.binary >> .
   - run: |
       [[ "<< parameters.os >>" == "linux" ]] && ./<< parameters.binary >> version || true

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -23,6 +23,11 @@ parameters:
         for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
+  tags:
+    default: ""
+    description: |
+      Additional tags to include in -tags flag of go build.
+    type: string
 executor: "architect"
 resource_class: "<< parameters.resource_class >>"
 steps:
@@ -32,6 +37,7 @@ steps:
   - go-build:
       binary: << parameters.binary >>
       os: << parameters.os >>
+      tags: << parameters.tags >>
   - go-cache-save
   - persist_to_workspace:
       root: .


### PR DESCRIPTION
This PR adds support for specifying custom tags for the `tags` flag of `go build`.

## Checklist

- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
