### PR TITLE
Let golangci-lint report more than 3 items of the same type of complaint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Let golangci-lint report more than 3 items of the same type of complaint
+
 ## [4.35.5] - 2023-11-28
 
 In the 'push-to-registries' job, pushing to `docker.io` is now the default as well.

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -54,7 +54,7 @@ steps:
   - run:
       name: Check if golangci-lint has any complaints
       command: |
-        CGO_ENABLED=0 golangci-lint run -E gosec -E goconst --timeout 10m
+        CGO_ENABLED=0 golangci-lint run -E gosec -E goconst --timeout 10m --max-same-issues 0
   - run:
       name: Check if dependencies have known security vulnerabilities
       command: |


### PR DESCRIPTION
By default, `golangci-lint` reports only 3 items of a particular type of error.

This can cause extra round-trips if developers only rely on the CI check. By adding `--max-same-issues 0` to the execution, all occurrences of the issues found are printed.

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
