### PR TITLE
add multiarch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Unified multi-arch and single-arch image build/push logic into `image-build-and-push-multiarch.yaml` command and `push-to-registries-multiarch` job.
+- Simplified `go-build` job and command: now supports multi-arch and always produces a `binary` for `linux/amd64`.
+
 ## [6.0.0] - 2025-06-11
 
 ### Removed
@@ -559,7 +564,7 @@ Introduce a new [`push-to-registries`](./docs/job/push-to-registries.md) job tha
 
 ### Changed
 
-- Change download URL of `dats.sh` wrapper to use raw.githubusercontent.com to be able to run pre-release versions of app-test-suite in `run-tests-with-ats` job.
+- Change download URL of `dats.sh` wrapper to use raw.githubusercontent.com to be able to run pre-release versions of app-test-suite in `run-tests-with-abs` job.
 
 ### Removed
 

--- a/docs/job/go-build.md
+++ b/docs/job/go-build.md
@@ -1,27 +1,103 @@
 # go-build
 
-This job:
+This job builds Go binaries for one or more target architectures and operating systems. It supports both classic single-architecture builds and modern multi-architecture workflows for container images.
 
-- Does everything [go-test](go-test.md) job does.
-- Builds a go binary.
-- Runs `BINARY version` and checks if it returned 0 exit code.
-- Persists the binary to the workspace.
+**How it works:**
+- Runs `go-test` (with optional `pre_test_target` and `test_target`)
+- Builds the binary for the specified architecture using the `go-build` command
+- If `architecture` is set (e.g., linux/amd64), the binary will be named `<binary>-<GOOS>-<GOARCH>`. If the architecture is linux/amd64, a copy will also be made as `<binary>` for compatibility with legacy workflows.
+- All produced binaries are persisted to the workspace (using a wildcard pattern)
 
-Example usage:
+## Parameters
+
+- `binary`: Name of the output binary (required).
+- `architecture`: Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64"). Defaults to "linux/amd64". If set, will split into GOOS/GOARCH and name the binary accordingly. If linux/amd64, also copies to `<binary>`.
+- `os`: **Deprecated.** Use `architecture` instead for multi-arch support.
+- `path`: Path to the Go package to build (default: ".").
+- `pre_test_target`: Makefile target to run before tests/lints (optional).
+- `tags`: Additional Go build tags (optional).
+- `test_target`: Makefile target to run for tests (optional).
+- `resource_class`: CircleCI resource class for the job.
+
+## Example usage
+
+### Single-architecture (default)
 
 ```yaml
 version: 2.1
 orbs:
-  architect: giantswarm/architect@VERSION
-
+  architect: giantswarm/architect@x.y.z
 workflows:
-  my-workflow:
+  build:
     jobs:
       - architect/go-build:
-          name: go-build-REPOSITORY
-          binary: REPOSITORY
-          filters:
-            # Trigger job also on git tag.
-            tags:
-              only: /^v.*/
+          binary: myapp
+          architecture: "linux/amd64"
 ```
