### PR TITLE
`go-test`: remove go vet, tweak golangci-lint, change order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- In command `go-test`, remove the step that executes `go vet`, as the same checks are also run by `golangci-lint`.
+
 ## [5.5.1] - 2024-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - In command `go-test`, remove the step that executes `go vet`, as the same checks are also run by `golangci-lint`.
 
+### Added
+
+- In command `go-test`, the `golangci-lint` now prints information on resource usage.
+
+### Changed
+
+- In command `go-test`, the `golangci-lint` call is no longer limited to a certain number of issues per linter (max-issues-per-linter is now 0).
+
 ## [5.5.1] - 2024-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - In command `go-test`, remove the step that executes `go vet`, as the same checks are also run by `golangci-lint`.
 
-### Added
-
-- In command `go-test`, the `golangci-lint` now prints information on resource usage.
-
 ### Changed
 
 - In command `go-test`, the `golangci-lint` call is no longer limited to a certain number of issues per linter (max-issues-per-linter is now 0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.1] - 2024-08-22
+
 ### Fixed
 
 - Set `GOGC` when running golangci-lint to help avoid using up all available memory in CircleCI
@@ -1067,7 +1069,8 @@ Introduce a new [`push-to-registries`](./docs/job/push-to-registries.md) job tha
 
 - Add push-to-app-catalog job.
 
-[Unreleased]: https://github.com/giantswarm/architect-orb/compare/v5.5.0...HEAD
+[Unreleased]: https://github.com/giantswarm/architect-orb/compare/v5.5.1...HEAD
+[5.5.1]: https://github.com/giantswarm/architect-orb/compare/v5.5.0...v5.5.1
 [5.5.0]: https://github.com/giantswarm/architect-orb/compare/v5.4.0...v5.5.0
 [5.4.0]: https://github.com/giantswarm/architect-orb/compare/v5.3.1...v5.4.0
 [5.3.1]: https://github.com/giantswarm/architect-orb/compare/v5.3.0...v5.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - In command `go-test`, the `golangci-lint` call is no longer limited to a certain number of issues per linter (max-issues-per-linter is now 0).
+- In command `go-test`, use the `environment` key for setting environment variables.
 
 ## [5.5.1] - 2024-08-22
 

--- a/src/commands/go-cache-restore.yaml
+++ b/src/commands/go-cache-restore.yaml
@@ -1,7 +1,9 @@
 steps:
   - restore_cache:
+      name: Restore Go build cache
       keys:
         - go-build-go-mod-v1-{{ checksum "go.sum" }}
   - restore_cache:
+      name: Restore golangci-lint cache
       keys:
         - go-build-golangcilint-v1-{{ checksum "go.sum" }}

--- a/src/commands/go-cache-restore.yaml
+++ b/src/commands/go-cache-restore.yaml
@@ -2,3 +2,6 @@ steps:
   - restore_cache:
       keys:
         - go-build-go-mod-v1-{{ checksum "go.sum" }}
+  - restore_cache:
+      keys:
+        - go-build-golangcilint-v1-{{ checksum "go.sum" }}

--- a/src/commands/go-cache-save.yaml
+++ b/src/commands/go-cache-save.yaml
@@ -3,3 +3,7 @@ steps:
       key: go-build-go-mod-v1-{{ checksum "go.sum" }}
       paths:
         - "/go/pkg/mod"
+  - save_cache:
+      key: go-build-golangcilint-v1-{{ checksum "go.sum" }}
+      paths:
+        - "/golancilint-cache"

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -59,8 +59,7 @@ steps:
           -E goconst \
           --timeout 10m \
           --max-same-issues 0 \
-          --max-issues-per-linter 0 \
-          --print-resources-usage
+          --max-issues-per-linter 0
   - run:
       name: Check if dependencies have known security vulnerabilities
       command: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -53,6 +53,24 @@ steps:
       name: Check if code structure differs from gofmt's
       command: |
         test -z $(gofmt -l .) || gofmt -d .
+  - when:
+      condition: <<parameters.test_target>>
+      steps:
+        - run:
+            name: Run unit tests via Makefile target
+            environment:
+              CGO_ENABLED: "0"
+            command: |
+              make <<parameters.test_target>>
+  - unless:
+      condition: <<parameters.test_target>>
+      steps:
+        - run:
+            name: Run unit tests
+            environment:
+              CGO_ENABLED: "0"
+            command: |
+              go test -ldflags "$(cat .ldflags)" ./...
   - run:
       name: Check if golangci-lint has any complaints
       environment:
@@ -85,21 +103,3 @@ steps:
           exit 0
         fi
         exit $nancy_result
