### PR TITLE
Merge ldflags steps into one for the `go-test` workflow

### DIFF
--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -24,22 +24,21 @@ steps:
       name: Check if go.mod and go.sum are clean
       command: |
         go mod tidy && git diff --exit-code
+
   - run:
-      name: Create .ldflags
+      name: Create ldflags file
       command: |
         echo -n "-w -linkmode 'auto' -extldflags '-static'" > .ldflags
-  - run:
-      name: Write build date to .ldflags
-      command: |
+        
+        # buildTimestamp
         echo -n " -X '$(go list .)/pkg/project.buildTimestamp=$(date --utc '+%FT%TZ')'" >> .ldflags
-  - run:
-      name: Write commit SHA to .ldflags
-      command: |
+
+        # Commit SHA
         echo -n " -X '$(go list .)/pkg/project.gitSHA=${CIRCLE_SHA1}'" >> .ldflags
-  - run:
-      name: Print .ldflags content
-      command: |
+
+        # Print content
         echo "\"$(cat .ldflags)\""
+        
   - run:
       name: Check if imports are properly sorted
       command: |


### PR DESCRIPTION
Currently there are 4 steps related to creation of the `.ldflags` file, each with trivial operations.

This PR merges them into one, with the goal to simplify (shorten) the CI run reports.

Before:

![image](https://github.com/giantswarm/architect-orb/assets/273727/c2748b79-716a-43ba-b607-3d1d59aa123a)
