### PR TITLE
Upgrade architect (6.10.0) and go (1.19.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `test_target` parameter to `go-test` command. This allows a Makefile target to be executed when specified.
 - Remove deprecated `kubeval` command in favor of `kubeconform`. Add more recent k8s version checks and validation against our giantswarm/json-schema repo
 
+### Changed
+
+- Update `architect` version to [`v6.10.0`](https://github.com/giantswarm/architect/releases/tag/v6.10.0).
+- Update Go version used in `machine-install` command to 1.19.6.
+
 ## [4.26.0] - 2022-11-21
 
 - Update `architect` version to [`v6.8.0`](https://github.com/giantswarm/architect/releases/tag/v6.8.0).

--- a/src/commands/machine-install-go.yaml
+++ b/src/commands/machine-install-go.yaml
@@ -1,10 +1,10 @@
 parameters:
   go_version:
     type: "string"
-    default: "1.19.1"
+    default: "1.19.6"
   archive_sha:
     type: "string"
-    default: "acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde"
+    default: "e3410c676ced327aec928303fef11385702a5562fd19d9a1750d5a2979763c3d"
 steps:
   - run:
       name: "architect/machine-install-go: Remove old Go"

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: quay.io/giantswarm/architect:6.9.0
+    image: quay.io/giantswarm/architect:6.10.0


### PR DESCRIPTION
This PR updates architect and go for 1.19.6
