### PR TITLE
Remove version command check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the version command check from go-build job
+
 ## [5.12.1] - 2025-04-03
 
 ### Changed

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -30,7 +30,3 @@ steps:
       name: Build binaries
       command: |
         CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -tags "<< parameters.tags >>" -o << parameters.binary >> << parameters.path >>
-  - run:
-      name: Execute version command of built binary (Linux only)
-      command: |
-        [[ "<< parameters.os >>" == "linux" ]] && ./<< parameters.binary >> version || true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/33157

This PR removes the check for version command in the `go-build` job.

This check was in place to ensure a version command was present in the built binary, this applied to binaries built with operatorkit. This is no longer required and the check silently fails which make it useless.