### PR TITLE
Add `pre_test_target` parameter to `go-build` and `go-test` jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `pre_test_target` parameter to `go-build` and `go-test` jobs. This allows a Makefile target to be executed when specified and is helpful for generating code before any linters run.
+
 ## [4.28.0] - 2023-02-21
 
 ### Added

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -3,6 +3,11 @@ parameters:
     type: "string"
   os:
     type: "string"
+  pre_test_target:
+    default: ""
+    description: |
+      Executes the requested Makefile target before lints and tests. Helpful to generate code in advance.
+    type: string
   tags:
     default: ""
     type: "string"
@@ -13,6 +18,7 @@ parameters:
     type: string
 steps:
   - go-test:
+      pre_test_target: <<parameters.pre_test_target>>
       test_target: <<parameters.test_target>>
   - run:
       name: Build binaries

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -1,10 +1,22 @@
 parameters:
+  pre_test_target:
+    default: ""
+    description: |
+      Executes the requested Makefile target before lints and tests. Helpful to generate code in advance.
+    type: string
   test_target:
     default: ""
     description: |
       Executes the requested Makefile target.
     type: string
 steps:
+  - when:
+      condition: <<parameters.pre_test_target>>
+      steps:
+      - run:
+          name: Run pre-test Makefile target
+          command: |
+            make <<parameters.pre_test_target>>
   - run:
       name: Check if go.mod and go.sum are clean
       command: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -10,13 +10,16 @@ parameters:
       Executes the requested Makefile target.
     type: string
 steps:
+  # We set `CGO_ENABLED=0` because the `architect` Docker image does not have a C compiler. Most cases
+  # should work without cgo.
+
   - when:
       condition: <<parameters.pre_test_target>>
       steps:
       - run:
           name: Run pre-test Makefile target
           command: |
-            make <<parameters.pre_test_target>>
+            CGO_ENABLED=0 make <<parameters.pre_test_target>>
   - run:
       name: Check if go.mod and go.sum are clean
       command: |

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -15,6 +15,11 @@ parameters:
     description: "The target Operating System for the binary. Must be one of \"linux\", \"darwin\"."
     type: enum
     enum: ["linux", "darwin"]
+  pre_test_target:
+    default: ""
+    description: |
+      Executes the requested Makefile target before lints and tests. Helpful to generate code in advance.
+    type: string
   resource_class:
     default: "medium"
     description: |
@@ -42,6 +47,7 @@ steps:
   - go-build:
       binary: << parameters.binary >>
       os: << parameters.os >>
+      pre_test_target: <<parameters.pre_test_target>>
       tags: << parameters.tags >>
       test_target: <<parameters.test_target>>
   - go-cache-save

--- a/src/jobs/go-test.yaml
+++ b/src/jobs/go-test.yaml
@@ -8,6 +8,11 @@ description: |
   - "version" produced by `architect project version` command.
 
 parameters:
+  pre_test_target:
+    default: ""
+    description: |
+      Executes the requested Makefile target before lints and tests. Helpful to generate code in advance.
+    type: string
   resource_class:
     default: "medium"
     description: |
@@ -28,5 +33,6 @@ steps:
   - tools-info
   - go-cache-restore
   - go-test:
+      pre_test_target: <<parameters.pre_test_target>>
       test_target: <<parameters.test_target>>
   - go-cache-save


### PR DESCRIPTION
This allows a Makefile target to be executed when specified and is helpful for generating code before any linters run.

Specifically, I've tested this change with https://github.com/giantswarm/capa-iam-operator/pull/161, in which I require code generation to run before linters.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
