### PR TITLE
Always install apptestctl binary in integration-test job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `integration-test` job to always install `apptestctl` binary.
+- Add `helm-version` parameter to `integration-test` job.
+
 ## [4.8.1] - 2021-11-17
 
 - Update `app-test-suite` to [0.2.2](https://github.com/giantswarm/app-test-suite/blob/master/CHANGELOG.md#022---2021-11-17). Includes 2 important bugfixes for working with ginatswarm catalog.

--- a/docs/job/integration-test.md
+++ b/docs/job/integration-test.md
@@ -26,7 +26,7 @@ workflows:
 
 - [common parameters](common.md#parameters) shared in all jobs.
 - [test-dir](#attach_workspace) (required string)
-- [apptestctl-version](#apptestctl-version) (optional string, default="v0.13.0")
+- [apptestctl-version](#apptestctl-version) (optional string, default="v0.13.1")
 - [env-file](#env-file) (optional string, default="")
 - [helm-version](#helm-version) (optional string, default="v3.6.3")
 - [install-app-platform](#install-app-platform) (optional boolean, default=false)

--- a/docs/job/integration-test.md
+++ b/docs/job/integration-test.md
@@ -26,11 +26,12 @@ workflows:
 
 - [common parameters](common.md#parameters) shared in all jobs.
 - [test-dir](#attach_workspace) (required string)
-- [apptestctl-version](#apptestctl-version) (optional string, default="v0.4.1")
+- [apptestctl-version](#apptestctl-version) (optional string, default="v0.13.0")
 - [env-file](#env-file) (optional string, default="")
+- [helm-version](#helm-version) (optional string, default="v3.6.3")
 - [install-app-platform](#install-app-platform) (optional boolean, default=false)
 - [kind-config](#kind-config) (optional string, default="")
-- [kubernetes-version](#kubernetes-version) (optional string, default="v1.17.11")
+- [kubernetes-version](#kubernetes-version) (optional string, default="v1.21.1")
 - [setup-script](#setup-script) (optional string, default="")
 - [test-dir](#test-dir) (required string)
 - [test-timeout](#test-timeout) (optional string, default="20m")

--- a/src/commands/integration-test-install-app-platform.yaml
+++ b/src/commands/integration-test-install-app-platform.yaml
@@ -1,19 +1,10 @@
 parameters:
-  apptestctl-version:
-    type: string
   install-app-platform:
     type: boolean
 steps:
   - when:
       condition: << parameters.install-app-platform >>
       steps:
-        - run:
-            name: "architect/integration-test-install-app-platform: Install apptestctl"
-            command: |
-              curl -L https://github.com/giantswarm/apptestctl/releases/download/<< parameters.apptestctl-version >>/apptestctl-<< parameters.apptestctl-version >>-linux-amd64.tar.gz > ./apptestctl.tar.gz
-              tar xzvf apptestctl.tar.gz
-              chmod u+x apptestctl-<< parameters.apptestctl-version >>-linux-amd64/apptestctl
-              sudo mv apptestctl-<< parameters.apptestctl-version >>-linux-amd64/apptestctl /usr/local/bin
         - run:
             name: "architect/integration-test-install-app-platform: Run apptestctl bootstrap"
             command: |

--- a/src/commands/integration-test-install-tools.yaml
+++ b/src/commands/integration-test-install-tools.yaml
@@ -1,4 +1,8 @@
 parameters:
+  apptestctl-version:
+    type: string
+  helm-version:
+    type: string
   kubernetes-version:
     type: string
 steps:
@@ -23,7 +27,14 @@ steps:
   - run:
       name: "architect/integration-test-install-tools: Install Helm"
       command: |
-        curl -L https://get.helm.sh/helm-v3.5.4-linux-amd64.tar.gz >./helm.tar.gz
+        curl -L https://get.helm.sh/helm-<< parameters.helm-version >>-linux-amd64.tar.gz >./helm.tar.gz
         tar xzvf helm.tar.gz
         chmod u+x linux-amd64/helm
         sudo mv linux-amd64/helm /usr/local/bin/
+  - run:
+      name: "architect/integration-test-install-tools: Install apptestctl"
+      command: |
+        curl -L https://github.com/giantswarm/apptestctl/releases/download/<< parameters.apptestctl-version >>/apptestctl-<< parameters.apptestctl-version >>-linux-amd64.tar.gz > ./apptestctl.tar.gz
+        tar xzvf apptestctl.tar.gz
+        chmod u+x apptestctl-<< parameters.apptestctl-version >>-linux-amd64/apptestctl
+        sudo mv apptestctl-<< parameters.apptestctl-version >>-linux-amd64/apptestctl /usr/local/bin

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -8,7 +8,7 @@ description: |
   See [docs](docs/integration_test.md) for more details.
 parameters:
   apptestctl-version:
-    default: "v0.13.0"
+    default: "v0.13.1"
     description: "apptestctl version for bootstrapping app platform."
     type: string
   env-file:

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -8,12 +8,16 @@ description: |
   See [docs](docs/integration_test.md) for more details.
 parameters:
   apptestctl-version:
-    default: "v0.9.0"
+    default: "v0.13.0"
     description: "apptestctl version for bootstrapping app platform."
     type: string
   env-file:
     default: ""
     description: "File of environment variables to set."
+    type: string
+  helm-version:
+    default: "v3.6.3"
+    description: "Helm version to install."
     type: string
   install-app-platform:
     type: boolean
@@ -58,12 +62,13 @@ steps:
       at: .
   - machine-install-go
   - integration-test-install-tools:
+      apptestctl-version:  << parameters.apptestctl-version >>
+      helm-version:  << parameters.helm-version >>
       kubernetes-version:  << parameters.kubernetes-version >>
   - integration-test-create-cluster:
       kind-config: << parameters.kind-config >>
       kubernetes-version:  << parameters.kubernetes-version >>
   - integration-test-install-app-platform:
-      apptestctl-version:  << parameters.apptestctl-version >>
       install-app-platform:  << parameters.install-app-platform >>
   - integration-test-setup:
       setup-script: << parameters.setup-script >>


### PR DESCRIPTION
Needed so we can use apptestctl to install CRDs in app-operator and chart-operator tests.
Otherwise we hit GitHub rate limits.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
