### PR TITLE
Bump architect to v6.17.0, necessary to support go 1.23.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `architect` to v6.17.0.
+
 ## [5.4.0] - 2024-08-01
 
 ### Changed

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: gsoci.azurecr.io/giantswarm/architect:6.16.0
+    image: gsoci.azurecr.io/giantswarm/architect:6.17.0


### PR DESCRIPTION
Updates architect to v6.17.0, which includes golangci-lint v1.60.1 that is compiled with/supports go 1.23
(see https://github.com/giantswarm/architect/pull/1005, with earlier versions linting jobs are getting killed because of RAM usage, e.g. https://app.circleci.com/pipelines/github/giantswarm/cert-exporter/1317/workflows/a9eda581-f647-4237-9c7f-15cc7c6aa7c8/jobs/6013/steps).

## Checklist

- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
