### PR TITLE
Update go 1.17.8 and architect 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `architect` version to [`v6.3.0`](https://github.com/giantswarm/architect/releases/tag/v6.3.0).
+  - Updates Go version to 1.17.8.
+- Update Go version used in `machine install` command to 1.17.8. 
+
 ## [4.13.0] - 2022-02-18
 
 ### Changed

--- a/src/commands/machine-install-go.yaml
+++ b/src/commands/machine-install-go.yaml
@@ -1,10 +1,10 @@
 parameters:
   go_version:
     type: "string"
-    default: "1.17.7"
+    default: "1.17.8"
   archive_sha:
     type: "string"
-    default: "02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259"
+    default: "d45bdb73eb0e1c4629e3e42082f2541cb0b997ca2ad9c60b86b33e8a71340681"
 steps:
   - run:
       name: "architect/machine-install-go: Remove old Go"

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:6.2.0
+    image: quay.io/giantswarm/architect:6.3.0


### PR DESCRIPTION
his PR updates dependencies to use Go 1.17.8

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [ ] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
