### PR TITLE
Add job `go-dependencies` for checking a Go projects dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added job `go-dependencies` for executing [nancy](https://github.com/sonatype-nexus-community/nancy) separately.
+
 ## [4.37.0] - 2023-12-20
 
 - `push-to-registries` job changes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ## Jobs
 
 - [go-build](job/go-build.md)
+- [go-dependencies](job/go-dependencies.md)
 - [go-test](job/go-test.md)
 - [integration-test](job/integration-test.md)
 - [push-to-app-catalog](job/push-to-app-catalog.md)

--- a/docs/job/go-dependencies.md
+++ b/docs/job/go-dependencies.md
@@ -1,0 +1,13 @@
+# go-dependencies
+
+Check the Go project's dependencies for known security vulnerabilities, using [nancy](https://github.com/sonatype-nexus-community/nancy).
+
+Depending on your project's needs, you may or may not make this job a required check. There are no configuration parameters.
+
+Example configuration snippet:
+
+```yaml
+    jobs:
+      - architect/go-dependencies:
+          name: go-dependencies
+```

--- a/src/commands/go-nancy.yaml
+++ b/src/commands/go-nancy.yaml
@@ -1,0 +1,14 @@
+steps:
+  - run:
+      name: Check if dependencies have known security vulnerabilities
+      command: |
+        set +e
+        CGO_ENABLED=0 go list -json -deps ./... | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
+        grep -q 'error accessing OSS Index' nancy-results.txt; grep_result=$?
+        set -e
+        # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.
+        if [[ $nancy_result -ne 0 && $grep_result -eq 0 ]]; then
+          echo Ignoring failed scan due to problem with the external scanner.
+          exit 0
+        fi
+        exit $nancy_result

--- a/src/jobs/go-dependencies.yaml
+++ b/src/jobs/go-dependencies.yaml
@@ -1,0 +1,9 @@
+description: |
+  Informs about security vulnerabilities in Go dependencies of the project.
+  Uses [nancy](https://github.com/sonatype-nexus-community/nancy) by Sonatype.
+executor: architect
+steps:
+  - checkout
+  - tools-info
+  - go-cache-restore
+  - go-nancy


### PR DESCRIPTION
The idea here is to call nancy in a job separate from `go-test` or `go-build` eventually, and make it non-blocking (not required).

The first step is to add a new job (this PR) which then has to be added to CircleCI configurations.

Later, the nancy execution will have to be removed from go-test and go-build.

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
