### PR TITLE
Make pushing dev builds configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- More improvements to the [`push-to-registries`](./docs/job/push-to-registries.md) job:
+  - It is possible now to configure which target registry should receive images for dev builds. This defaults to gsoci (new ACR) and quay.io only. Check the docs for details.
+  - The `image` parameter is now optional. The default is to create the name from the GitHub organization and repository name.
+
 ## [4.35.1] - 2023-11-22
 
 ### Changed

--- a/docs/job/push-to-registries.md
+++ b/docs/job/push-to-registries.md
@@ -2,7 +2,7 @@
 
 This job builds a container image and pushes it to a set of registries configured within the job itself.
 This way this job centralizes the management over image uploads and build process.
-It uses the `Dockerfile` found at the root of the workspace directory and the root directory as 
+It uses the `Dockerfile` found at the root of the workspace directory and the root directory as
 build context by default.
 Otherwise, it is possible to specify the Dockerfile and build context to use with `dockerfile` and `build-context` arguments respectively.
 

--- a/docs/job/push-to-registries.md
+++ b/docs/job/push-to-registries.md
@@ -12,8 +12,6 @@ Otherwise, it is possible to specify the Dockerfile and build context to use wit
 
 Argument `tag-suffix` allows to specify a special suffix to be added after the generated container tag.
 
-
-
 Example usage
 
 ```yaml
@@ -26,12 +24,11 @@ workflows:
     jobs:
       - architect/push-to-registries:
           context: architect
-          name: push-image-to-registries
-          image: giantswarm/REPOSITORY
-          tag-suffix: ""
+          name: push-to-registries
+          image: giantswarm/my-repo
           requires:
             # Make sure binary is built.
-            - go-build-REPOSITORY
+            - go-build
           filters:
             # Trigger job also on git tag.
             tags:
@@ -53,3 +50,23 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?$/
 ```
+
+## Selecting target registries
+
+The default configuration enables pushing to all registries we care about. Sticking with the defaults is recommended here. However, if you want to override pushing to any of the target registries, you have the following config parameters available:
+
+- `push-to-gsoci` (boolean): Whether or not to push to `gsoci.azurecr.io`
+- `push-to-quay` (boolean): Whether or not to push to `quay.io`
+- `push-to-aliyun` (boolean): Whether or not to push to Aliyun (for AWS China)
+- `push-to-docker` (boolean): Whether or not to push to `docker.io`
+
+## Pushing dev vs. release images
+
+The job distinguishes between release and dev builds. Builds for commits in a branch (other than the default branch) are considered **dev** builds, all others are **release** builds.
+
+By default, images from dev builds are only pushed to `gsoci` and `quay.io`, but not to Aliyun and `docker.io`.
+
+- `push-dev-to-gsoci` (boolean): Whether or not to push to `gsoci.azurecr.io`. Also requires `push-to-gsoci` to be true.
+- `push-dev-to-quay` (boolean): Whether or not to push to `quay.io`. Also requires `push-to-quay` to be true.
+- `push-dev-to-aliyun` (boolean): Whether or not to push to Aliyun (for AWS China). Also requires `push-to-aliyun` to be true.
+- `push-dev-to-docker` (boolean): Whether or not to push to `docker.io`. Also requires `push-to-docker` to be true.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,5 +1,5 @@
 version: 2.1
 
 description: |
-  Tools for interactions with giantswarm managed App Catalog. Full orb source
+  Tools for interactions with Giant Swarm app catalogs and registries. Full orb source
   code: https://github.com/giantswarm/architect-orb.

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -41,8 +41,8 @@ steps:
             BUILD_TYPE=release
           fi
 
-          if [ "$BUILD_TYPE" -eq "dev" ]; then
-            if [ "<<parameters.push_dev_builds>>" -eq "false" ]; then
+          if [ "$BUILD_TYPE" = "dev" ]; then
+            if [ "<<parameters.push_dev_builds>>" = "false" ]; then
               echo "This is a dev build, but dev builds are not wanted for this step based on the 'push_dev_builds' parameter. Doing nothing."
               # Exit without failing
               circleci-agent step halt
@@ -58,7 +58,7 @@ steps:
           echo "Pushing the image"
           docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
 
-          if [ "$CIRCLE_BRANCH" -eq "<<parameters.tag-latest-branch>>" ]; then
+          if [ "$CIRCLE_BRANCH" = "<<parameters.tag-latest-branch>>" ]; then
             echo "Also push the image with :latest<<parameters.tag-suffix>> tag (only for branch <<parameters.tag-latest-branch>>)"
             docker tag <<parameters.image_sha256>> "<<parameters.registry>>/<<parameters.image>>:latest"
             docker push "<<parameters.image>>:latest<<parameters.tag-suffix>>"

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -35,13 +35,13 @@ steps:
         name: Push to registry <<parameters.registry>>
         command: |
           BUILD_TYPE=dev
-          if [[ -z $(echo "<< parameters.tag >>" | grep -E "[a-h0-9]{40}")]]; then
+          if [[ -z $(echo "<< parameters.tag >>" | grep -E "[a-h0-9]{40}") ]]; then
             # Release build
             BUILD_TYPE=release
           fi
 
-          if [ "$BUILD_TYPE" -eq "dev"]; then
-            if [ "<<parameters.push_dev_builds>>" -eq "false"]; then
+          if [ "$BUILD_TYPE" -eq "dev" ]; then
+            if [ "<<parameters.push_dev_builds>>" -eq "false" ]; then
               echo "This is a dev build, but dev builds are not wanted for this step based on the 'push_dev_builds' parameter. Doing nothing."
               # Exit without failing
               circleci-agent step halt

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -33,7 +33,7 @@ parameters:
 steps:
     - run:
         name: Push to registry <<parameters.registry>>
-        command: |
+        command: |          
           BUILD_TYPE=dev
           MATCH=$(echo "<< parameters.tag >>" | grep -E "[a-h0-9]{40}")
           if [[ -z "$MATCH" ]]; then
@@ -41,10 +41,12 @@ steps:
             BUILD_TYPE=release
           fi
 
