### PR TITLE
Ignore nancy failure if OSS index is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't fail `go test` if the `nancy` back end is down.
+
 ## [4.25.1] - 2022-10-20
 
 ### Added
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.24.0] - 2022-07-12
 
 ### Changed
+
 - Update `architect` version to [`v6.6.0`](https://github.com/giantswarm/architect/releases/tag/v6.6.0).
   - Update `nancy` to `v1.0.37`.
 - Use an additional nancy exclude vulnerabilities file at the root of the repositories: `.nancy-ignore.generated`. If the file does not exist, nancy will ignore it. The standard `.nancy-ignore` file should contain the repository specific excludes and `.nancy-ignore.generated` is a generated one that should contain globally ignored vulnerabilities, if any.

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -38,15 +38,17 @@ steps:
   - run:
       name: Check if dependencies have known security vulnerabilities
       command: |
-        CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated | sed '/error accessing OSS Index/,$b;$q1'
-        pstats=(${PIPESTATUS[@]})
+        # CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated | sed '/error accessing OSS Index/,$b;$q1'
+        # pstats=(${PIPESTATUS[@]})
         # Credit for the sed idea to https://unix.stackexchange.com/a/711864.
-        # If nancy gave us a bad exit code AND sed found an OSS index error in the output, then we don't fail the build.
-        if [[ ${pstats[1]} -eq 1 && ${pstats[2]} -eq 0 ]]; then
+        CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
+        grep -q 'error accessing OSS Index' nancy-results.txt; grep_result=$?
+        # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.
+        if [[ $nancy_result -eq 1 && $grep_result -eq 0 ]]; then
           echo Ignoring failed scan due to problem with the external scanner.
           exit 0
         fi
-        exit ${pstats[1]}
+        exit $nancy_result
   - run:
       name: Run unit tests
       command: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -38,7 +38,15 @@ steps:
   - run:
       name: Check if dependencies have known security vulnerabilities
       command: |
-        CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
+        CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated | sed '/error accessing OSS Index/,$b;$q1'
+        pstats=(${PIPESTATUS[@]})
+        # Credit for the sed idea to https://unix.stackexchange.com/a/711864.
+        # If nancy gave us a bad exit code AND sed found an OSS index error in the output, then we don't fail the build.
+        if [[ ${pstats[1]} -eq 1 && ${pstats[2]} -eq 0 ]]; then
+          echo Ignoring failed scan due to problem with the external scanner.
+          exit 0
+        fi
+        exit ${pstats[1]}
   - run:
       name: Run unit tests
       command: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -38,11 +38,10 @@ steps:
   - run:
       name: Check if dependencies have known security vulnerabilities
       command: |
-        # CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated | sed '/error accessing OSS Index/,$b;$q1'
-        # pstats=(${PIPESTATUS[@]})
-        # Credit for the sed idea to https://unix.stackexchange.com/a/711864.
+        set +e
         CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
         grep -q 'error accessing OSS Index' nancy-results.txt; grep_result=$?
+        set -e
         # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.
         if [[ $nancy_result -eq 1 && $grep_result -eq 0 ]]; then
           echo Ignoring failed scan due to problem with the external scanner.


### PR DESCRIPTION
On (so far) rare occasions, the OSS Index back end for `nancy` is unreachable. When this happens, we can't scan, and there's no way to skip or ignore a step in architect.

This PR attempts to let the build continue if the back end is down, based on the limited data available from the last time it happened. 

Can be seen in action [here (no CVE case)](https://app.circleci.com/pipelines/github/giantswarm/starboard-exporter/672/workflows/5a8801ec-5b86-421c-95c1-e61781f14b58/jobs/3472) and [here (CVE found case)](https://app.circleci.com/pipelines/github/giantswarm/starboard-exporter/674/workflows/6139e099-a61a-41c4-a1f9-73559fb292ff/jobs/3480). I wasn't able to force a 500 error in CI to test the grep, but did my best locally.

Related: https://github.com/giantswarm/giantswarm/issues/24153

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
