### PR TITLE
`push-to-registries` fix order and params cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `push-to-registries` job changes:
+  - remove deprecated `push-to-*` config options
+  - login to registries before an image is built, so it's possible to use private base images
+
+
 ## [4.36.0] - 2023-12-19
 
 - `push-to-registries` job changes:
   - Add retries to all remote commands
   - Add a check for a visibility of the source code in the job that pushes images to registry. If repo is private, an image should only be pushed to registries that are configured as private ones.
-  - Add repos configuration that is parsed from an enviroment variable. This allows to configure the job to push to different registries based on the configuration only.
+  - Add repos configuration that is parsed from an environment variable. This allows to configure the job to push to different registries based on the configuration only.
 
 ## [4.35.6] - 2023-12-05
 

--- a/src/commands/image-login-to-registries.yaml
+++ b/src/commands/image-login-to-registries.yaml
@@ -1,0 +1,40 @@
+parameters:
+  registries-data:
+    default: ""
+    description: |
+      A string that defines configuration for registries
+      Each line describes one registry using the following format
+
+      visibility registry username_envvar password_envvar push_dev_image
+
+      where
+
+      access is one of ("public" "private" "public/private")
+      registry is a string containing registry url
+      username_envvar is a string containing the name of an env var with a username
+      password_envvar is as string containing the name of an env var with a password
+      push_dev is boolean, when true, dev images are uploaded to registries
+    type: string
+steps:
+  - run:
+      name: Login to registries
+      command: |
+        set -x
+
+        if [[ "<<parameters.registries-data>>" ]]; then
+          REGISTRIES_DATA="<<parameters.registries-data>>";
+        else
+          echo "Using registries data from the circle.ci environment settings.";
+          if ! [[ "${REGISTRIES_DATA_BASE64}" ]]; then
+            echo "Environment variable REGISTRIES_DATA_BASE64 is not set properly in circleci's context."
+            exit 1
+          fi
+          REGISTRIES_DATA=$(echo $REGISTRIES_DATA_BASE64 | base64 -d)
+        fi
+
+        echo "${REGISTRIES_DATA}" > .registries_data
+
+        cat .registries_data | while read -r _ reg username password _; do
+          CMD="docker login $reg --username '${!username}' --password '${!password}'"
+          for i in {1..3}; do [[ $i -gt 1 ]] && sleep 1;  bash -c "${CMD}" && s=0 && break || s=$?; done; (exit $s)
+        done

--- a/src/commands/image-push-to-registries.yaml
+++ b/src/commands/image-push-to-registries.yaml
@@ -37,28 +37,6 @@ parameters:
     default: false
 steps:
   - run:
-      name: Login to registries
-      command: |
-        set -x
-
-        if [[ "<<parameters.registries-data>>" ]]; then
-          REGISTRIES_DATA="<<parameters.registries-data>>";
-        else
-          echo "Using registries data from the circle.ci environment settings.";
-          if ! [[ "${REGISTRIES_DATA_BASE64}" ]]; then
-            echo "Environment variable REGISTRIES_DATA_BASE64 is not set properly in circleci's context."
-            exit 1
-          fi
-          REGISTRIES_DATA=$(echo $REGISTRIES_DATA_BASE64 | base64 -d)
-        fi
-
-        echo "${REGISTRIES_DATA}" > .registries_data
-
-        cat .registries_data | while read -r _ reg username password _; do
-          CMD="docker login $reg --username '${!username}' --password '${!password}'"
-          for i in {1..3}; do [[ $i -gt 1 ]] && sleep 1;  bash -c "${CMD}" && s=0 && break || s=$?; done; (exit $s)
-        done
-  - run:
       name: Push image to registries
       command: |
         # If image is forced to be pushed as a public one,
@@ -77,6 +55,21 @@ steps:
             echo -e "The GitHub repository is detected as public, treating the image as a public one.\n"
             IMAGE_ACCESS=public
           fi
+        fi
+
+        if ! [[ -f .registries_data ]]; then
+          if [[ "<<parameters.registries-data>>" ]]; then
+            REGISTRIES_DATA="<<parameters.registries-data>>";
+          else
+            echo "Using registries data from the circle.ci environment settings.";
+            if ! [[ "${REGISTRIES_DATA_BASE64}" ]]; then
+              echo "Environment variable REGISTRIES_DATA_BASE64 is not set properly in circleci's context."
+              exit 1
+            fi
+            REGISTRIES_DATA=$(echo $REGISTRIES_DATA_BASE64 | base64 -d)
+          fi
+
+          echo "${REGISTRIES_DATA}" > .registries_data
         fi
 
         cat .registries_data | while read -r access reg _ _ push_dev; do

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -35,83 +35,7 @@ parameters:
   registries-data:
     default: ""
     type: string
