### PR TITLE
Use architect dev version 6.19.1-b4a2a1... with golangci-lint v2

### DIFF
--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: gsoci.azurecr.io/giantswarm/architect:6.19.1
+    image: gsoci.azurecr.io/giantswarm/architect:6.19.1-b4a2a1267b056bf910a23954b28b84535d36e1a0


### PR DESCRIPTION
For https://github.com/giantswarm/architect/pull/1108