### PR TITLE
Add `resource_name` parameter to `push-to-app-collection` job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `name` parameter to `push-to-app-collection` job.
+
 ### Changed
 
 Updated Kubernetes versions in kubeconform command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-Updated Kubernetes versions in kubeconform command.
+- Updated Kubernetes versions in kubeconform command.
 
 ## [5.8.0] - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `name` parameter to `push-to-app-collection` job.
+- Add `resource_name` parameter to `push-to-app-collection` job.
 
 ### Changed
 

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -12,6 +12,8 @@ parameters:
     type: "string"
   disable_force_upgrade:
     type: "boolean"
+  name:
+    type: "string"
 steps:
   - run:
       name: "architect/push-to-app-collection: Generate version"
@@ -20,8 +22,10 @@ steps:
   - run:
       name: "architect/push-to-app-collection: Generate Flux Generator"
       command: |
+        name="<<parameters.name>>"
+        [[ -z "$name" ]] && name="<<parameters.app_name>>"
         architect create fluxgenerator \
-          --name="<<parameters.app_name>>" \
+          --name="$name" \
           --app-name="<<parameters.app_name>>" \
           --app-version="$(cat .app_version_in_project)" \
           --app-destination-namespace="<<parameters.app_namespace>>" \

--- a/src/commands/push-to-app-collection.yaml
+++ b/src/commands/push-to-app-collection.yaml
@@ -12,7 +12,7 @@ parameters:
     type: "string"
   disable_force_upgrade:
     type: "boolean"
-  name:
+  resource_name:
     type: "string"
 steps:
   - run:
@@ -22,10 +22,10 @@ steps:
   - run:
       name: "architect/push-to-app-collection: Generate Flux Generator"
       command: |
-        name="<<parameters.name>>"
-        [[ -z "$name" ]] && name="<<parameters.app_name>>"
+        resource_name="<<parameters.resource_name>>"
+        [[ -z "$resource_name" ]] && resource_name="<<parameters.app_name>>"
         architect create fluxgenerator \
-          --name="$name" \
+          --name="$resource_name" \
           --app-name="<<parameters.app_name>>" \
           --app-version="$(cat .app_version_in_project)" \
           --app-destination-namespace="<<parameters.app_namespace>>" \

--- a/src/jobs/push-to-app-collection.yaml
+++ b/src/jobs/push-to-app-collection.yaml
@@ -5,7 +5,7 @@ description: >
 
 parameters:
   app_name:
-    description: "Name of the application."
+    description: "Name of the application in the catalog."
     type: "string"
   app_namespace:
     default: "giantswarm"
@@ -22,6 +22,10 @@ parameters:
     description: "Disable helm chart force upgrade."
     type: "boolean"
     default: false
+  name:
+    description: "Name of the app when deployed."
+    type: "string"
+    default: ""
   resource_class:
     default: "small"
     description: |
@@ -41,3 +45,4 @@ steps:
       app_catalog: <<parameters.app_catalog>>
       app_collection_repo: <<parameters.app_collection_repo>>
       disable_force_upgrade: <<parameters.disable_force_upgrade>>
+      name: <<parameters.name>>

--- a/src/jobs/push-to-app-collection.yaml
+++ b/src/jobs/push-to-app-collection.yaml
@@ -22,8 +22,8 @@ parameters:
     description: "Disable helm chart force upgrade."
     type: "boolean"
     default: false
-  name:
-    description: "Name of the app when deployed."
+  resource_name:
+    description: "Resource name being the name of the app when deployed."
     type: "string"
     default: ""
   resource_class:
@@ -45,4 +45,4 @@ steps:
       app_catalog: <<parameters.app_catalog>>
       app_collection_repo: <<parameters.app_collection_repo>>
       disable_force_upgrade: <<parameters.disable_force_upgrade>>
-      name: <<parameters.name>>
+      resource_name: <<parameters.resource_name>>


### PR DESCRIPTION
This PR adds a `resource_name` parameter to the `push-to-app-collection` job. This parameter is used to specify the name of the app that is being pushed to the app collection.
The name being the final name of the app when deployed into a cluster.