+          echo "Pushing dev builds (push_dev_builds) for this registry is set to: <<parameters.push_dev_builds>>"
+          echo "The type of this build is: $BUILD_TYPE"
+
           if [ "$BUILD_TYPE" = "dev" ]; then
             if [ "<<parameters.push_dev_builds>>" = "false" ]; then
-              echo "This is a dev build, but dev builds are not wanted for this step based on the 'push_dev_builds' parameter. Doing nothing."
-              # Exit without failing
+              echo "As this is a dev build, and dev builds should not be pushed to this registry, ending here."
               circleci-agent step halt
             fi
           fi
@@ -52,11 +54,11 @@ steps:
           echo "Tagging image with SHA256 <<parameters.image_sha256>> as <<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
           docker tag <<parameters.image_sha256>> "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
 
-          echo "Authenticating for registry <<parameters.registry>> as user ${<<parameters.username_envar>>}"
+          echo "Authenticating for registry <<parameters.registry>>"
           docker login <<parameters.registry>> --username "${<<parameters.username_envar>>}" --password "${<<parameters.password_envar>>}"
 
           echo "Pushing the image"
-          docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
+          docker push -q "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push -q "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push -q "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
 
           if [ "$CIRCLE_BRANCH" = "<<parameters.tag-latest-branch>>" ]; then
             echo "Also push the image with :latest<<parameters.tag-suffix>> tag (only for branch <<parameters.tag-latest-branch>>)"

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -47,7 +47,7 @@ steps:
           if [ "$BUILD_TYPE" = "dev" ]; then
             if [ "<<parameters.push_dev_builds>>" = "false" ]; then
               echo "As this is a dev build, and dev builds should not be pushed to this registry, ending here."
-              circleci-agent step halt
+              exit 0
             fi
           fi
 

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -1,5 +1,6 @@
 # This command checks whether the tag represents a dev or release build
-# and then decides whether 
+# and then decides whether a push should happen.
+# The :latest tag is also pushed if conditions match.
 
 parameters:
   image_sha256:

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -33,7 +33,7 @@ parameters:
 steps:
     - run:
         name: Push to registry <<parameters.registry>>
-        command: |          
+        command: |
           BUILD_TYPE=dev
           MATCH=$(echo "<< parameters.tag >>" | grep -E "[a-h0-9]{40}")
           if [[ -z "$MATCH" ]]; then

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -8,6 +8,7 @@ parameters:
   registry:
     type: string
   image:
+    description: Name of the repository and image, e. g. giantswarm/my-project. Defaults to the org and repo name separated with a slash.
     type: string
   tag:
     type: string
@@ -51,17 +52,23 @@ steps:
             fi
           fi
 
-          echo "Tagging image with SHA256 <<parameters.image_sha256>> as <<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
-          docker tag <<parameters.image_sha256>> "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
+          # Default the image name
+          IMAGE="<<parameters.image>>"
+          if [[ -z "$IMAGE" ]]; then
+            IMAGE="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+          fi
+
+          echo "Tagging image with SHA256 <<parameters.image_sha256>> as <<parameters.registry>>/${IMAGE}:<<parameters.tag>>"
+          docker tag <<parameters.image_sha256>> "<<parameters.registry>>/${IMAGE}:<<parameters.tag>>"
 
           echo "Authenticating for registry <<parameters.registry>>"
           docker login <<parameters.registry>> --username "${<<parameters.username_envar>>}" --password "${<<parameters.password_envar>>}"
 
           echo "Pushing the image"
-          docker push -q "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push -q "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push -q "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
+          docker push -q "<<parameters.registry>>/${IMAGE}:<<parameters.tag>>" || docker push -q "<<parameters.registry>>/${IMAGE}:<<parameters.tag>>" || docker push -q "<<parameters.registry>>/${IMAGE}:<<parameters.tag>>"
 
           if [ "$CIRCLE_BRANCH" = "<<parameters.tag-latest-branch>>" ]; then
             echo "Also push the image with :latest<<parameters.tag-suffix>> tag (only for branch <<parameters.tag-latest-branch>>)"
-            docker tag <<parameters.image_sha256>> "<<parameters.registry>>/<<parameters.image>>:latest"
-            docker push "<<parameters.image>>:latest<<parameters.tag-suffix>>"
+            docker tag <<parameters.image_sha256>> "<<parameters.registry>>/${IMAGE}:latest"
+            docker push "${IMAGE}:latest<<parameters.tag-suffix>>"
           fi

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -53,7 +53,7 @@ steps:
           docker tag <<parameters.image_sha256>> "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
 
           echo "Authenticating for registry <<parameters.registry>> as user ${<<parameters.username_envar>>}"
-          echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "<<parameters.registry>>"
+          docker login <<parameters.registry>> --username "${<<parameters.username_envar>>}" --password "${<<parameters.password_envar>>}"
 
           echo "Pushing the image"
           docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -35,7 +35,8 @@ steps:
         name: Push to registry <<parameters.registry>>
         command: |
           BUILD_TYPE=dev
-          if [[ -z $(echo "<< parameters.tag >>" | grep -E "[a-h0-9]{40}") ]]; then
+          MATCH=$(echo "<< parameters.tag >>" | grep -E "[a-h0-9]{40}")
+          if [[ -z "$MATCH" ]]; then
             # Release build
             BUILD_TYPE=release
           fi

