### PR TITLE
Move machine image to machine executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update machine executor image to `default`.
+
 ## [5.0.1] - 2024-02-05
 
 ## [5.0.1] - 2024-02-05

--- a/src/executors/machine.yaml
+++ b/src/executors/machine.yaml
@@ -1,1 +1,4 @@
-machine: true
+description: A ubuntu-2004-based machine executor
+
+machine:
+  image: ubuntu-2004:202010-01

--- a/src/executors/machine.yaml
+++ b/src/executors/machine.yaml
@@ -1,4 +1,4 @@
 description: A ubuntu-2004-based machine executor
 
 machine:
-  image: ubuntu-2004:202010-01
+  image: ubuntu-2004:202101-01

--- a/src/executors/machine.yaml
+++ b/src/executors/machine.yaml
@@ -1,4 +1,6 @@
-description: A ubuntu-2004-based machine executor
+# https://circleci.com/docs/linux-vm-support-policy/
+
+description: A ubuntu-based machine executor
 
 machine:
-  image: ubuntu-2004:202101-01
+  image: default

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -53,8 +53,6 @@ parameters:
     type: "enum"
     enum: ["medium", "large", "xlarge", "2xlarge"]
 executor: "machine"
-machine:
-  image: ubuntu-2004:202010-01
 resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout

--- a/src/jobs/run-kat-tests.yaml
+++ b/src/jobs/run-kat-tests.yaml
@@ -37,8 +37,6 @@ parameters:
     type: "enum"
     enum: ["medium", "large", "xlarge", "2xlarge"]
 executor: "machine"
-machine:
-  image: ubuntu-2004:202010-01
 resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout

--- a/src/jobs/run-tests-with-ats.yaml
+++ b/src/jobs/run-tests-with-ats.yaml
@@ -24,8 +24,6 @@ parameters:
     type: "enum"
     enum: ["medium", "large", "xlarge", "2xlarge"]
 executor: "machine"
-machine:
-  image: ubuntu-2004:202010-01
 resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

This PR:
- Moves `machine.image` to the executor `machine`
- Updates from `ubuntu-2004:202010-01` to `default` following the [instructions from CircleCI](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177)

Unfortunately CircleCI is deprecating version pinning on machine images, and instead adopting a floating tag.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
