### PR TITLE
Fix multi-arch build & push regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Drop the duplicated `<version>-<suffix>-<suffix>` tag emitted by the multi-arch push when `tag-suffix` was set (the suffix is already baked into `DOCKER_IMAGE_TAG`).
+- Read the single `.ldflags` file (written by `go-test`) in the multi-arch `go-build` path. The previous lookup of `.ldflags-<GOOS>-<GOARCH>` always missed and silently dropped `gitSHA` / `buildTimestamp` from cross-compiled binaries.
+- Remove the unreachable legacy branch in `go-build` (the `architecture` default of `linux/amd64` made the `os`-based branch dead code). The `os` parameter is kept for backward compatibility but is now ignored; use `architecture` instead.
+- Fail loudly when the GitHub repository visibility check returns a non-200 status or an unparseable body. Previously a rate-limited or errored API response caused the image to be silently treated as private, skipping pushes to public registries.
+- Pin `setup_remote_docker` to `docker24` in `push-to-registries` and `push-to-registries-multiarch` to keep image builds reproducible across CircleCI default-version drift.
+
 ## [8.0.0] - 2026-05-06
 
 ### Removed

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -1,30 +1,30 @@
 # Command: go-build
 #
-# Builds a Go binary for a specified architecture and persists it to the workspace. If the architecture is set (e.g., linux/amd64),
-# the binary will be named <binary>-<GOOS>-<GOARCH>. If the architecture is linux/amd64, a copy will also be made as <binary> for
-# compatibility with legacy workflows.
+# Builds a Go binary for the architecture given by `architecture` and persists it to the workspace
+# as `<binary>-<GOOS>-<GOARCH>`. For linux/amd64 a copy is also written to `<binary>`.
 #
 # Parameters:
-#   binary: Name of the binary to produce (and to copy to if linux/amd64).
-#   os: (Deprecated) Use 'architecture' instead for multi-arch support.
+#   binary: Name of the binary to produce.
+#   architecture: Target architecture (e.g., linux/amd64, linux/arm64, darwin/amd64). Default: linux/amd64.
+#   os: **Deprecated.** Ignored.
 #   path: Path to the Go package to build (default: ".").
 #   pre_test_target: Makefile target to run before tests/lints (optional).
 #   tags: Additional Go build tags (optional).
 #   test_target: Makefile target to run for tests (optional).
-#   architecture: Target architecture (e.g., linux/amd64, linux/arm64, darwin/amd64). If set, will split into GOOS/GOARCH and name
-#                 the binary accordingly. If not set, falls back to 'os' for legacy single-arch builds.
 #
 # Behavior:
 #   - Runs go-test first (with pre_test_target and test_target if set).
 #   - Builds the binary for the specified architecture.
-#   - If architecture is linux/amd64, also copies the binary to <binary>.
-#   - If architecture is not set, builds <binary> using the deprecated 'os' parameter.
+#   - For linux/amd64, also copies the binary to <binary>.
 
 parameters:
   binary:
     type: "string"
   os:
     type: "string"
+    default: ""
+    description: |
+      **Deprecated.** Ignored. Use `architecture` instead.
   path:
     default: "."
     type: "string"
@@ -47,7 +47,8 @@ parameters:
     default: "linux/amd64"
     description: |
       Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64").
-      This will be split into GOOS and GOARCH for the build. Example: "linux/amd64".
+      Split into GOOS and GOARCH for the build. Produces `<binary>-<GOOS>-<GOARCH>`. For
+      `linux/amd64` a copy is also written to `<binary>` for backward compatibility.
     type: string
 steps:
   - go-test:
@@ -57,24 +58,19 @@ steps:
   - run:
       name: Build binaries
       command: |
-        if [[ -n "<< parameters.architecture >>" ]]; then
-          ARCH="<<parameters.architecture>>"
-          GOOS=$(echo $ARCH | cut -d'/' -f1)
-          GOARCH=$(echo $ARCH | cut -d'/' -f2)
-          binary_name="<< parameters.binary >>-${GOOS}-${GOARCH}"
-          LD_FLAGS="-s -w"
-          ldflags_file=".ldflags-${GOOS}-${GOARCH}"
+        ARCH="<<parameters.architecture>>"
+        GOOS="${ARCH%%/*}"
+        GOARCH="${ARCH##*/}"
+        binary_name="<< parameters.binary >>-${GOOS}-${GOARCH}"
 
-          if [ -f "$ldflags_file" ]; then
-            LD_FLAGS="$(cat "$ldflags_file")"
-          fi
+        LD_FLAGS="-s -w"
+        if [ -f .ldflags ]; then
+          LD_FLAGS="$(cat .ldflags)"
+        fi
 
-          CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LD_FLAGS" -tags "<< parameters.tags >>" -o "$binary_name" << parameters.path >>
+        CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LD_FLAGS" -tags "<< parameters.tags >>" -o "$binary_name" << parameters.path >>
 
-          # If linux/amd64, also create/copy to <<parameters.binary>>
-          if [[ "$GOOS" == "linux" && "$GOARCH" == "amd64" ]]; then
-            cp "$binary_name" "<< parameters.binary >>"
-          fi
-        else
-          CGO_ENABLED=0 GOOS="<< parameters.os >>" go build -ldflags "$(cat .ldflags)" -tags "<< parameters.tags >>" -o << parameters.binary >> << parameters.path >>
+        # If linux/amd64, also create/copy to <<parameters.binary>>
+        if [[ "$GOOS" == "linux" && "$GOARCH" == "amd64" ]]; then
+          cp "$binary_name" "<< parameters.binary >>"
         fi