--- a/src/commands/image-push-to-registry-v2.yaml
+++ b/src/commands/image-push-to-registry-v2.yaml
@@ -1,0 +1,63 @@
+# This command checks whether the tag represents a dev or release build
+# and then decides whether 
+
+parameters:
+  image_sha256:
+    type: string
+  registry:
+    type: string
+  image:
+    type: string
+  tag:
+    type: string
+  password_envar:
+    type: env_var_name
+  username_envar:
+    type: env_var_name
+  push_dev_builds:
+    description: "Normally only release builds are pushed. If this is true, also dev builds are pushed to the selected registry."
+    type: boolean
+    default: false
+  tag-latest-branch:
+    type: string
+  tag-suffix:
+    type: string
+    default: ""
+  build-context:
+    type: string
+    default: "."
+  dockerfile:
+    type: string
+    default: "./Dockerfile"
+steps:
+    - run:
+        name: Push to registry <<parameters.registry>>
+        command: |
+          BUILD_TYPE=dev
+          if [[ -z $(echo "<< parameters.tag >>" | grep -E "[a-h0-9]{40}")]]; then
+            # Release build
+            BUILD_TYPE=release
+          fi
+
+          if [ "$BUILD_TYPE" -eq "dev"]; then
+            if [ "<<parameters.push_dev_builds>>" -eq "false"]; then
+              echo "This is a dev build, but dev builds are not wanted for this step based on the 'push_dev_builds' parameter. Doing nothing."
+              # Exit without failing
+              circleci-agent step halt
+            fi
+          fi
+
+          echo "Tagging image with SHA256 <<parameters.image_sha256>> as <<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
+          docker tag <<parameters.image_sha256>> "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
+
+          echo "Authenticating for registry <<parameters.registry>> as user ${<<parameters.username_envar>>}"
+          echo -n "${<<parameters.password_envar>>}" | docker login --username "${<<parameters.username_envar>>}" --password-stdin "<<parameters.registry>>"
+
+          echo "Pushing the image"
+          docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>" || docker push "<<parameters.registry>>/<<parameters.image>>:<<parameters.tag>>"
+
+          if [ "$CIRCLE_BRANCH" -eq "<<parameters.tag-latest-branch>>" ]; then
+            echo "Also push the image with :latest<<parameters.tag-suffix>> tag (only for branch <<parameters.tag-latest-branch>>)"
+            docker tag <<parameters.image_sha256>> "<<parameters.registry>>/<<parameters.image>>:latest"
+            docker push "<<parameters.image>>:latest<<parameters.tag-suffix>>"
+          fi

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -76,16 +76,16 @@ steps:
       condition:
         or:
           - and:
-            - equal: [true, <<parameters.push-to-gsoci>>]
-            - matches:
-                pattern: "^(main|master)$"
-                value: <<pipeline.git.branch>>
-          - and:
-            - equal: [true, <<parameters.push-dev-to-gsoci>>]
-            - not:
+              - equal: [true, <<parameters.push-to-gsoci>>]
               - matches:
                   pattern: "^(main|master)$"
                   value: <<pipeline.git.branch>>
+          - and:
+              - equal: [true, <<parameters.push-dev-to-gsoci>>]
+              - not:
+                - matches:
+                    pattern: "^(main|master)$"
+                    value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -103,16 +103,16 @@ steps:
       condition:
         or:
           - and:
-            - equal: [true, <<parameters.push-to-quay>>]
-            - matches:
-                pattern: "^(main|master)$"
-                value: <<pipeline.git.branch>>
-          - and:
-            - equal: [true, <<parameters.push-dev-to-quay>>]
-            - not:
+              - equal: [true, <<parameters.push-to-quay>>]
               - matches:
                   pattern: "^(main|master)$"
                   value: <<pipeline.git.branch>>
+          - and:
+              - equal: [true, <<parameters.push-dev-to-quay>>]
+              - not:
+                - matches:
+                    pattern: "^(main|master)$"
+                    value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -131,16 +131,16 @@ steps:
       condition:
         or:
           - and:
-            - equal: [true, <<parameters.push-to-aliyun>>]
-            - matches:
-                pattern: "^(main|master)$"
-                value: <<pipeline.git.branch>>
-          - and:
-            - equal: [true, <<parameters.push-dev-to-aliyun>>]
-            - not:
+              - equal: [true, <<parameters.push-to-aliyun>>]
               - matches:
                   pattern: "^(main|master)$"
                   value: <<pipeline.git.branch>>
+          - and:
+              - equal: [true, <<parameters.push-dev-to-aliyun>>]
+              - not:
+                - matches:
+                    pattern: "^(main|master)$"
+                    value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -159,16 +159,16 @@ steps:
       condition:
         or:
           - and:
-            - equal: [true, <<parameters.push-to-docker>>]
-            - matches:
-                pattern: "^(main|master)$"
-                value: <<pipeline.git.branch>>
-          - and:
-            - equal: [true, <<parameters.push-dev-to-docker>>]
-            - not:
+              - equal: [true, <<parameters.push-to-docker>>]
               - matches:
                   pattern: "^(main|master)$"
                   value: <<pipeline.git.branch>>
+          - and:
+              - equal: [true, <<parameters.push-dev-to-docker>>]
+              - not:
+                - matches:
+                    pattern: "^(main|master)$"
+                    value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -82,34 +82,34 @@ steps:
         equal: [true, <<parameters.push-to-gsoci>>]
       steps:
         - image-push-to-registry-v2:
-          image_sha256: $(cat .image_sha256)
-          registry: gsoci.azurecr.io
-          image: <<parameters.image>>
-          tag: $(cat .docker_image_tag)
-          username_envar: ACR_GSOCI_USERNAME
-          password_envar: ACR_GSOCI_PASSWORD
-          push_dev_builds: <<parameters.push-dev-to-gsoci>>
-          build-context: <<parameters.build-context>>
-          dockerfile: <<parameters.dockerfile>>
-          tag-latest-branch: <<parameters.tag-latest-branch>>
-          tag-suffix: <<parameters.tag-suffix>>
+            image_sha256: $(cat .image_sha256)
+            registry: gsoci.azurecr.io
+            image: <<parameters.image>>
+            tag: $(cat .docker_image_tag)
+            username_envar: ACR_GSOCI_USERNAME
+            password_envar: ACR_GSOCI_PASSWORD
+            push_dev_builds: <<parameters.push-dev-to-gsoci>>
+            build-context: <<parameters.build-context>>
+            dockerfile: <<parameters.dockerfile>>
+            tag-latest-branch: <<parameters.tag-latest-branch>>
+            tag-suffix: <<parameters.tag-suffix>>
   # quay
   - when:
       condition:
         equal: [true, <<parameters.push-to-quay>>]
       steps:
         - image-push-to-registry-v2:
