### PR TITLE
Add clone_depth param to go-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `multiarch`, `platforms`, and `annotations` parameters to `push-to-registries` job, enabling multi-architecture image builds via `docker buildx` as an opt-in path (`multiarch: true`). Single-arch behaviour is unchanged. `platforms` defaults to `"linux/amd64,linux/arm64"`.
+- Add `clone_depth` parameter to the `go-build` job. Defaults to `1` (preserves current behaviour). Set to `0` for full history when build steps need `git log` / `git rev-list` to traverse the whole repo (e.g. `go generate` that records the last commit touching a file). Any value greater than `1` deepens the history to that many commits.
 
 ### Deprecated
 

--- a/docs/job/go-build.md
+++ b/docs/job/go-build.md
@@ -18,6 +18,7 @@ This job builds Go binaries for one or more target architectures and operating s
 - `tags`: Additional Go build tags (optional).
 - `test_target`: Makefile target to run for tests (optional).
 - `resource_class`: CircleCI resource class for the job.
+- `clone_depth`: Number of commits to keep in the local git history after checkout (default: `1`). Use `0` for full history. Values greater than `1` deepen the history to that many commits. The default of `1` preserves the behaviour of CircleCI's built-in `checkout` step. Set to `0` when build steps rely on `git log` or `git rev-list` to traverse the repo (for example, a `go generate` step that embeds the commit SHA of the last change to a template file).
 
 ## Example usage
 

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -85,7 +85,7 @@ steps:
   - checkout
   - unless:
       condition:
-        equal: [ 1, << parameters.clone_depth >> ]
+        equal: [1, << parameters.clone_depth >>]
       steps:
         - run:
             name: Adjust git clone depth

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -22,6 +22,7 @@ description: |
 #   resource_class: CircleCI resource class for the job.
 #   test_target: Makefile target to run for tests (optional).
 #   tags: Additional Go build tags (optional).
+#   clone_depth: Number of commits to fetch after checkout. Default: 1 (current CircleCI default). Use 0 for full history.
 #
 # Behavior:
 #   - Runs go-build command with all parameters.
@@ -68,10 +69,33 @@ parameters:
     description: |
       Additional tags to include in -tags flag of go build.
     type: string
+  clone_depth:
+    default: 1
+    description: |
+      Number of commits to include in the local git history after checkout.
+      Use `0` for unlimited depth (unshallow). Values greater than `1` deepen
+      the history to that many commits. The default of `1` preserves the
+      current behaviour of CircleCI's built-in `checkout` step. Use `0` when
+      build steps (e.g. `go generate`) rely on `git log` / `git rev-list` to
+      find the last commit that touched a specific file.
+    type: integer
 executor: "architect"
 resource_class: "<< parameters.resource_class >>"
 steps:
   - checkout
+  - unless:
+      condition:
+        equal: [ 1, << parameters.clone_depth >> ]
+      steps:
+        - run:
+            name: Adjust git clone depth
+            command: |
+              depth="<< parameters.clone_depth >>"
+              if [[ "$depth" == "0" ]]; then
+                git fetch --tags --unshallow 2>/dev/null || git fetch --tags
+              else
+                git fetch --tags --depth="$depth"
+              fi
   - tools-info
   - go-cache-restore
   - go-build:


### PR DESCRIPTION
This PR adds the `clone_depth` parameter to the `go-build` job.

In some projects like `devctl` we need the full git commit history. This optional parameter enables that by setting `clone_depth: 0`. The default is 1.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