+
+Dockerfile example:
+```dockerfile
+FROM gcr.io/distroless/static
+COPY myapp /usr/local/bin/myapp
+ENTRYPOINT ["/usr/local/bin/myapp"]
+```
+
+### Multi-architecture (multiple jobs, different resource_class)
+
+```yaml
+version: 2.1
+orbs:
+  architect: giantswarm/architect@x.y.z
+workflows:
+  build-multiarch:
+    jobs:
+      - architect/go-build:
+          binary: myapp
+          architecture: "linux/amd64"
+          resource_class: medium
+      - architect/go-build:
+          binary: myapp
+          architecture: "linux/arm64"
+          resource_class: arm.medium
+      - architect/go-build:
+          binary: myapp
+          architecture: "darwin/amd64"
+          resource_class: macos.xlarge
+```
+
+This will run the `go-build` job in parallel for each architecture, and you can specify a different executor or resource_class for each if needed (e.g., to use ARM or macOS runners).
+
+### Multi-architecture (using CircleCI matrix, recommended for push-to-registries-multiarch)
+
+For best results and maintainability, we recommend using a CircleCI matrix to build all required architectures in parallel. This is especially useful when using `push-to-registries-multiarch`, as it ensures all binaries are built and available for the multi-arch image build step.
+
+```yaml
+version: 2.1
+orbs:
+  architect: giantswarm/architect@x.y.z
+workflows:
+  build-multiarch:
+    jobs:
+      - architect/go-build:
+          matrix:
+            parameters:
+              architecture: ["linux/amd64", "linux/arm64"]
+          binary: myapp
+```
+
+This approach is scalable and makes it easy to add or remove architectures. Each job runs in parallel, and you can use the `requires` field in your workflow to ensure all builds complete before running `push-to-registries-multiarch`.
+
+## Migrating from `os` to `architecture`
+
+The `os` parameter is now deprecated. For multi-arch builds, use the `architecture` parameter and run the job multiple times (once per architecture). For single-arch, you can omit `architecture` (defaults to `linux/amd64`).
+
+## Preparing for multi-arch container images
+
+If you plan to use the output binaries in a multi-arch Docker image (see [`push-to-registries-multiarch`](./push-to-registries-multiarch.md)), ensure your Dockerfile uses the `TARGETPLATFORM` build argument to select the correct binary at build time. See the multi-arch Dockerfile example in the `push-to-registries-multiarch` documentation.
+
+- All referenced binaries (e.g., `myapp-linux-amd64`, `myapp-linux-arm64`) must be present in the workspace before the image build step.
+
+## Notes
+- Backward compatible: existing single-arch workflows do not need to change.
+- For classic single-arch Dockerfiles, use the default or specify a single architecture.
+- For true multi-arch images, use this job with multiple architectures and update your Dockerfile accordingly.

--- a/docs/job/image-build-and-push-multiarch.md
+++ b/docs/job/image-build-and-push-multiarch.md
@@ -1,0 +1,100 @@
+# push-to-registries-multiarch
+
+This job builds and pushes a multi-architecture container image to a set of registries using a single, efficient step. It leverages the `push-to-registries-multiarch` command, which combines building and pushing for all specified platforms and registries.
+
+**Use this job if:**
+- You want to publish a single image that supports multiple architectures (e.g., linux/amd64 and linux/arm64).
+- Your Dockerfile uses the `TARGETPLATFORM` build argument to select the correct binary for each platform (see below).
+- You have already built and persisted binaries for all target architectures in your workspace before the image build step.
+
+If you are using a classic single-arch Dockerfile (with a plain `COPY` of a single binary), use [`push-to-registries`](./push-to-registries.md) instead.
+
+## Example usage
+
+### Recommended: Matrix pattern for multi-arch builds
+
+Use a CircleCI matrix to build all required architectures in parallel, then run the push-to-registries-multiarch job after all builds complete. This is scalable, efficient, and easy to maintain.
+
+```yaml
+version: 2.1
+orbs:
+  architect: giantswarm/architect@VERSION
+
+workflows:
+  my-workflow:
+    jobs:
+      - architect/go-build:
+          matrix:
+            parameters:
+              architecture: ["linux/amd64", "linux/arm64"]
+          binary: myapp
+      - architect/push-to-registries-multiarch:
+          name: push-to-registries-multiarch
+          requires:
+            - architect/go-build
+          image: giantswarm/myapp
+          platforms: "linux/amd64,linux/arm64"
+```
+
+- The matrix runs go-build for each architecture in parallel.
+- The push-to-registries-multiarch job waits for all go-build jobs to finish, then builds and pushes the multi-arch image.
+
+### Classic (single-arch) usage
+
+```yaml
+version: 2.1
+orbs:
+  architect: giantswarm/architect@VERSION
+
+workflows:
+  my-workflow:
+    jobs:
+      - architect/go-build:
+          name: go-build
+          binary: myapp
+      - architect/push-to-registries-multiarch:
+          name: push-to-registries-multiarch
+          requires:
+            - go-build
+          image: giantswarm/myapp
+```
+
+## Dockerfile requirements for multi-arch
+
+Your Dockerfile must use the `TARGETPLATFORM` build argument to select the correct binary for each architecture. Example:
+
+```dockerfile
+FROM alpine AS binary-selector
+ARG TARGETPLATFORM
+COPY myapp-* /binaries/
+RUN case "$TARGETPLATFORM" in \
+      "linux/amd64") cp /binaries/myapp-linux-amd64 /bin/myapp ;; \
+      "linux/arm64") cp /binaries/myapp-linux-arm64 /bin/myapp ;; \
+      *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
+    esac
+
+FROM gcr.io/distroless/static
+WORKDIR /workspace
+COPY --from=binary-selector /bin/myapp /workspace/myapp
+EXPOSE 8080
+ENTRYPOINT ["/workspace/myapp"]
+```
+
+- Adjust binary names, workdir, and EXPOSE as needed for your project.
+- All referenced binaries must be present in the workspace before the image build step.
+
+## Parameters
+- `image`: Name of the container image (without registry host).
+- `build-context`: Build context directory (default: ".").
+- `dockerfile`: Path to the Dockerfile (default: "./Dockerfile").
+- `force-public`: Skip the repo visibility check and push the image to public registries.
+- `tag-latest-branch`: Name of the branch on which the image will be additionally tagged as "latest".
+- `tag-suffix`: Suffix to append to image tags (optional).
+- `registries-data`: Registry configuration string (see orb docs for format).
+- `platforms`: Comma-separated string of platforms to build for (e.g., "linux/amd64,linux/arm64"). Defaults to "linux/amd64".
+
+## Notes
+- This job requires Docker Buildx and a compatible executor (the default architect executor supports this).
+- The build and push are performed in a single step for all tags and registries, improving efficiency and reducing duplication.
+- If your Dockerfile does not use the multi-arch pattern, the build will fail for non-matching architectures.
+- For single-arch images, set `platforms: linux/amd64` (the default).

