### PR TITLE
Update app-test-suite to v0.4.1 in run-tests-with-ats  CircleCI job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `app-test-suite` to v0.4.1. 
 
 ## [4.31.0] - 2023-08-02
 

--- a/src/jobs/run-tests-with-ats.yaml
+++ b/src/jobs/run-tests-with-ats.yaml
@@ -6,11 +6,11 @@ parameters:
   app-test-suite_version:
     description: "Version of app-test-suite dabs.sh container wrapper to use (git tag or commit)"
     type: string
-    default: "v0.2.4"
+    default: "v0.4.1"
   app-test-suite_container_tag:
     description: "Container tag of app-test-suite to use (check quay.io/giantswarm/app-test-suite)"
     type: string
-    default: "0.2.4"
+    default: "0.4.1"
   additional_app-test-suite_flags:
     description: "Additional app-test-suite flags to use"
     type: string


### PR DESCRIPTION
This PR bumps the `app-test-suite` version for the `run-tests-with-ats` CircleCI job to v0.4.1 by default.