### PR TITLE
Set 'docker build' flag for plain progress logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Let `docker build` command produce plain progress output
+
 ## [4.14.2] - 2022-03-08
 
 ### Fixed

--- a/src/commands/push-to-docker.yaml
+++ b/src/commands/push-to-docker.yaml
@@ -28,7 +28,7 @@ steps:
   - run:
       name: Build the container image using 'docker build'
       command: |
-        docker build -f "<<parameters.dockerfile>>" -t "$(cat .docker_image_name)" "<<parameters.build-context>>"
+        docker build -f "<<parameters.dockerfile>>" -t "$(cat .docker_image_name)" "<<parameters.build-context>>" --progress plain
   - run:
       name: Push the container image using 'docker push'
       command: |


### PR DESCRIPTION
Currently the `docker build` output (introduced some versions ago) does not work well for CI, as it's meant for interactive TTYs. This PR switches on the plain progress logging.