### PR TITLE
Fix Go checksum for `machine-install-go` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Go checksum for `machine-install-go` command
+
 ## [4.34.0] - 2023-11-08
 
 ### Changed

--- a/src/commands/machine-install-go.yaml
+++ b/src/commands/machine-install-go.yaml
@@ -4,7 +4,7 @@ parameters:
     default: "1.21.3"
   archive_sha:
     type: "string"
-    default: "c2ccd27ca7a5bf8260102b6f5905e39d64bfe41aabedbf61864d2b44fb2b5286"
+    default: "1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8"
 steps:
   - run:
       name: "architect/machine-install-go: Remove old Go"


### PR DESCRIPTION
I had downloaded the archive with `curl -O`, missing `-L` to follow the redirect to the actual tarball download. So I had hashed an HTML redirect page 🙈.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