--- a/src/commands/image-build-and-push-multiarch.yaml
+++ b/src/commands/image-build-and-push-multiarch.yaml
@@ -61,9 +61,23 @@ steps:
           IMAGE_ACCESS=public
         else
           GITHUB_API_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-          GITHUB_RESPONSE=$(curl -s -X GET -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" "${GITHUB_API_URL}")
+          HTTP_STATUS=$(curl -s -o /tmp/.gh_response -w "%{http_code}" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "${GITHUB_API_URL}")
 
-          REPO_PRIVATE=$(echo $GITHUB_RESPONSE | jq .private)
+          if [[ "${HTTP_STATUS}" != "200" ]]; then
+            echo "GitHub API call to ${GITHUB_API_URL} failed (HTTP ${HTTP_STATUS}):"
+            cat /tmp/.gh_response
+            exit 1
+          fi
+
+          REPO_PRIVATE=$(jq -r '.private' < /tmp/.gh_response)
+          if [[ "${REPO_PRIVATE}" != "true" && "${REPO_PRIVATE}" != "false" ]]; then
+            echo "Unexpected GitHub API response (could not parse .private):"
+            cat /tmp/.gh_response
+            exit 1
+          fi
 
           if [[ "${REPO_PRIVATE}" = "false" ]]; then
             echo -e "The GitHub repository is detected as public, treating the image as a public one.\n"
@@ -93,9 +107,6 @@ steps:
         tags=("<<parameters.image>>:${TAG_VALUE}")
         if [[ "$CIRCLE_BRANCH" == "$tag_latest_branch" ]]; then
           tags+=("<<parameters.image>>:latest$tag_suffix")
-        fi
-        if [[ -n "$tag_suffix" ]]; then
-          tags+=("<<parameters.image>>:${TAG_VALUE}-$tag_suffix")
         fi
 
         # Prepare all registry/image:tag combinations

--- a/src/commands/image-push-to-registries.yaml
+++ b/src/commands/image-push-to-registries.yaml
@@ -53,9 +53,23 @@ steps:
           IMAGE_ACCESS=public
         else
           GITHUB_API_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-          GITHUB_RESPONSE=$(curl -s -X GET -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" "${GITHUB_API_URL}")
+          HTTP_STATUS=$(curl -s -o /tmp/.gh_response -w "%{http_code}" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "${GITHUB_API_URL}")
 
-          REPO_PRIVATE=$(echo $GITHUB_RESPONSE | jq .private)
+          if [[ "${HTTP_STATUS}" != "200" ]]; then
+            echo "GitHub API call to ${GITHUB_API_URL} failed (HTTP ${HTTP_STATUS}):"
+            cat /tmp/.gh_response
+            exit 1
+          fi
+
+          REPO_PRIVATE=$(jq -r '.private' < /tmp/.gh_response)
+          if [[ "${REPO_PRIVATE}" != "true" && "${REPO_PRIVATE}" != "false" ]]; then
+            echo "Unexpected GitHub API response (could not parse .private):"
+            cat /tmp/.gh_response
+            exit 1
+          fi
 
           if [[ "${REPO_PRIVATE}" = "false" ]]; then
             echo -e "The GitHub repository is detected as public, treating the image as a public one.\n"

--- a/src/jobs/push-to-registries-multiarch.yaml
+++ b/src/jobs/push-to-registries-multiarch.yaml
@@ -58,7 +58,7 @@ parameters:
 steps:
   - checkout
   - setup_remote_docker:
-      version: default
+      version: docker24
   - attach_workspace:
       at: .
   - run:

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -69,7 +69,7 @@ parameters:
 steps:
   - checkout
   - setup_remote_docker:
-      version: default
+      version: docker24
   - attach_workspace:
       at: .
   - run:


### PR DESCRIPTION
## Summary

Five surgical fixes to the v8.0.x line. No behavior changes for callers other than `os:` on `go-build` (now ignored — was already documented as deprecated).

### Fixed

- **Tag-suffix double-append in multi-arch push.** `image-prepare-tag` already bakes `tag-suffix` into `DOCKER_IMAGE_TAG`; `image-build-and-push-multiarch` then emitted a third tag `${TAG_VALUE}-${tag_suffix}` producing e.g. `1.2.3-debug--debug`. Removed the redundant block — the kept tag list now matches the single-arch path (`image-push-to-registries`).
- **`.ldflags-<GOOS>-<GOARCH>` lookup in `go-build` always missed.** `go-test` writes a single arch-agnostic `.ldflags`; the multi-arch path looked for per-arch files that nothing produces and silently fell back to `-s -w`. Result: `gitSHA` and `buildTimestamp` were stamped into native builds but **not** into cross-compiled binaries. Now reads `.ldflags`.
- **Unreachable legacy branch in `go-build`.** `architecture` defaults to `linux/amd64`, so the `[[ -n "$architecture" ]]` guard was always true and the `os`-based branch was dead code. Removed it. The `os` parameter is kept (default `""`) for backward compatibility but explicitly ignored — it stays around until v9.
- **Silent failure on GitHub repo visibility check.** Both the multi-arch and single-arch push commands ran `jq .private` on the raw `curl` body. On 403 / 429 / 5xx the response is `{"message": "..."}` and `jq .private` returns `null`, which compares unequal to `"false"` so the image was treated as **private** — silently dropping pushes to public registries. Now: capture HTTP status separately, fail with the response body when status ≠ 200 or `.private` doesn't parse to a boolean. Mirrors the v6.15.0 fix already applied to `push-helm.yaml`.
- **`setup_remote_docker: version: default`** is unspecified — drifts with whatever CircleCI defaults to today. Pinned to `docker24` in `push-to-registries` and `push-to-registries-multiarch`. Bump deliberately when a newer version is needed.

Target version: v8.0.1 (patch — no API breakage).