### PR TITLE
Prevent false positives from nancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent false positives in nancy's vulnerability reports by using `go list` with `-deps ./...`
+
 ## [4.33.0] - 2023-10-10
 
 ### Changed

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -59,7 +59,7 @@ steps:
       name: Check if dependencies have known security vulnerabilities
       command: |
         set +e
-        CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
+        CGO_ENABLED=0 go list -json -deps ./... | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
         grep -q 'error accessing OSS Index' nancy-results.txt; grep_result=$?
         set -e
         # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.


### PR DESCRIPTION
This PR changes the `go list` command that lists Go dependencies.

Previously we were using `go list -m all`, which returned more Go modules than were used in the current project. This resulted in nancy reporting vulnerabilities of modules that weren't even used in the project.

The nancy docs recommends to use `go list -deps ./...`, which is what we are changing towards.