### PR TITLE
Deprecate push-to-docker, update docs job list to include push-to-registries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 - [integration-test](job/integration-test.md)
 - [push-to-app-catalog](job/push-to-app-catalog.md)
 - [push-to-app-collection](job/push-to-app-collection.md)
-- [push-to-docker](job/push-to-docker.md)
+- [push-to-docker](job/push-to-docker.md) (deprecated)
+- [push-to-registries](job/push-to-registries.md)
 - [run-kat-tests](job/run-kat-tests.md)
 - [run-tests-with-ats](job/run-tests-with-ats.md) (Experimental)

--- a/docs/job/push-to-docker.md
+++ b/docs/job/push-to-docker.md
@@ -1,5 +1,7 @@
 # push-to-docker
 
+**This job is DEPRECATED since 21 Nov 2023. Please use [push-to-registries](push-to-registries.md) instead.**
+
 This job builds a docker image and pushes it to a registry.
 It uses the Dockerfile at the root of the workspace directory and the root directory as build context by default.
 Otherwise, it is possible to specify the Dockerfile and build context to use with `dockerfile` and `build-context` arguments respectively.


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2882