--- a/docs/job/push-to-registries.md
+++ b/docs/job/push-to-registries.md
@@ -1,7 +1,8 @@
 # push-to-registries
 
 This job builds a container image and pushes it to a set of registries configured within the job itself.
-This way this job centralizes the management over image uploads and build process.
+This job is intended for classic single-architecture Dockerfiles, where a single binary is copied into the image (e.g., `COPY myapp /usr/local/bin/myapp`).
+
 It uses the `Dockerfile` found at the root of the workspace directory and the root directory as
 build context by default.
 Otherwise, it is possible to specify the Dockerfile and build context to use with `dockerfile` and `build-context` arguments respectively.
@@ -12,7 +13,7 @@ Otherwise, it is possible to specify the Dockerfile and build context to use wit
 
 Argument `tag-suffix` allows to specify a special suffix to be added after the generated container tag.
 
-Example usage:
+## Example usage
 
 ```yaml
 version: 2.1
@@ -23,15 +24,7 @@ workflows:
   my-workflow:
     jobs:
       - architect/push-to-registries:
-          context: architect
-          name: push-to-registries
-          requires:
-            # Make sure binary is built.
-            - go-build
-          filters:
-            # Trigger job also on git tag.
-            tags:
-              only: /^v.*/
+          image: myapp
 ```
 
 You might want to restrict the build of tags even further, by only building tags that are valid semver strings.

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -1,3 +1,22 @@
+# Command: go-build
+#
+# Builds a Go binary for a specified architecture and persists it to the workspace. If the architecture is set (e.g., linux/amd64), the binary will be named <binary>-<GOOS>-<GOARCH>. If the architecture is linux/amd64, a copy will also be made as <binary> for compatibility with legacy workflows.
+#
+# Parameters:
+#   binary: Name of the binary to produce (and to copy to if linux/amd64).
+#   os: (Deprecated) Use 'architecture' instead for multi-arch support.
+#   path: Path to the Go package to build (default: ".").
+#   pre_test_target: Makefile target to run before tests/lints (optional).
+#   tags: Additional Go build tags (optional).
+#   test_target: Makefile target to run for tests (optional).
+#   architecture: Target architecture (e.g., linux/amd64, linux/arm64, darwin/amd64). If set, will split into GOOS/GOARCH and name the binary accordingly. If not set, falls back to 'os' for legacy single-arch builds.
+#
+# Behavior:
+#   - Runs go-test first (with pre_test_target and test_target if set).
+#   - Builds the binary for the specified architecture.
+#   - If architecture is linux/amd64, also copies the binary to <binary>.
+#   - If architecture is not set, builds <binary> using the deprecated 'os' parameter.
+
 parameters:
   binary:
     type: "string"
@@ -21,6 +40,12 @@ parameters:
     description: |
       Executes the requested Makefile target.
     type: string
+  architecture:
+    default: "linux/amd64"
+    description: |
+      Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64").
+      This will be split into GOOS and GOARCH for the build. Example: "linux/amd64".
+    type: string
 steps:
   - go-test:
       path: <<parameters.path>>
