### PR TITLE
Fix docker SHA detection in image-build-with-docker command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Made the `image-build-with-docker` command work in a situation where the `docker build` command would output the image SHA more than once.
+
 ## [4.35.2] - 2023-11-24
 
 - More improvements to the [`push-to-registries`](./docs/job/push-to-registries.md) job:

--- a/src/commands/image-build-with-docker.yaml
+++ b/src/commands/image-build-with-docker.yaml
@@ -13,4 +13,4 @@ steps:
   - run:
       name: Save container image SHA256 to temp file
       command: |
-        awk -F" " '/^#[0-9]+ writing image sha256:[0-9a-f]{40}/ {print $4}' .docker.log | tee .image_sha256
+        awk -F" " '/^#[0-9]+ writing image sha256:[0-9a-f]{40}/ {print $4;exit}' .docker.log | tee .image_sha256


### PR DESCRIPTION
Made the `image-build-with-docker` command work in a situation where the `docker build` command would output the image SHA more than once.

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
