### PR TITLE
revert non-working .nancy-ignore.local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `.nancy-ignore.local` file.
+
 ## [4.20.0] - 2022-05-27
 
 ### Added

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -20,6 +20,6 @@ steps:
   - run: |
       CGO_ENABLED=0 golangci-lint run -E gosec -E goconst
   - run: |
-      CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --exclude-vulnerability-file ./.nancy-ignore.local
+      CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore
   - run: |
       CGO_ENABLED=0 go test -ldflags "$(cat .ldflags)" ./...


### PR DESCRIPTION
Revert `.nancy-ignore.local` file, which does not work in combination with the current `.nancy-ignore` file, as `nancy` only accept one `--exclude-vulnerability-file` and take the latest.