### PR TITLE
Update golang to v1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `architect` version to [`v6.7.0`](https://github.com/giantswarm/architect/releases/tag/v6.7.0).
+- Update Go version used in `machine-install` command to 1.19.1.
+
 ## [4.24.0] - 2022-07-12
 
 ### Changed

--- a/src/commands/machine-install-go.yaml
+++ b/src/commands/machine-install-go.yaml
@@ -1,10 +1,10 @@
 parameters:
   go_version:
     type: "string"
-    default: "1.18.1"
+    default: "1.19.1"
   archive_sha:
     type: "string"
-    default: "b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334"
+    default: "acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde"
 steps:
   - run:
       name: "architect/machine-install-go: Remove old Go"

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:6.6.0
+    image: quay.io/giantswarm/architect:6.7.0


### PR DESCRIPTION
- Update `architect` version to [`v6.7.0`](https://github.com/giantswarm/architect/releases/tag/v6.7.0).
- Update Go version used in `machine-install` command to 1.19.1.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