-  - when:
-      condition: <<parameters.test_target>>
-      steps:
-        - run:
-            name: Run unit tests via Makefile target
-            environment:
-              CGO_ENABLED: "0"
-            command: |
-              make <<parameters.test_target>>
-  - unless:
-      condition: <<parameters.test_target>>
-      steps:
-        - run:
-            name: Run unit tests
-            environment:
-              CGO_ENABLED: "0"
-            command: |
-              go test -ldflags "$(cat .ldflags)" ./...

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -18,8 +18,10 @@ steps:
       steps:
         - run:
             name: Run pre-test Makefile target
+            environment:
+              CGO_ENABLED: "0"
             command: |
-              CGO_ENABLED=0 make <<parameters.pre_test_target>>
+              make <<parameters.pre_test_target>>
   - run:
       name: Check if go.mod and go.sum are clean
       command: |
@@ -66,9 +68,11 @@ steps:
           --max-issues-per-linter 0
   - run:
       name: Check if dependencies have known security vulnerabilities
+      environment:
+        CGO_ENABLED: "0"
       command: |
         set +e
-        CGO_ENABLED=0 go list -json -deps ./... \
+        go list -json -deps ./... \
           | nancy sleuth --skip-update-check \
             --quiet --exclude-vulnerability-file ./.nancy-ignore \
             --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 \
@@ -86,12 +90,16 @@ steps:
       steps:
         - run:
             name: Run unit tests via Makefile target
+            environment:
+              CGO_ENABLED: "0"
             command: |
-              CGO_ENABLED=0 make <<parameters.test_target>>
+              make <<parameters.test_target>>
   - unless:
       condition: <<parameters.test_target>>
       steps:
         - run:
             name: Run unit tests
+            environment:
+              CGO_ENABLED: "0"
             command: |
-              CGO_ENABLED=0 go test -ldflags "$(cat .ldflags)" ./...
+              go test -ldflags "$(cat .ldflags)" ./...

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -54,7 +54,7 @@ steps:
   - run:
       name: Check if golangci-lint has any complaints
       command: |
-        CGO_ENABLED=0 GOGC=20 golangci-lint run \
+        CGO_ENABLED=0 golangci-lint run \
           -E gosec \
           -E goconst \
           --timeout 10m \

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -54,7 +54,7 @@ steps:
   - run:
       name: Check if golangci-lint has any complaints
       command: |
-        CGO_ENABLED=0 golangci-lint run \
+        CGO_ENABLED=0 GOGC=20 golangci-lint run \
           -E gosec \
           -E goconst \
           --timeout 10m \

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -54,7 +54,13 @@ steps:
   - run:
       name: Check if golangci-lint has any complaints
       command: |
-        CGO_ENABLED=0 GOGC=20 golangci-lint run -E gosec -E goconst --timeout 10m --max-same-issues 0
+        CGO_ENABLED=0 GOGC=20 golangci-lint run \
+          -E gosec \
+          -E goconst \
+          --timeout 10m \
+          --max-same-issues 0 \
+          --max-issues-per-linter 0 \
+          --print-resources-usage
   - run:
       name: Check if dependencies have known security vulnerabilities
       command: |

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -52,10 +52,6 @@ steps:
       command: |
         test -z $(gofmt -l .) || gofmt -d .
   - run:
-      name: Check if go vet has any complaints
-      command: |
-        CGO_ENABLED=0 go vet ./...
-  - run:
       name: Check if golangci-lint has any complaints
       command: |
         CGO_ENABLED=0 GOGC=20 golangci-lint run -E gosec -E goconst --timeout 10m --max-same-issues 0

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -53,8 +53,12 @@ steps:
         test -z $(gofmt -l .) || gofmt -d .
   - run:
       name: Check if golangci-lint has any complaints
+      environment:
+        GOLANGCI_LINT_CACHE: /golancilint-cache
+        GOGC: "20"
+        CGO_ENABLED: "0"
       command: |
-        CGO_ENABLED=0 GOGC=20 golangci-lint run \
+        golangci-lint run \
           -E gosec \
           -E goconst \
           --timeout 10m \


### PR DESCRIPTION
In this PR I'm mainly removing the separate execution of `go vet`, as it's redundant with the checks executed by `golangci-lint`.

Additional changes:

- Set `--max-issues-per-linter` to 0 (unlimited) in golangci-lint execution
- Using the `environment` key to set environment variables in a more idiomatic way
- Run `go test` before golangci-lint (see below)
- Adding a persistent cache for `golangci-lint`. We'll have to evaluate in practice whether this really speeds up anything.

---

During testing I noticed that `golangci-lint` can take a relatively long time to end up finding a compilation problem, like a breaking API change in a major dependency upgrade.

To catch problems like this faster, I moved the `go test` step to happen before the `golangci-lint` step. This means that compilation problems are already found in the build that happens on `go test`, and according to my tests with `kubectl-gs`, this is faster than the `golangci-lint` execution.


## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
