### PR TITLE
Remove specific branch checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check out app catalog at default `HEAD` instead of specifying `master` branch for compatibility with `main` branch.
+
 ## [4.14.1] - 2022-03-07
 
 ### Added

--- a/src/commands/package-and-push-with-abs.yaml
+++ b/src/commands/package-and-push-with-abs.yaml
@@ -62,7 +62,7 @@ steps:
   - run:
       name: Clone app catalog repo
       command: |
-        git clone -q --depth=1 --single-branch -b master "git@github.com:giantswarm/$(cat .app_catalog_name).git" .app_catalog
+        git clone -q --depth=1 --single-branch "git@github.com:giantswarm/$(cat .app_catalog_name).git" .app_catalog
   - run:
       name: Push chart archive to app catalog repo
       command: |

--- a/src/commands/package-and-push.yaml
+++ b/src/commands/package-and-push.yaml
@@ -51,7 +51,7 @@ steps:
   - run:
       name: Clone app catalog repo
       command: |
-        git clone -q --depth=1 --single-branch -b master "git@github.com:giantswarm/$(cat .app_catalog_name).git" .app_catalog
+        git clone -q --depth=1 --single-branch "git@github.com:giantswarm/$(cat .app_catalog_name).git" .app_catalog
   - run:
       name: Package the chart archive
       command: |


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21059

Fixes problem discovered in https://github.com/giantswarm/default-apps-openstack/pull/30 - https://app.circleci.com/pipelines/github/giantswarm/default-apps-openstack/158/workflows/adc5b3c2-0a23-4712-b19b-26b02548715a/jobs/158. `cluster-catalog` uses `main` as the default branch instead of `master`. I don't see any reason to specify `-b` as git will automatically check out the default branch. Tested locally.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