-          image_sha256: $(cat .image_sha256)
-          registry: quay.io
-          image: <<parameters.image>>
-          tag: $(cat .docker_image_tag)
-          username_envar: QUAY_USERNAME
-          password_envar: QUAY_PASSWORD
-          push_dev_builds: <<parameters.push-dev-to-quay>>
-          build-context: <<parameters.build-context>>
-          dockerfile: <<parameters.dockerfile>>
-          tag-latest-branch: <<parameters.tag-latest-branch>>
-          tag-suffix: <<parameters.tag-suffix>>
+            image_sha256: $(cat .image_sha256)
+            registry: quay.io
+            image: <<parameters.image>>
+            tag: $(cat .docker_image_tag)
+            username_envar: QUAY_USERNAME
+            password_envar: QUAY_PASSWORD
+            push_dev_builds: <<parameters.push-dev-to-quay>>
+            build-context: <<parameters.build-context>>
+            dockerfile: <<parameters.dockerfile>>
+            tag-latest-branch: <<parameters.tag-latest-branch>>
+            tag-suffix: <<parameters.tag-suffix>>
 
   # aliyun
   - when:
@@ -117,17 +117,17 @@ steps:
         equal: [true, <<parameters.push-to-aliyun>>]
       steps:
         - image-push-to-registry-v2:
-          image_sha256: $(cat .image_sha256)
-          registry: giantswarm-registry.cn-shanghai.cr.aliyuncs.com
-          image: <<parameters.image>>
-          tag: $(cat .docker_image_tag)
-          username_envar: ALIYUN_USERNAME
-          password_envar: ALIYUN_PASSWORD
-          push_dev_builds: <<parameters.push-dev-to-aliyun>>
-          build-context: <<parameters.build-context>>
-          dockerfile: <<parameters.dockerfile>>
-          tag-latest-branch: <<parameters.tag-latest-branch>>
-          tag-suffix: <<parameters.tag-suffix>>
+            image_sha256: $(cat .image_sha256)
+            registry: giantswarm-registry.cn-shanghai.cr.aliyuncs.com
+            image: <<parameters.image>>
+            tag: $(cat .docker_image_tag)
+            username_envar: ALIYUN_USERNAME
+            password_envar: ALIYUN_PASSWORD
+            push_dev_builds: <<parameters.push-dev-to-aliyun>>
+            build-context: <<parameters.build-context>>
+            dockerfile: <<parameters.dockerfile>>
+            tag-latest-branch: <<parameters.tag-latest-branch>>
+            tag-suffix: <<parameters.tag-suffix>>
 
   # docker
   - when:
@@ -135,14 +135,14 @@ steps:
         equal: [true, <<parameters.push-to-docker>>]
       steps:
         - image-push-to-registry-v2:
-          image_sha256: $(cat .image_sha256)
-          registry: docker.io
-          image: <<parameters.image>>
-          tag: $(cat .docker_image_tag)
-          username_envar: DOCKER_USERNAME
-          password_envar: DOCKER_PASSWORD
-          push_dev_builds: <<parameters.push-dev-to-docker>>
-          build-context: <<parameters.build-context>>
-          dockerfile: <<parameters.dockerfile>>
-          tag-latest-branch: <<parameters.tag-latest-branch>>
-          tag-suffix: <<parameters.tag-suffix>>
+            image_sha256: $(cat .image_sha256)
+            registry: docker.io
+            image: <<parameters.image>>
+            tag: $(cat .docker_image_tag)
+            username_envar: DOCKER_USERNAME
+            password_envar: DOCKER_PASSWORD
+            push_dev_builds: <<parameters.push-dev-to-docker>>
+            build-context: <<parameters.build-context>>
+            dockerfile: <<parameters.dockerfile>>
+            tag-latest-branch: <<parameters.tag-latest-branch>>
+            tag-suffix: <<parameters.tag-suffix>>

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -1,39 +1,59 @@
 parameters:
   image:
     description: 'Name of the  container repository and image, without tag. e.g. "my-org/my-image".'
-    type: "string"
+    type: string
   tag-latest-branch:
     description: 'Name of the branch on which the image will be additionally tagged as "latest".'
-    type: "string"
-    default: "main"
+    type: string
+    default: main
   resource_class:
-    default: "small"
+    default: small
     description: |
       Configures the amount of CPU and RAM for the job. See
       https://circleci.com/docs/2.0/configuration-reference/#docker-executor
       for details.
-    type: "enum"
+    type: enum
     enum: ["small", "medium", "medium+", "large", "xlarge"]
   build-context:
-    type: "string"
+    type: string
     default: "."
   dockerfile:
-    type: "string"
+    type: string
     default: "./Dockerfile"
   tag-suffix:
-    type: "string"
+    type: string
     default: ""
   push-to-aliyun:
-    type: "boolean"
+    description: Whether a release image should be pushed to the Aliyun registry (used only for AWS china).
+    type: boolean
     default: true
-  push-to-acr-gsoci:
-    type: "boolean"
+  push-to-gsoci:
+    description: Whether a release image should be pushed to gsoci.azureacr.io (recommended!).
+    type: boolean
     default: true
   push-to-quay:
-    type: "boolean"
+    description: Whether a release image should be pushed to quay.io.
+    type: boolean
     default: true
   push-to-docker:
-    type: "boolean"
+    description: Whether a release image should be pushed to Docker Hub (docker.io).
+    type: boolean
+    default: false
+  push-dev-to-aliyun:
+    description: Whether a dev image should be pushed to the Aliyun registry (used only for AWS china).
+    type: boolean
+    default: false
+  push-dev-to-gsoci:
+    description: Whether a dev image should be pushed to gsoci.azureacr.io.
+    type: boolean
+    default: true
+  push-dev-to-quay:
+    description: Whether a dev image should be pushed to quay.io.
+    type: boolean
+    default: true
+  push-dev-to-docker:
+    description: Whether a dev image should be pushed to Docker Hub (docker.io).
+    type: boolean
     default: false
 executor: "architect"
 resource_class: "<< parameters.resource_class >>"