@@ -29,4 +54,21 @@ steps:
   - run:
       name: Build binaries
       command: |
-        CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -tags "<< parameters.tags >>" -o << parameters.binary >> << parameters.path >>
+        if [[ -n "<< parameters.architecture >>" ]]; then
+          ARCH="<<parameters.architecture>>"
+          GOOS=$(echo $ARCH | cut -d'/' -f1)
+          GOARCH=$(echo $ARCH | cut -d'/' -f2)
+          binary_name="<< parameters.binary >>-${GOOS}-${GOARCH}"
+          LD_FLAGS=""
+          ldflags_file=".ldflags-${GOOS}-${GOARCH}"
+          if [ -f "$ldflags_file" ]; then
+            LD_FLAGS="$(cat "$ldflags_file")"
+          fi
+          CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LD_FLAGS" -tags "<< parameters.tags >>" -o "$binary_name" << parameters.path >>
+          # If linux/amd64, also create/copy to <<parameters.binary>>
+          if [[ "$GOOS" == "linux" && "$GOARCH" == "amd64" ]]; then
+            cp "$binary_name" "<< parameters.binary >>"
+          fi
+        else
+          CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -tags "<< parameters.tags >>" -o << parameters.binary >> << parameters.path >>
+        fi

--- a/src/commands/image-build-and-push-multiarch.yaml
+++ b/src/commands/image-build-and-push-multiarch.yaml
@@ -1,0 +1,125 @@
+parameters:
+  image:
+    type: string
+  tag-latest-branch:
+    type: string
+    default: ""
+  tag-suffix:
+    type: string
+    default: ""
+  build-context:
+    type: string
+    default: "."
+  dockerfile:
+    type: string
+    default: "./Dockerfile"
+  registries-data:
+    default: ""
+    description: |
+      A string that defines configuration for registries
+      Each line describes one registry using the following format
+      visibility registry username_envvar password_envvar push_dev_image
+    type: string
+  force-public:
+    type: boolean
+    default: false
+  platforms:
+    description: "Comma-separated string of platforms for multi-arch image build (e.g., 'linux/amd64,linux/arm64'). If not set, defaults to 'linux/amd64'."
+    type: string
+    default: "linux/amd64"
+steps:
+  - run:
+      name: Build and push multi-arch image to all registries
+      command: |
+        # Determine tag value from tag_envvar or fallback
+        TAG_VALUE="${DOCKER_IMAGE_TAG}"
+        tag_suffix="<<parameters.tag-suffix>>"
+        tag_latest_branch="<<parameters.tag-latest-branch>>"
+        platforms=$(IFS=,; echo "<<parameters.platforms>>")
+        # If image is forced to be pushed as a public one,
+        # we shouldn't check whether the source is public
+        # if repo is private, push to private only
+        # if repo is public or force-public is set push to public only
+        if [[ "<< parameters.force-public >>" = "true" ]]; then
+          echo -e "'force-public' flag is set, treating the image as public.\n"
+          IMAGE_ACCESS=public
+        else
+          GITHUB_API_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+          GITHUB_MESSAGE=$(curl -sL -H "Accept: application/vnd.github+json" -H "X-Github-Api-Version: 2022-11-28" "${GITHUB_API_URL}" | jq -r '.message')
+          if [[ "${GITHUB_MESSAGE}" = "Not Found" ]]; then
+            echo -e "The GitHub repository is not detected as public, treating the image as a private one.\n"
+            IMAGE_ACCESS=private
+          else
+            echo -e "The GitHub repository is detected as public, treating the image as a public one.\n"
+            IMAGE_ACCESS=public
+          fi
+        fi
+
+        if ! [[ -f .registries_data ]]; then
+          if [[ "<<parameters.registries-data>>" ]]; then
+            echo "Using registries data from the circle.ci job parameters."
+            REGISTRIES_DATA="<<parameters.registries-data>>"
+          else
+            echo "Using registries data from the circle.ci environment variable settings."
+            if ! [[ "${REGISTRIES_DATA_BASE64}" ]]; then
+              echo "Environment variable REGISTRIES_DATA_BASE64 is not set properly in circleci's context."
+              exit 1
+            fi
+            REGISTRIES_DATA=$(echo $REGISTRIES_DATA_BASE64 | base64 -d)
+          fi
+          echo "${REGISTRIES_DATA}" > .registries_data
+        fi
+
+        # Collect all tags
+        tags=("<<parameters.image>>:${TAG_VALUE}")
+        if [[ "$CIRCLE_BRANCH" == "$tag_latest_branch" ]]; then
+          tags+=("<<parameters.image>>:latest$tag_suffix")
+        fi
+        if [[ -n "$tag_suffix" ]]; then
+          tags+=("<<parameters.image>>:${TAG_VALUE}-$tag_suffix")
+        fi
+        # Prepare all registry/image:tag combinations
+        all_tags=()
+        while IFS=' ' read -r access reg _ _ push_dev; do
+          [[ -z "$reg" || "$reg" =~ ^# ]] && continue
+          if [[ "$push_dev" == "false" && "$TAG_VALUE" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "Not uploading image with tag $TAG_VALUE, as 'push-dev' is 'false'"
+            continue
+          fi
+          if [[ "$access" == *"$IMAGE_ACCESS"* ]]; then
+            for tag in "${tags[@]}"; do
+              echo -e "\nProcessing image push config for registry $reg."
+              echo "Tag the image for $reg"
+              echo "Preparing tag for $reg: <<parameters.image>>:${tag##*:}"
+              all_tags+=("--tag" "$reg/<<parameters.image>>:${tag##*:}")
+            done
+          else
+            echo "Registry $reg is not configured for $IMAGE_ACCESS images, skipping"
+          fi
+        done < .registries_data
+        if [[ ${#all_tags[@]} -eq 0 ]]; then
+          echo "No valid registry/tag combinations found for push. Exiting."
+          exit 1
+        fi
+        docker buildx create --use --name multiarch-builder 2>/dev/null || docker buildx use multiarch-builder
+        # Single buildx build/push for all tags/registries
+        SUCCESS=false
+        for i in {1..4}; do
+          echo "attempt: $i for all registries/tags"
+          if docker buildx build \
+            --platform "$platforms" \
+            "${all_tags[@]}" \
+            -f "<<parameters.dockerfile>>" \
+            "<<parameters.build-context>>" \
+            --push; then
+            echo "Image is pushed to all registries."
+            SUCCESS=true
+            break
+          fi
+          echo "Waiting 5 seconds before the next attempt."
+          sleep 5
+        done
+        if [[ "$SUCCESS" == "false" ]]; then
+          echo "Some images couldn't be pushed. Check buildx output above."
+          exit 1
+        fi

--- a/src/commands/image-push-to-registries.yaml
+++ b/src/commands/image-push-to-registries.yaml
@@ -70,7 +70,6 @@ steps:
             fi
             REGISTRIES_DATA=$(echo $REGISTRIES_DATA_BASE64 | base64 -d)
           fi
-
           echo "${REGISTRIES_DATA}" > .registries_data
         fi
 

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -6,15 +6,40 @@ description: |
 
   The job produces static binary named after the repository name. It is
   persisted to workspace under "./" path.
+#
+# Job: go-build
+#
+# This job runs go-test and then builds a Go binary for the specified architecture using the go-build command.
+# If the architecture is set (e.g., linux/amd64), the binary will be named <binary>-<GOOS>-<GOARCH> and, if linux/amd64, also as <binary>.
+# All produced binaries are persisted to the workspace.
+#
+# Parameters:
+#   binary: Name of the binary produced by the job. It is also persisted to the workspace.
+#   architecture: Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64"). Default: linux/amd64.
+#   os: (Deprecated) Use architecture instead for multi-arch support.
+#   path: Path where the Go package to build is located (default: ".").
+#   pre_test_target: Makefile target to run before lints and tests (optional).
+#   resource_class: CircleCI resource class for the job.
+#   test_target: Makefile target to run for tests (optional).
+#   tags: Additional Go build tags (optional).
+#
+# Behavior:
+#   - Runs go-build command with all parameters.
+#   - Persists all binaries (including multi-arch and default) to the workspace.
 parameters:
   binary:
     description: "Name of the binary produced by the job. It is also persisted to the workspace."
     type: "string"
+  architecture:
+    description: |
+      Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64").
+      This will be split into GOOS and GOARCH for the build. Example: "linux/amd64".
+    type: string
+    default: "linux/amd64"
   os:
+    description: "**Deprecated.** Use architecture instead for multi-arch support."
+    type: string
     default: "linux"
-    description: "The target Operating System for the binary. Must be one of \"linux\", \"darwin\"."
-    type: enum
-    enum: ["linux", "darwin"]
   path:
     default: "."
     description: |
@@ -53,11 +78,12 @@ steps:
       binary: << parameters.binary >>
       os: << parameters.os >>
       path: << parameters.path >>
-      pre_test_target: <<parameters.pre_test_target>>
+      pre_test_target: << parameters.pre_test_target >>
       tags: << parameters.tags >>
-      test_target: <<parameters.test_target>>
-  - go-cache-save
+      test_target: << parameters.test_target >>
+      architecture: << parameters.architecture >>
   - persist_to_workspace:
       root: .
       paths:
-        - ./<< parameters.binary >>
+        - ./<< parameters.binary >>*
+  - go-cache-save

--- a/src/jobs/push-to-registries-multiarch.yaml
+++ b/src/jobs/push-to-registries-multiarch.yaml
@@ -1,0 +1,75 @@
+# Multi-arch version of push-to-registries job
+description: "Build and push a multi-architecture container image to registries."
+executor: "architect"
+environment:
+  DOCKER_BUILDKIT: "1"
+resource_class: "<< parameters.resource_class >>"
+parameters:
+  image:
+    description: Name of the  container repository and image. Defaults to `giantswarm/REPO_NAME`. Must not contain registry host name!
+    type: string
+    default: "giantswarm/${CIRCLE_PROJECT_REPONAME}"
+  tag-latest-branch:
+    description: 'Name of the branch on which the image will be additionally tagged as "latest".'
+    type: string
+    default: main
+  resource_class:
+    default: small
+    description: |
+      Configures the amount of CPU and RAM for the job. See
+      https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+      for details.
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge"]
+  build-context:
+    type: string
+    default: "."
+  dockerfile:
+    type: string
+    default: "./Dockerfile"
+  git-tag-prefix:
+    type: string
+    default: ""
+  tag-suffix:
+    type: string
+    default: ""
+  force-public:
+    description: Skip the repo visibility check and push the the image to public registries
+    type: boolean
+    default: false
+  registries-data:
+    default: ""
+    type: string
+  platforms:
+    description: "Comma-separated string of platforms for multi-arch image build (e.g., 'linux/amd64,linux/arm64'). If not set, defaults to 'linux/amd64'."
+    type: string
+    default: "linux/amd64"
+steps:
+  - checkout
+  - setup_remote_docker:
+      version: default
+  - attach_workspace:
+      at: .
+  - run:
+      name: Set git tag prefix (empty if not set, only used on mono repos)
+      command: echo 'export GS_GIT_TAG_PREFIX="<<parameters.git-tag-prefix>>"' >> "$BASH_ENV"
+  - image-prepare-tag:
+      tag-suffix: <<parameters.tag-suffix>>
+  - image-login-to-registries:
+      registries-data: <<parameters.registries-data>>
+  - run:
+      name: Validate platforms parameter
+      command: |
+        if [ -z "<<parameters.platforms>>" ] || [[ ! "<<parameters.platforms>>" =~ ^[a-zA-Z0-9/_,-]+$ ]]; then
+          echo "ERROR: The 'platforms' parameter must be a non-empty, comma-separated list of valid platform strings (e.g., linux/amd64,linux/arm64)."
+          exit 1
+        fi
+  - image-build-and-push-multiarch:
+      image: <<parameters.image>>
+      build-context: <<parameters.build-context>>
+      dockerfile: <<parameters.dockerfile>>
+      force-public: <<parameters.force-public>>
+      tag-latest-branch: <<parameters.tag-latest-branch>>
+      tag-suffix: <<parameters.tag-suffix>>
+      registries-data: <<parameters.registries-data>>
+      platforms: <<parameters.platforms>>


### PR DESCRIPTION
This pull request introduces multi-architecture support for Go builds and container image workflows, enhancing flexibility and modernizing the pipeline. Key changes include the addition of new parameters and jobs to handle multi-architecture builds, deprecation of older parameters, and updates to documentation for clarity.

These changes ensure backward compatibility while enabling modern multi-architecture workflows for both Go builds and container image publishing.

## Checklist

- [ ] Make yourself familiar with following readme sections:
    - [ ] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [ ] [Development](https://github.com/giantswarm/architect-orb#development).
    - [ ] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [ ] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
