### PR TITLE
Improve wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `push-to-registries-multiarch` job is deprecated. Use `push-to-registries` with `multiarch: true` instead. It will be removed in the next major version.
+
 ### Removed
 
 - Remove deprecated `run-kat-tests` job and related `kat-tests-install-tools` and `kat-tests-run` commands. The `kube-app-testing` tool is no longer maintained.
+
+### Changed
+
+- Improved wording and documentation for `goimports` step in `go-test` job
 
 ## [6.15.0] - 2026-03-12
 

--- a/docs/job/go-test.md
+++ b/docs/job/go-test.md
@@ -3,6 +3,7 @@
 This job:
 
 - Checks if Go modules are tidy.
+- Checks if Go code is formatted according to rules.
 - Checks if imports in .go files are properly sorted using `goimports`.
 - Checks if filenames contain non-ASCII characters.
 - Runs `go vet` against the codebase.

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -62,7 +62,7 @@ steps:
         echo "Found $non_ascii non-ASCII filenames in $checked files."
         exit $non_ascii
   - run:
-      name: Check if imports are properly sorted
+      name: Check if Go code is formatted according to goimports
       command: |
         go install golang.org/x/tools/cmd/goimports@latest && \
         if [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -l .) ]];


### PR DESCRIPTION
A nitpick. goimports is responsible for formatting entire .go files, despite the naming. It also sorts and groups imports.

"Check if imports are properly sorted" --> "Check if Go code is formatted according to goimports"