### PR TITLE
add a second .nancy-ignore.local file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a second `.nancy-ignore.local` file.
+
 ## [4.19.0] - 2022-05-24
 
 ### Changed

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -20,6 +20,6 @@ steps:
   - run: |
       CGO_ENABLED=0 golangci-lint run -E gosec -E goconst
   - run: |
-      CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet
+      CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --exclude-vulnerability-file ./.nancy-ignore.local
   - run: |
       CGO_ENABLED=0 go test -ldflags "$(cat .ldflags)" ./...


### PR DESCRIPTION
This PR allow to use a second `.nancy-ignore.local` file to be able to ignore some CVEs without to go through the `github` repository sync.

Syncing `.nancy-ignore` accross repositories with `github` is good for global CVEs, but we also need a mechanism with an easy  per repo ignore solution. cc/ @hervenicol 

The file given in `--exclude-vulnerability-file` is not required to exist, it just skip if not found. This works : 

```
$ CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --exclude-vulnerability-file ./.non-existent-file
```