### PR TITLE
Command go test: Fix Nancy External Service Error Ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Fix `go test` `nancy` external service error ignore logic
 - Add `explicit_allow_chart_name_mismatch` to `push-to-app-catalog` with `app-build-suite` executor.
 - Add `test_target` parameter to `go-test` command. This allows a Makefile target to be executed when specified.
 

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -45,11 +45,11 @@ steps:
       name: Check if dependencies have known security vulnerabilities
       command: |
         set +e
-        CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
+        CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
         grep -q 'error accessing OSS Index' nancy-results.txt; grep_result=$?
         set -e
         # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.
-        if [[ $nancy_result -eq 1 && $grep_result -eq 0 ]]; then
+        if [[ $nancy_result -ne 0 && $grep_result -eq 0 ]]; then
           echo Ignoring failed scan due to problem with the external scanner.
           exit 0
         fi


### PR DESCRIPTION
## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).

## Reasoning

Fix `go test` command error ignore logic for external `nancy` service failures.

Resolves giantswarm/giantswarm#25912