### PR TITLE
allow-app-creation-in-collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Support new app creation in collections.
+
 ## [5.10.1] - 2024-10-09
 
 ### Changed

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -35,7 +35,11 @@ steps:
   - run:
       name: "architect/push-to-app-collection: Fetch current version of the app in the collection"
       command: |
-        yq eval ".app_version" ".app-collection/flux-manifests/<<parameters.app_name>>.yaml" | tee .app_version_in_collection
+        if [ ! -f .app-collection/flux-manifests/<<parameters.app_name>>.yaml ]; then
+          echo "0.0.0" | tee .app_version_in_collection
+        else
+          yq eval ".app_version" ".app-collection/flux-manifests/<<parameters.app_name>>.yaml" | tee .app_version_in_collection
+        fi
   - run:
       name: "architect/push-to-app-collection: Add / update resources to the collection repo"
       command: |


### PR DESCRIPTION
It is currently impossible to push a new app in a collection because there is no base file to compare version with like so https://app.circleci.com/pipelines/github/giantswarm/alloy-app/192/workflows/500bf071-f394-499d-a823-565718fd6262/jobs/237

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [ ] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
