### PR TITLE
Use dev version of architect to downgrade to golangci-lint v1.64.8

### DIFF
--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: gsoci.azurecr.io/giantswarm/architect:6.20.0-b643c094874ad7a22aca4d3c13c1a63431da0fa8
+    image: gsoci.azurecr.io/giantswarm/architect:6.20.1

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,3 +1,3 @@
 docker:
   - entrypoint: /bin/bash
-    image: gsoci.azurecr.io/giantswarm/architect:6.20.0
+    image: gsoci.azurecr.io/giantswarm/architect:6.20.0-b643c094874ad7a22aca4d3c13c1a63431da0fa8


### PR DESCRIPTION
Uses https://github.com/giantswarm/architect/pull/1123