### PR TITLE
Test app-test-suite failure diagnostics output

### DIFF
--- a/src/jobs/run-tests-with-ats.yaml
+++ b/src/jobs/run-tests-with-ats.yaml
@@ -10,7 +10,7 @@ parameters:
   app-test-suite_container_tag:
     description: "Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite)"
     type: string
-    default: "0.12.0-276b493ab6840a31c92d4fabd177d0b4d689afed"
+    default: "0.12.0-290966046aae6447fbae3a1bf7860c699758cf02"
   additional_app-test-suite_flags:
     description: "Additional app-test-suite flags to use"
     type: string

--- a/src/jobs/run-tests-with-ats.yaml
+++ b/src/jobs/run-tests-with-ats.yaml
@@ -6,11 +6,11 @@ parameters:
   app-test-suite_version:
     description: "Version of app-test-suite dabs.sh container wrapper to use (git tag or commit)"
     type: string
-    default: "v0.10.6"
+    default: "add-diagnostic-output"
   app-test-suite_container_tag:
     description: "Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite)"
     type: string
-    default: "0.10.6"
+    default: "v0.12.0-4c692d16314738922ff85649ef61178b5dc5df71"
   additional_app-test-suite_flags:
     description: "Additional app-test-suite flags to use"
     type: string

--- a/src/jobs/run-tests-with-ats.yaml
+++ b/src/jobs/run-tests-with-ats.yaml
@@ -10,7 +10,7 @@ parameters:
   app-test-suite_container_tag:
     description: "Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite)"
     type: string
-    default: "v0.12.0-4c692d16314738922ff85649ef61178b5dc5df71"
+    default: "0.12.0-276b493ab6840a31c92d4fabd177d0b4d689afed"
   additional_app-test-suite_flags:
     description: "Additional app-test-suite flags to use"
     type: string


### PR DESCRIPTION
## Summary

- Points `run-tests-with-ats` job defaults to a dev build of app-test-suite from [giantswarm/app-test-suite#594](https://github.com/giantswarm/app-test-suite/pull/594)
- This allows testing the new failure diagnostics feature, which collects pod status, logs, events, and operator logs from the cluster when a test fails

## Changes

- `app-test-suite_version`: `v0.10.6` → `add-diagnostic-output` (downloads `dats.sh` from the PR branch)
- `app-test-suite_container_tag`: `0.10.6` → `v0.12.0-4c692d16314738922ff85649ef61178b5dc5df71` (dev image from the PR CI build)

## Test plan

- [ ] Use this orb branch from a repo with a failing ATS smoke test to verify diagnostics appear in CI logs
- [ ] Revert these defaults once app-test-suite#594 is released

**Do not merge** — this is a temporary testing branch. Close after validation.