@@ -50,7 +70,18 @@ steps:
       dockerfile: <<parameters.dockerfile>>
   - when:
       condition:
-        equal: [true, <<parameters.push-to-acr-gsoci>>]
+        or:
+          - and:
+            - equal: [true, <<parameters.push-to-gsoci>>]
+            - matches:
+                pattern: "^(main|master)$"
+                value: <<pipeline.git.branch>>
+          - and:
+            - equal: [true, <<parameters.push-dev-to-gsoci>>]
+            - not:
+              - matches:
+                  pattern: "^(main|master)$"
+                  value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -65,7 +96,18 @@ steps:
             tag-suffix: <<parameters.tag-suffix>>
   - when:
       condition:
-        equal: [true, <<parameters.push-to-quay>>]
+        or:
+          - and:
+            - equal: [true, <<parameters.push-to-quay>>]
+            - matches:
+                pattern: "^(main|master)$"
+                value: <<pipeline.git.branch>>
+          - and:
+            - equal: [true, <<parameters.push-dev-to-quay>>]
+            - not:
+              - matches:
+                  pattern: "^(main|master)$"
+                  value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -80,7 +122,18 @@ steps:
             tag-suffix: <<parameters.tag-suffix>>
   - when:
       condition:
-        equal: [true, <<parameters.push-to-aliyun>>]
+        or:
+          - and:
+            - equal: [true, <<parameters.push-to-aliyun>>]
+            - matches:
+                pattern: "^(main|master)$"
+                value: <<pipeline.git.branch>>
+          - and:
+            - equal: [true, <<parameters.push-dev-to-aliyun>>]
+            - not:
+              - matches:
+                  pattern: "^(main|master)$"
+                  value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -95,7 +148,18 @@ steps:
             tag-suffix: <<parameters.tag-suffix>>
   - when:
       condition:
-        equal: [true, <<parameters.push-to-docker>>]
+        or:
+          - and:
+            - equal: [true, <<parameters.push-to-docker>>]
+            - matches:
+                pattern: "^(main|master)$"
+                value: <<pipeline.git.branch>>
+          - and:
+            - equal: [true, <<parameters.push-dev-to-docker>>]
+            - not:
+              - matches:
+                  pattern: "^(main|master)$"
+                  value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -70,7 +70,7 @@ steps:
   - image-build-with-docker:
       build-context: <<parameters.build-context>>
       dockerfile: <<parameters.dockerfile>>
-  
+
   # gsoci
   - when:
       condition:

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -76,16 +76,16 @@ steps:
       condition:
         or:
           - and:
-              - equal: [true, <<parameters.push-to-gsoci>>]
-              - matches:
+            - equal: [true, <<parameters.push-to-gsoci>>]
+            - matches:
+                pattern: "^(main|master)$"
+                value: <<pipeline.git.branch>>
+          - and:
+            - equal: [true, <<parameters.push-dev-to-gsoci>>]
+            - not:
+                matches:
                   pattern: "^(main|master)$"
                   value: <<pipeline.git.branch>>
-          - and:
-              - equal: [true, <<parameters.push-dev-to-gsoci>>]
-              - not:
-                  - matches:
-                      pattern: "^(main|master)$"
-                      value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -110,9 +110,9 @@ steps:
           - and:
               - equal: [true, <<parameters.push-dev-to-quay>>]
               - not:
-                  - matches:
-                      pattern: "^(main|master)$"
-                      value: <<pipeline.git.branch>>
+                  matches:
+                    pattern: "^(main|master)$"
+                    value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -138,9 +138,9 @@ steps:
           - and:
               - equal: [true, <<parameters.push-dev-to-aliyun>>]
               - not:
-                  - matches:
-                      pattern: "^(main|master)$"
-                      value: <<pipeline.git.branch>>
+                  matches:
+                    pattern: "^(main|master)$"
+                    value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -166,9 +166,9 @@ steps:
           - and:
               - equal: [true, <<parameters.push-dev-to-docker>>]
               - not:
-                  - matches:
-                      pattern: "^(main|master)$"
-                      value: <<pipeline.git.branch>>
+                  matches:
+                    pattern: "^(main|master)$"
+                    value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -79,7 +79,7 @@ steps:
       tag: $(cat .docker_image_tag)
       username_envar: ACR_GSOCI_USERNAME
       password_envar: ACR_GSOCI_PASSWORD
-      push_dev_builds: <<parameters.push-to-gsoci>>
+      push_dev_builds: <<parameters.push-dev-to-gsoci>>
       build-context: <<parameters.build-context>>
       dockerfile: <<parameters.dockerfile>>
       tag-latest-branch: <<parameters.tag-latest-branch>>
@@ -92,7 +92,7 @@ steps:
       tag: $(cat .docker_image_tag)
       username_envar: QUAY_USERNAME
       password_envar: QUAY_PASSWORD
-      push_dev_builds: <<parameters.push-to-quay>>
+      push_dev_builds: <<parameters.push-dev-to-quay>>
       build-context: <<parameters.build-context>>
       dockerfile: <<parameters.dockerfile>>
       tag-latest-branch: <<parameters.tag-latest-branch>>
@@ -106,7 +106,7 @@ steps:
       tag: $(cat .docker_image_tag)
       username_envar: ALIYUN_USERNAME
       password_envar: ALIYUN_PASSWORD
-      push_dev_builds: <<parameters.push-to-aliyun>>
+      push_dev_builds: <<parameters.push-dev-to-aliyun>>
       build-context: <<parameters.build-context>>
       dockerfile: <<parameters.dockerfile>>
       tag-latest-branch: <<parameters.tag-latest-branch>>
@@ -120,7 +120,7 @@ steps:
       tag: $(cat .docker_image_tag)
       username_envar: DOCKER_USERNAME
       password_envar: DOCKER_PASSWORD
-      push_dev_builds: <<parameters.push-to-docker>>
+      push_dev_builds: <<parameters.push-dev-to-docker>>
       build-context: <<parameters.build-context>>
       dockerfile: <<parameters.dockerfile>>
       tag-latest-branch: <<parameters.tag-latest-branch>>

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -83,9 +83,9 @@ steps:
           - and:
               - equal: [true, <<parameters.push-dev-to-gsoci>>]
               - not:
