### PR TITLE
Ensure publishing a prod version on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ workflows:
           orb_name: giantswarm/architect
           vcs_type: github
           circleci_token: CIRCLECI_DEV_API_TOKEN
+          pub_type: production
           requires:
             - "orb-tools/pack"
           filters:


### PR DESCRIPTION
This adds the `pub_type: production` parameter to the `publish-tag` step.

See https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish