### PR TITLE
Bump apptestctl to v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `app-test-suite` to v0.4.1. 
+- Update `apptestctl` to v0.18.0, which installs VerticalPodAutoscaler and PolicyException CRDs to test clusters.
 
 ## [4.31.0] - 2023-08-02
 

--- a/docs/job/integration-test.md
+++ b/docs/job/integration-test.md
@@ -26,7 +26,7 @@ workflows:
 
 - [common parameters](common.md#parameters) shared in all jobs.
 - [test-dir](#attach_workspace) (required string)
-- [apptestctl-version](#apptestctl-version) (optional string, default="v0.17.0")
+- [apptestctl-version](#apptestctl-version) (optional string, default="v0.18.0")
 - [env-file](#env-file) (optional string, default="")
 - [helm-version](#helm-version) (optional string, default="v3.6.3")
 - [install-app-platform](#install-app-platform) (optional boolean, default=false)

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -8,7 +8,7 @@ description: |
   See [docs](docs/integration_test.md) for more details.
 parameters:
   apptestctl-version:
-    default: "v0.17.0"
+    default: "v0.18.0"
     description: "apptestctl version for bootstrapping app platform."
     type: string
   env-file:


### PR DESCRIPTION
Bumps apptestctl to v0.18.0 to install VPA and PolicyException CRDs