-                - matches:
-                    pattern: "^(main|master)$"
-                    value: <<pipeline.git.branch>>
+                  - matches:
+                      pattern: "^(main|master)$"
+                      value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -110,9 +110,9 @@ steps:
           - and:
               - equal: [true, <<parameters.push-dev-to-quay>>]
               - not:
-                - matches:
-                    pattern: "^(main|master)$"
-                    value: <<pipeline.git.branch>>
+                  - matches:
+                      pattern: "^(main|master)$"
+                      value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -138,9 +138,9 @@ steps:
           - and:
               - equal: [true, <<parameters.push-dev-to-aliyun>>]
               - not:
-                - matches:
-                    pattern: "^(main|master)$"
-                    value: <<pipeline.git.branch>>
+                  - matches:
+                      pattern: "^(main|master)$"
+                      value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)
@@ -166,9 +166,9 @@ steps:
           - and:
               - equal: [true, <<parameters.push-dev-to-docker>>]
               - not:
-                - matches:
-                    pattern: "^(main|master)$"
-                    value: <<pipeline.git.branch>>
+                  - matches:
+                      pattern: "^(main|master)$"
+                      value: <<pipeline.git.branch>>
       steps:
         - image-push-to-registry:
             image_sha256: $(cat .image_sha256)

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -1,3 +1,7 @@
+environment:
+  DOCKER_BUILDKIT: "1"
+executor: "architect"
+resource_class: "<< parameters.resource_class >>"
 parameters:
   image:
     description: 'Name of the  container repository and image, without tag. e.g. "my-org/my-image".'
@@ -55,8 +59,6 @@ parameters:
     description: Whether a dev image should be pushed to Docker Hub (docker.io).
     type: boolean
     default: false
-executor: "architect"
-resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
   - setup_remote_docker:
@@ -68,6 +70,8 @@ steps:
   - image-build-with-docker:
       build-context: <<parameters.build-context>>
       dockerfile: <<parameters.dockerfile>>
+  
+  # gsoci
   - when:
       condition:
         or:
@@ -94,6 +98,7 @@ steps:
             dockerfile: <<parameters.dockerfile>>
             tag-latest-branch: <<parameters.tag-latest-branch>>
             tag-suffix: <<parameters.tag-suffix>>
+  # quay
   - when:
       condition:
         or:
@@ -120,6 +125,8 @@ steps:
             dockerfile: <<parameters.dockerfile>>
             tag-latest-branch: <<parameters.tag-latest-branch>>
             tag-suffix: <<parameters.tag-suffix>>
+
+  # aliyun
   - when:
       condition:
         or:
@@ -146,6 +153,8 @@ steps:
             dockerfile: <<parameters.dockerfile>>
             tag-latest-branch: <<parameters.tag-latest-branch>>
             tag-suffix: <<parameters.tag-suffix>>
+
+  # docker
   - when:
       condition:
         or:
@@ -172,5 +181,3 @@ steps:
             dockerfile: <<parameters.dockerfile>>
             tag-latest-branch: <<parameters.tag-latest-branch>>
             tag-suffix: <<parameters.tag-suffix>>
-environment:
-  DOCKER_BUILDKIT: "1"

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -72,112 +72,56 @@ steps:
       dockerfile: <<parameters.dockerfile>>
 
   # gsoci
-  - when:
-      condition:
-        or:
-          - and:
-            - equal: [true, <<parameters.push-to-gsoci>>]
-            - matches:
-                pattern: "^(main|master)$"
-                value: <<pipeline.git.branch>>
-          - and:
-            - equal: [true, <<parameters.push-dev-to-gsoci>>]
-            - not:
-                matches:
-                  pattern: "^(main|master)$"
-                  value: <<pipeline.git.branch>>
-      steps:
-        - image-push-to-registry:
-            image_sha256: $(cat .image_sha256)
-            registry: gsoci.azurecr.io
-            image: <<parameters.image>>
-            tag: $(cat .docker_image_tag)
-            username_envar: ACR_GSOCI_USERNAME
-            password_envar: ACR_GSOCI_PASSWORD
-            build-context: <<parameters.build-context>>
-            dockerfile: <<parameters.dockerfile>>
-            tag-latest-branch: <<parameters.tag-latest-branch>>
-            tag-suffix: <<parameters.tag-suffix>>
+  - image-push-to-registry-v2:
+      image_sha256: $(cat .image_sha256)
+      registry: gsoci.azurecr.io
+      image: <<parameters.image>>
+      tag: $(cat .docker_image_tag)
+      username_envar: ACR_GSOCI_USERNAME
+      password_envar: ACR_GSOCI_PASSWORD
+      push_dev_builds: <<parameters.push-to-gsoci>>
+      build-context: <<parameters.build-context>>
+      dockerfile: <<parameters.dockerfile>>
+      tag-latest-branch: <<parameters.tag-latest-branch>>
+      tag-suffix: <<parameters.tag-suffix>>
   # quay
-  - when:
-      condition:
-        or:
-          - and:
-              - equal: [true, <<parameters.push-to-quay>>]
-              - matches:
-                  pattern: "^(main|master)$"
-                  value: <<pipeline.git.branch>>
-          - and:
-              - equal: [true, <<parameters.push-dev-to-quay>>]
-              - not:
-                  matches:
-                    pattern: "^(main|master)$"
-                    value: <<pipeline.git.branch>>
-      steps:
-        - image-push-to-registry:
-            image_sha256: $(cat .image_sha256)
-            registry: quay.io
-            image: <<parameters.image>>
-            tag: $(cat .docker_image_tag)
-            username_envar: QUAY_USERNAME
-            password_envar: QUAY_PASSWORD
-            build-context: <<parameters.build-context>>
-            dockerfile: <<parameters.dockerfile>>
-            tag-latest-branch: <<parameters.tag-latest-branch>>
-            tag-suffix: <<parameters.tag-suffix>>
+  - image-push-to-registry-v2:
+      image_sha256: $(cat .image_sha256)
+      registry: quay.io
+      image: <<parameters.image>>
+      tag: $(cat .docker_image_tag)
+      username_envar: QUAY_USERNAME
+      password_envar: QUAY_PASSWORD
+      push_dev_builds: <<parameters.push-to-quay>>
+      build-context: <<parameters.build-context>>
+      dockerfile: <<parameters.dockerfile>>
+      tag-latest-branch: <<parameters.tag-latest-branch>>
+      tag-suffix: <<parameters.tag-suffix>>
 
   # aliyun
