### PR TITLE
Run helm dependency update before helm tempalte in kyverno test

### DIFF
--- a/src/commands/run-kyverno.yaml
+++ b/src/commands/run-kyverno.yaml
@@ -45,6 +45,8 @@ steps:
         export CHART_NAME="$(find helm -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)"
         echo "CHART_NAME=${CHART_NAME}" >> $BASH_ENV
 
+        # install chart dependencies
+        helm dependency update helm/${CHART_NAME}
         # template the helm chart
         helm template --release-name ${CHART_NAME} helm/${CHART_NAME} > manifests/resources/${CHART_NAME}.yaml
   - run:


### PR DESCRIPTION
This pull request includes an important change to the `src/commands/run-kyverno.yaml` file to improve the Helm chart installation process.

It adds  a step to install chart dependencies using `helm dependency update` before templating the Helm chart.