-  # -- Deprecated parameters
-  push-to-gsoci:
-    description: |
-      Whether images should be pushed to gsoci.azurecr.io (recommended!).
-    type: boolean
-    default: false
-  push-dev-to-gsoci:
-    description: Whether a dev image should be pushed to gsoci.azurecr.io.
-    type: boolean
-    default: false
-  push-to-gsociprivate:
-    description: |
-      Whether images should be pushed to gsociprivate.azurecr.io. This will work only
-      if hte source GitHub repository is detected as private as well.
-    type: boolean
-    default: false
-  push-dev-to-gsociprivate:
-    description: |
-      Whether dev images should be pushed to gsociprivate.azurecr.io. This will work only
-      if hte source GitHub repository is detected as private as well.
-    type: boolean
-    default: false
-  push-to-quay:
-    description: Whether images should be pushed to quay.io.
-    type: boolean
-    default: false
-  push-dev-to-quay:
-    description: Whether a dev image should be pushed to quay.io.
-    type: boolean
-    default: false
-  push-to-aliyun:
-    description: |
-      Whether images should be pushed to the Aliyun registry (used only for AWS china).
-      For dev images, also set `push-dev-to-aliyun` to true.
-    type: boolean
-    default: false
-  push-dev-to-aliyun:
-    description: Whether a dev image should be pushed to the Aliyun registry (used only for AWS china).
-    type: boolean
-    default: false
-  push-to-docker:
-    description: |
-      Whether images image should be pushed to Docker Hub (docker.io).
-      For dev images, also set `push-dev-to-docker` to true.
-    type: boolean
-    default: false
-  push-dev-to-docker:
-    description: Whether a dev image should be pushed to Docker Hub (docker.io).
-    type: boolean
-    default: false
 steps:
-  # TODO: Remove this step when push-to-* parameters are removed
-  # I've tried not going this way, but I have absolutely no idea how to avoid it
-  - run:
-      name: Check for deprecated parameters
-      command: |
-        echo "Detecting deprecated paramameters, please check this PR for explanations: https://github.com/giantswarm/architect-orb/pull/481"
-        [[ "<< parameters.push-to-docker >>" = "true" ]] && \
-          echo "WARNING: Parameter push-to-docker is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-dev-to-docker >>" = "true" ]] && \
-          echo "WARNING: Parameter push-dev-to-docker is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-to-quay>>" = "true" ]] && \
-          echo "WARNING: Parameter push-to-quay is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-dev-to-quay >>" = "true" ]] && \
-          echo "WARNING: Parameter push-dev-to-quay is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-to-aliyun >>" = "true" ]] && \
-          echo "WARNING: Parameter push-to-aliyun is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-dev-to-aliyun >>" = "true" ]] && \
-          echo "WARNING: Parameter push-dev-to-aliyun is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-to-gsoci >>" = "true" ]] && \
-          echo "WARNING: Parameter push-to-gsoci is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-dev-to-gsoci >>" = "true" ]] && \
-          echo "WARNING: Parameter push-dev-to-gsoci is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-to-gsociprivate >>" = "true" ]] && \
-          echo "WARNING: Parameter push-to-gsociprivate is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
-        [[ "<< parameters.push-dev-to-gsociprivate >>" = "true" ]] && \
-          echo "WARNING: Parameter push-dev-to-gsociprivate is deprecated and will be removed soon, please consider using 'registries-data' instead" || true
   - checkout
   - setup_remote_docker:
       version: default
@@ -131,7 +55,9 @@ steps:
       dockerfile: <<parameters.dockerfile>>
       tag-latest-branch: <<parameters.tag-latest-branch>>
       tag-suffix: <<parameters.tag-suffix>>
-      registries-data: <<parameters.registries-data>>
+      registries-data:
+        <<parameters.registries-data>>
+        # 2023.12.20 Current config in the env var
         #        private gsociprivate.azurecr.io ACR_GSOCIPRIVATE_USERNAME ACR_GSOCIPRIVATE_PASSWORD true
         #        public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true
         #        private/public quay.io QUAY_USERNAME QUAY_PASSWORD true

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -43,10 +43,11 @@ steps:
       at: .
   - image-prepare-tag:
       tag-suffix: <<parameters.tag-suffix>>
+  - image-login-to-registries:
+      registries-data: <<parameters.registries-data>>
   - image-build-with-docker:
       build-context: <<parameters.build-context>>
       dockerfile: <<parameters.dockerfile>>
-
   - image-push-to-registries:
       image-sha256_envvar: DOCKER_IMAGE_SHA256
       image: <<parameters.image>>


### PR DESCRIPTION
- `push-to-registries` job changes:
  - remove deprecated `push-to-*` config options
  - login to registries before an image is built, so it's possible to use private base images