-  - when:
-      condition:
-        or:
-          - and:
-              - equal: [true, <<parameters.push-to-aliyun>>]
-              - matches:
-                  pattern: "^(main|master)$"
-                  value: <<pipeline.git.branch>>
-          - and:
-              - equal: [true, <<parameters.push-dev-to-aliyun>>]
-              - not:
-                  matches:
-                    pattern: "^(main|master)$"
-                    value: <<pipeline.git.branch>>
-      steps:
-        - image-push-to-registry:
-            image_sha256: $(cat .image_sha256)
-            registry: giantswarm-registry.cn-shanghai.cr.aliyuncs.com
-            image: <<parameters.image>>
-            tag: $(cat .docker_image_tag)
-            username_envar: ALIYUN_USERNAME
-            password_envar: ALIYUN_PASSWORD
-            build-context: <<parameters.build-context>>
-            dockerfile: <<parameters.dockerfile>>
-            tag-latest-branch: <<parameters.tag-latest-branch>>
-            tag-suffix: <<parameters.tag-suffix>>
+  - image-push-to-registry-v2:
+      image_sha256: $(cat .image_sha256)
+      registry: giantswarm-registry.cn-shanghai.cr.aliyuncs.com
+      image: <<parameters.image>>
+      tag: $(cat .docker_image_tag)
+      username_envar: ALIYUN_USERNAME
+      password_envar: ALIYUN_PASSWORD
+      push_dev_builds: <<parameters.push-to-aliyun>>
+      build-context: <<parameters.build-context>>
+      dockerfile: <<parameters.dockerfile>>
+      tag-latest-branch: <<parameters.tag-latest-branch>>
+      tag-suffix: <<parameters.tag-suffix>>
 
   # docker
-  - when:
-      condition:
-        or:
-          - and:
-              - equal: [true, <<parameters.push-to-docker>>]
-              - matches:
-                  pattern: "^(main|master)$"
-                  value: <<pipeline.git.branch>>
-          - and:
-              - equal: [true, <<parameters.push-dev-to-docker>>]
-              - not:
-                  matches:
-                    pattern: "^(main|master)$"
-                    value: <<pipeline.git.branch>>
-      steps:
-        - image-push-to-registry:
-            image_sha256: $(cat .image_sha256)
-            registry: docker.io
-            image: <<parameters.image>>
-            tag: $(cat .docker_image_tag)
-            username_envar: DOCKER_USERNAME
-            password_envar: DOCKER_PASSWORD
-            build-context: <<parameters.build-context>>
-            dockerfile: <<parameters.dockerfile>>
-            tag-latest-branch: <<parameters.tag-latest-branch>>
-            tag-suffix: <<parameters.tag-suffix>>
+  - image-push-to-registry-v2:
+      image_sha256: $(cat .image_sha256)
+      registry: docker.io
+      image: <<parameters.image>>
+      tag: $(cat .docker_image_tag)
+      username_envar: DOCKER_USERNAME
+      password_envar: DOCKER_PASSWORD
+      push_dev_builds: <<parameters.push-to-docker>>
+      build-context: <<parameters.build-context>>
+      dockerfile: <<parameters.dockerfile>>
+      tag-latest-branch: <<parameters.tag-latest-branch>>
+      tag-suffix: <<parameters.tag-suffix>>

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -27,34 +27,39 @@ parameters:
   tag-suffix:
     type: string
     default: ""
-  push-to-aliyun:
-    description: Whether a release image should be pushed to the Aliyun registry (used only for AWS china).
+  push-to-gsoci:
+    description: |
+      Whether images should be pushed to gsoci.azureacr.io (recommended!).
     type: boolean
     default: true
-  push-to-gsoci:
-    description: Whether a release image should be pushed to gsoci.azureacr.io (recommended!).
+  push-dev-to-gsoci:
+    description: Whether a dev image should be pushed to gsoci.azureacr.io.
     type: boolean
     default: true
   push-to-quay:
-    description: Whether a release image should be pushed to quay.io.
-    type: boolean
-    default: true
-  push-to-docker:
-    description: Whether a release image should be pushed to Docker Hub (docker.io).
-    type: boolean
-    default: false
-  push-dev-to-aliyun:
-    description: Whether a dev image should be pushed to the Aliyun registry (used only for AWS china).
-    type: boolean
-    default: false
-  push-dev-to-gsoci:
-    description: Whether a dev image should be pushed to gsoci.azureacr.io.
+    description: Whether images should be pushed to quay.io.
     type: boolean
     default: true
   push-dev-to-quay:
     description: Whether a dev image should be pushed to quay.io.
     type: boolean
     default: true
+  push-to-aliyun:
+    description: |
+      Whether images should be pushed to the Aliyun registry (used only for AWS china).
+      For dev images, also set `push-dev-to-aliyun` to true.
+    type: boolean
+    default: true
+  push-dev-to-aliyun:
+    description: Whether a dev image should be pushed to the Aliyun registry (used only for AWS china).
+    type: boolean
+    default: false
+  push-to-docker:
+    description: |
+      Whether images image should be pushed to Docker Hub (docker.io).
+      For dev images, also set `push-dev-to-docker` to true.
+    type: boolean
+    default: false
   push-dev-to-docker:
     description: Whether a dev image should be pushed to Docker Hub (docker.io).
     type: boolean
@@ -72,56 +77,72 @@ steps:
       dockerfile: <<parameters.dockerfile>>
 
   # gsoci
