### PR TITLE
fix(go-build): narrow workspace persist glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `go-build`: narrow the workspace persist glob from `./<binary>*` to `./<binary>` (legacy linux/amd64 / `os`-only path) plus `./<binary>-*-*` (multi-arch named binaries). The previous wildcard also captured unrelated repo files matching the binary prefix (e.g. `<binary>-manifest.yaml`), causing matrix multi-arch builds to fail at `attach_workspace` with "Concurrent upstream jobs persisted the same file(s)".
+- `go-build`: narrow the workspace persist glob from `./<binary>*` to `./<binary>-*-*` (multi-arch named binaries) plus `./<binary>` only on the linux/amd64 build. The previous wildcard also captured unrelated repo files matching the binary prefix (e.g. `<binary>-manifest.yaml`), causing matrix multi-arch builds to fail at `attach_workspace` with "Concurrent upstream jobs persisted the same file(s)".
 - Drop the duplicated `<version>-<suffix>-<suffix>` tag emitted by the multi-arch push when `tag-suffix` was set (the suffix is already baked into `DOCKER_IMAGE_TAG`).
 - Read the single `.ldflags` file (written by `go-test`) in the multi-arch `go-build` path. The previous lookup of `.ldflags-<GOOS>-<GOARCH>` always missed and silently dropped `gitSHA` / `buildTimestamp` from cross-compiled binaries.
 - Remove the unreachable legacy branch in `go-build` (the `architecture` default of `linux/amd64` made the `os`-based branch dead code). The `os` parameter is kept for backward compatibility but is now ignored; use `architecture` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `go-build`: narrow the workspace persist glob from `./<binary>*` to `./<binary>` (legacy linux/amd64 / `os`-only path) plus `./<binary>-*-*` (multi-arch named binaries). The previous wildcard also captured unrelated repo files matching the binary prefix (e.g. `<binary>-manifest.yaml`), causing matrix multi-arch builds to fail at `attach_workspace` with "Concurrent upstream jobs persisted the same file(s)".
+
 ## [8.0.0] - 2026-05-06
 
 ### Removed

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -106,8 +106,36 @@ steps:
       tags: << parameters.tags >>
       test_target: << parameters.test_target >>
       architecture: << parameters.architecture >>
-  - persist_to_workspace:
-      root: .
-      paths:
-        - ./<< parameters.binary >>*
+  # Persist only the binaries produced by go-build, not unrelated repo files
+  # that share the binary name as a prefix (e.g. `<binary>-manifest.yaml`).
+  # The previous `./<binary>*` glob caused matrix builds to fail with
+  # "Concurrent upstream jobs persisted the same file(s)" whenever such a
+  # file existed in the repo.
+  #
+  # `<binary>-*-*` matches `<binary>-<GOOS>-<GOARCH>` (no hyphens in GOOS or
+  # GOARCH) but not files with a single hyphen.
+  #
+  # The legacy `./<binary>` copy is only created on the linux/amd64 build
+  # (and on the deprecated `os`-only path), so we persist it conditionally.
+  - when:
+      condition:
+        or:
+          - equal: ["linux/amd64", << parameters.architecture >>]
+          - equal: ["", << parameters.architecture >>]
+      steps:
+        - persist_to_workspace:
+            root: .
+            paths:
+              - ./<< parameters.binary >>
+              - ./<< parameters.binary >>-*-*
+  - unless:
+      condition:
+        or:
+          - equal: ["linux/amd64", << parameters.architecture >>]
+          - equal: ["", << parameters.architecture >>]
+      steps:
+        - persist_to_workspace:
+            root: .
+            paths:
+              - ./<< parameters.binary >>-*-*
   - go-cache-save

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -110,32 +110,22 @@ steps:
   # that share the binary name as a prefix (e.g. `<binary>-manifest.yaml`).
   # The previous `./<binary>*` glob caused matrix builds to fail with
   # "Concurrent upstream jobs persisted the same file(s)" whenever such a
-  # file existed in the repo.
-  #
-  # `<binary>-*-*` matches `<binary>-<GOOS>-<GOARCH>` (no hyphens in GOOS or
-  # GOARCH) but not files with a single hyphen.
-  #
-  # The legacy `./<binary>` copy is only created on the linux/amd64 build
-  # (and on the deprecated `os`-only path), so we persist it conditionally.
+  # file existed in the repo. `<binary>-*-*` matches `<binary>-<GOOS>-<GOARCH>`
+  # (neither GOOS nor GOARCH contains a hyphen) but not files with a single
+  # hyphen.
+  - persist_to_workspace:
+      root: .
+      paths:
+        - ./<< parameters.binary >>-*-*
+  # The legacy `./<binary>` copy is only created on the linux/amd64 build,
+  # so persist it only there — otherwise the literal path would error in
+  # other matrix arms where the file does not exist.
   - when:
       condition:
-        or:
-          - equal: ["linux/amd64", << parameters.architecture >>]
-          - equal: ["", << parameters.architecture >>]
+        equal: ["linux/amd64", << parameters.architecture >>]
       steps:
         - persist_to_workspace:
             root: .
             paths:
               - ./<< parameters.binary >>
-              - ./<< parameters.binary >>-*-*
-  - unless:
-      condition:
-        or:
-          - equal: ["linux/amd64", << parameters.architecture >>]
-          - equal: ["", << parameters.architecture >>]
-      steps:
-        - persist_to_workspace:
-            root: .
-            paths:
-              - ./<< parameters.binary >>-*-*
   - go-cache-save


### PR DESCRIPTION
## Summary

The `go-build` job persists `./<binary>*` to the workspace. That glob also matches unrelated repo files sharing the binary name as a prefix (e.g. `<binary>-manifest.yaml`). When `go-build` runs as a matrix for multiple architectures, both matrix arms persist the same unrelated file, and `push-to-registries` fails at `attach_workspace`:

```
Concurrent upstream jobs persisted the same file(s) into the workspace:
  - <binary>-manifest.yaml
Error applying workspace layer ... Concurrent upstream jobs persisted the same file(s)
```

Hit while wiring multi-arch container builds in [giantswarm/helloworld#162](https://github.com/giantswarm/helloworld/pull/162) — the repo has a tracked `helloworld-manifest.yaml`.

## Fix

Narrow the persist glob:

- `./<binary>-*-*` is persisted unconditionally — it matches only `<binary>-<GOOS>-<GOARCH>` (GOOS/GOARCH never contain hyphens), not files with a single hyphen like `<binary>-manifest.yaml`.
- The legacy `./<binary>` copy is only created on the linux/amd64 build, so persist it only when `architecture == linux/amd64` — otherwise the literal path would error in non-amd64 matrix arms where the file does not exist.

Builds on top of #735, which removed the now-defunct `os`-only build path, so we no longer need to special-case empty `architecture`.

## Backward compatibility

- Default single-arch users (`architect/go-build` without `architecture` override → defaults to `linux/amd64`): still get `./<binary>` persisted. Unchanged.
- Multi-arch matrix users: each arm persists only its own arch-named binary; no overlap.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).