### PR TITLE
Run `conftest` after `app-build-suite` in `push-to-app-catalog` job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Run `app-build-suite` before `conftest` in `push-to-app-catalog` job to fix missing subchart issue.
+
 ## [5.11.3] - 2025-01-07
 
 ### Changed

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -12,6 +12,7 @@ steps:
         policies="${policies},https://raw.githubusercontent.com/swade1987/deprek8ion/${sha}/policies/_cert-manager.rego"
         policies="${policies},https://raw.githubusercontent.com/swade1987/deprek8ion/${sha}/policies/_service-account.rego"
 
+        helm dependency build helm/<<parameters.chart>>
         if [ -d "helm/<<parameters.chart>>/ci" ]; then
           for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update "${policies}" - ; done
         else

--- a/src/commands/helm-conftest.yaml
+++ b/src/commands/helm-conftest.yaml
@@ -12,7 +12,6 @@ steps:
         policies="${policies},https://raw.githubusercontent.com/swade1987/deprek8ion/${sha}/policies/_cert-manager.rego"
         policies="${policies},https://raw.githubusercontent.com/swade1987/deprek8ion/${sha}/policies/_service-account.rego"
 
-        helm dependency build helm/<<parameters.chart>>
         if [ -d "helm/<<parameters.chart>>/ci" ]; then
           for t in $(ls helm/<<parameters.chart>>/ci/*.yaml); do helm template --values $t helm/<<parameters.chart>> | conftest test --update "${policies}" - ; done
         else

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -140,15 +140,15 @@ steps:
       condition:
         equal: ["<< parameters.executor >>", "app-build-suite"]
       steps:
+        - run:
+            name: "architect/package-helm-with-abs: Execute App Build Suite"
+            command: |
+              mkdir build && python -m app_build_suite --chart-dir ./helm/<< parameters.chart >> --destination build --generate-metadata --catalog-base-url "https://giantswarm.github.io/$(cat .app_catalog_name)/" --keep-chart-changes
         - unless:
             condition: << parameters.skip_conftest_deprek8ion >>
             steps:
               - helm-conftest:
                   chart: "<< parameters.chart >>"
-        - run:
-            name: "architect/package-helm-with-abs: Execute App Build Suite"
-            command: |
-              mkdir build && python -m app_build_suite --chart-dir ./helm/<< parameters.chart >> --destination build --generate-metadata --catalog-base-url "https://giantswarm.github.io/$(cat .app_catalog_name)/" --keep-chart-changes
   - push-helm:
       push_to_appcatalog: << parameters.push_to_appcatalog >>
       push_to_oci_registry: << parameters.push_to_oci_registry >>


### PR DESCRIPTION
Run `conftest` after `app-build-suite` to prevent conftest being sad about missing subchart depndencies

## Checklist

- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
