### PR TITLE
Make prepare image tag command fail when architect call fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `image-prepare-tag` command fail when `architect project version` command fails (because CircleCI runs the scripts with `-o pipefail`)
+
 ## [5.1.0] - 2024-02-23
 
 ### Changed

--- a/src/commands/image-prepare-tag.yaml
+++ b/src/commands/image-prepare-tag.yaml
@@ -6,5 +6,6 @@ steps:
   - run:
       name: Generate container tag from 'architect project version' and tag-suffix parameter
       command: |
-        echo -n "$(architect project version)<<parameters.tag-suffix>>" | tee .docker_image_tag
+        architect project version | head -n 1 | tr -d "\n" | tee .docker_image_tag
+        echo -n "<<parameters.tag-suffix>>" | tee -a .docker_image_tag
         echo 'export DOCKER_IMAGE_TAG=$(cat .docker_image_tag)' >> $BASH_ENV


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30055

The command substitution hides the return code from the `architect project version` call. CircleCI runs the script with `-eo pipefail` ([reference](https://circleci.com/docs/configuration-reference/#default-shell-options) + [example](https://app.circleci.com/pipelines/github/giantswarm/giantswarm/11900/workflows/50a61db0-579f-49df-a8b5-0502b8d3d35d/jobs/15865?invite=true#step-104-0_69)).