-  - image-push-to-registry-v2:
-      image_sha256: $(cat .image_sha256)
-      registry: gsoci.azurecr.io
-      image: <<parameters.image>>
-      tag: $(cat .docker_image_tag)
-      username_envar: ACR_GSOCI_USERNAME
-      password_envar: ACR_GSOCI_PASSWORD
-      push_dev_builds: <<parameters.push-dev-to-gsoci>>
-      build-context: <<parameters.build-context>>
-      dockerfile: <<parameters.dockerfile>>
-      tag-latest-branch: <<parameters.tag-latest-branch>>
-      tag-suffix: <<parameters.tag-suffix>>
+  - when:
+      condition:
+        equal: [true, <<parameters.push-to-gsoci>>]
+      steps:
+        - image-push-to-registry-v2:
+          image_sha256: $(cat .image_sha256)
+          registry: gsoci.azurecr.io
+          image: <<parameters.image>>
+          tag: $(cat .docker_image_tag)
+          username_envar: ACR_GSOCI_USERNAME
+          password_envar: ACR_GSOCI_PASSWORD
+          push_dev_builds: <<parameters.push-dev-to-gsoci>>
+          build-context: <<parameters.build-context>>
+          dockerfile: <<parameters.dockerfile>>
+          tag-latest-branch: <<parameters.tag-latest-branch>>
+          tag-suffix: <<parameters.tag-suffix>>
   # quay
-  - image-push-to-registry-v2:
-      image_sha256: $(cat .image_sha256)
-      registry: quay.io
-      image: <<parameters.image>>
-      tag: $(cat .docker_image_tag)
-      username_envar: QUAY_USERNAME
-      password_envar: QUAY_PASSWORD
-      push_dev_builds: <<parameters.push-dev-to-quay>>
-      build-context: <<parameters.build-context>>
-      dockerfile: <<parameters.dockerfile>>
-      tag-latest-branch: <<parameters.tag-latest-branch>>
-      tag-suffix: <<parameters.tag-suffix>>
+  - when:
+      condition:
+        equal: [true, <<parameters.push-to-quay>>]
+      steps:
+        - image-push-to-registry-v2:
+          image_sha256: $(cat .image_sha256)
+          registry: quay.io
+          image: <<parameters.image>>
+          tag: $(cat .docker_image_tag)
+          username_envar: QUAY_USERNAME
+          password_envar: QUAY_PASSWORD
+          push_dev_builds: <<parameters.push-dev-to-quay>>
+          build-context: <<parameters.build-context>>
+          dockerfile: <<parameters.dockerfile>>
+          tag-latest-branch: <<parameters.tag-latest-branch>>
+          tag-suffix: <<parameters.tag-suffix>>
 
   # aliyun
-  - image-push-to-registry-v2:
-      image_sha256: $(cat .image_sha256)
-      registry: giantswarm-registry.cn-shanghai.cr.aliyuncs.com
-      image: <<parameters.image>>
-      tag: $(cat .docker_image_tag)
-      username_envar: ALIYUN_USERNAME
-      password_envar: ALIYUN_PASSWORD
-      push_dev_builds: <<parameters.push-dev-to-aliyun>>
-      build-context: <<parameters.build-context>>
-      dockerfile: <<parameters.dockerfile>>
-      tag-latest-branch: <<parameters.tag-latest-branch>>
-      tag-suffix: <<parameters.tag-suffix>>
+  - when:
+      condition:
+        equal: [true, <<parameters.push-to-aliyun>>]
+      steps:
+        - image-push-to-registry-v2:
+          image_sha256: $(cat .image_sha256)
+          registry: giantswarm-registry.cn-shanghai.cr.aliyuncs.com
+          image: <<parameters.image>>
+          tag: $(cat .docker_image_tag)
+          username_envar: ALIYUN_USERNAME
+          password_envar: ALIYUN_PASSWORD
+          push_dev_builds: <<parameters.push-dev-to-aliyun>>
+          build-context: <<parameters.build-context>>
+          dockerfile: <<parameters.dockerfile>>
+          tag-latest-branch: <<parameters.tag-latest-branch>>
+          tag-suffix: <<parameters.tag-suffix>>
 
   # docker
-  - image-push-to-registry-v2:
-      image_sha256: $(cat .image_sha256)
-      registry: docker.io
-      image: <<parameters.image>>
-      tag: $(cat .docker_image_tag)
-      username_envar: DOCKER_USERNAME
-      password_envar: DOCKER_PASSWORD
-      push_dev_builds: <<parameters.push-dev-to-docker>>
-      build-context: <<parameters.build-context>>
-      dockerfile: <<parameters.dockerfile>>
-      tag-latest-branch: <<parameters.tag-latest-branch>>
-      tag-suffix: <<parameters.tag-suffix>>
+  - when:
+      condition:
+        equal: [true, <<parameters.push-to-docker>>]
+      steps:
+        - image-push-to-registry-v2:
+          image_sha256: $(cat .image_sha256)
+          registry: docker.io
+          image: <<parameters.image>>
+          tag: $(cat .docker_image_tag)
+          username_envar: DOCKER_USERNAME
+          password_envar: DOCKER_PASSWORD
+          push_dev_builds: <<parameters.push-dev-to-docker>>
+          build-context: <<parameters.build-context>>
+          dockerfile: <<parameters.dockerfile>>
+          tag-latest-branch: <<parameters.tag-latest-branch>>
+          tag-suffix: <<parameters.tag-suffix>>

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -4,8 +4,9 @@ executor: "architect"
 resource_class: "<< parameters.resource_class >>"
 parameters:
   image:
-    description: 'Name of the  container repository and image, without tag. e.g. "my-org/my-image".'
+    description: Name of the  container repository and image. Defaults to org-name/repo-name. Must not contain registry host name!
     type: string
+    default: ""
   tag-latest-branch:
     description: 'Name of the branch on which the image will be additionally tagged as "latest".'
     type: string


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2882 , https://github.com/giantswarm/roadmap/issues/2915

This PR allows to configure whether dev builds should be pushed, per registry.

Also the `image` parameter is made optiona and defaults to the format `orga_name/repo_name` now.

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
