### PR TITLE
Update architect and Go to use Golang 1.17.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Default to use `DOCKER_BUILDKIT=1` environment variable in `push-to-docker` job.
+- Update `architect` version to [`v6.2.0`](https://github.com/giantswarm/architect/releases/tag/v6.2.0).
+  - Updates Go version to 1.17.7
+- Update Go version used in `machine-install` command to 1.17.7.
 
 ## [4.11.0] - 2022-02-09
 

--- a/src/commands/machine-install-go.yaml
+++ b/src/commands/machine-install-go.yaml
@@ -1,10 +1,10 @@
 parameters:
   go_version:
     type: "string"
-    default: "1.17.1"
+    default: "1.17.7"
   archive_sha:
     type: "string"
-    default: "dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef"
+    default: "02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259"
 steps:
   - run:
       name: "architect/machine-install-go: Remove old Go"
@@ -13,7 +13,7 @@ steps:
   - run:
       name: "architect/machine-install-go: Download Go"
       command: |
-        wget https://dl.google.com/go/go<< parameters.go_version >>.linux-amd64.tar.gz
+        wget https://go.dev/dl/go<< parameters.go_version >>.linux-amd64.tar.gz
   - run:
       name: "architect/machine-install-go: Check downloaded Go checksum"
       command: |

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:6.1.1
+    image: quay.io/giantswarm/architect:6.2.0


### PR DESCRIPTION
This PR updates dependencies to use Go 1.17.7

## Checklist

- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
