### PR TITLE
Update kubeval.yaml

### DIFF
--- a/src/commands/kubeval.yaml
+++ b/src/commands/kubeval.yaml
@@ -8,7 +8,7 @@ steps:
       name: kubeval
       environment:
         KUBEVAL_SCHEMA_LOCATION: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/411622f5e91bc54d3eff7b700661ba03f23f7729
-        KUBERNETES_VERSIONS: 1.16.0 1.17.0 1.18.0 1.19.0 1.20.0 1.21.0 1.22.0
+        KUBERNETES_VERSIONS: 1.20.0 1.21.0 1.22.0
       command: |
         for v in $KUBERNETES_VERSIONS; do
           echo "Validating against kubernetes version $v"


### PR DESCRIPTION
The oldest active k8s release we have around is kvm 15.1.0 using k8s 1.20: https://github.com/giantswarm/releases/blob/master/kvm/v15.1.0/release.yaml#L47

It does not make sense to test all helm charts with previous k8s versions IMHO.

WDYT?


## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
