### PR TITLE
Simplify multi-arch API: architectures list, auto-derive platforms, OCI labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `architectures` parameter on the `go-build` command and job: comma-separated list (e.g. `linux/amd64,linux/arm64`) that builds all targets in a single job, removing the need for a CircleCI matrix at the consumer. Writes the resolved list to `.platforms` in the workspace.
 - Auto-derive `platforms` in `push-to-registries` (and the legacy `push-to-registries-multiarch`) from the `.platforms` file written by `go-build`. The `platforms` parameter default is now `""` and falls back to `linux/amd64,linux/arm64` when neither an explicit value nor a workspace file is available — existing consumers see no behavior change.
-- Standard OCI image labels emitted by default in both single-arch (`docker build`) and multi-arch (`docker buildx build`) paths: `org.opencontainers.image.{source,revision,version,created}`. In multi-arch mode the same values are also emitted as OCI manifest index annotations.
+- Standard OCI image labels emitted by default in both single-arch (`docker build`) and multi-arch (`docker buildx build`) paths: `org.opencontainers.image.{source,revision,version,created}`. In multi-arch mode the same values are also emitted as OCI manifest index annotations. The `created` label is taken from the commit timestamp (`git show -s --format=%cI`) so rebuilds of the same SHA produce identical labels; the `version` label is omitted when no tag is available rather than emitting `unknown`.
 - `oci-labels` boolean parameter (default `true`) on `push-to-registries`, `push-to-registries-multiarch`, `image-build-with-docker`, and `image-build-and-push-multiarch` to opt out of the standard labels.
 
 ### Changed
 
 - `image-login-to-registries`: docker and regctl logins now pipe the password via stdin (`--password-stdin` / `--pass-stdin`) instead of building a shell command string. Drops the `eval`-based env-var resolution in the regctl branch in favour of bash indirect expansion.
 - `image-login-to-registries`: read the registries data file directly (`while read … done < .registries_data`) instead of piping through `cat`, so a failed login terminates the script instead of being trapped in a subshell.
+- `go-build`: validate the `architectures` parameter against `^[a-zA-Z0-9/_,-]+$` before splitting, matching the existing check on `platforms`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `architectures` parameter on the `go-build` command and job: comma-separated list (e.g. `linux/amd64,linux/arm64`) that builds all targets in a single job, removing the need for a CircleCI matrix at the consumer. Writes the resolved list to `.platforms` in the workspace.
+- Auto-derive `platforms` in `push-to-registries` (and the legacy `push-to-registries-multiarch`) from the `.platforms` file written by `go-build`. The `platforms` parameter default is now `""` and falls back to `linux/amd64,linux/arm64` when neither an explicit value nor a workspace file is available — existing consumers see no behavior change.
+- Standard OCI image labels emitted by default in both single-arch (`docker build`) and multi-arch (`docker buildx build`) paths: `org.opencontainers.image.{source,revision,version,created}`.
+
+### Changed
+
+- `image-login-to-registries`: docker and regctl logins now pipe the password via stdin (`--password-stdin` / `--pass-stdin`) instead of building a shell command string. Drops the `eval`-based env-var resolution in the regctl branch in favour of bash indirect expansion.
+
+### Deprecated
+
+- The `os` parameter on `go-build` is now ignored (kept for backward compatibility). Use `architectures` for multi-arch or `architecture` for single-arch matrix-based callers.
+
 ## [8.0.2] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `architectures` parameter on the `go-build` command and job: comma-separated list (e.g. `linux/amd64,linux/arm64`) that builds all targets in a single job, removing the need for a CircleCI matrix at the consumer. Writes the resolved list to `.platforms` in the workspace.
 - Auto-derive `platforms` in `push-to-registries` (and the legacy `push-to-registries-multiarch`) from the `.platforms` file written by `go-build`. The `platforms` parameter default is now `""` and falls back to `linux/amd64,linux/arm64` when neither an explicit value nor a workspace file is available — existing consumers see no behavior change.
-- Standard OCI image labels emitted by default in both single-arch (`docker build`) and multi-arch (`docker buildx build`) paths: `org.opencontainers.image.{source,revision,version,created}`.
+- Standard OCI image labels emitted by default in both single-arch (`docker build`) and multi-arch (`docker buildx build`) paths: `org.opencontainers.image.{source,revision,version,created}`. In multi-arch mode the same values are also emitted as OCI manifest index annotations.
+- `oci-labels` boolean parameter (default `true`) on `push-to-registries`, `push-to-registries-multiarch`, `image-build-with-docker`, and `image-build-and-push-multiarch` to opt out of the standard labels.
 
 ### Changed
 
 - `image-login-to-registries`: docker and regctl logins now pipe the password via stdin (`--password-stdin` / `--pass-stdin`) instead of building a shell command string. Drops the `eval`-based env-var resolution in the regctl branch in favour of bash indirect expansion.
+- `image-login-to-registries`: read the registries data file directly (`while read … done < .registries_data`) instead of piping through `cat`, so a failed login terminates the script instead of being trapped in a subshell.
+
+### Fixed
+
+- Drop the duplicated `<version>-<suffix>-<suffix>` tag emitted by the multi-arch push when `tag-suffix` was set (the suffix is already baked into `DOCKER_IMAGE_TAG`).
+- Read the single `.ldflags` file (written by `go-test`) in the multi-arch `go-build` path. The previous lookup of `.ldflags-<GOOS>-<GOARCH>` always missed and silently dropped `gitSHA` / `buildTimestamp` from cross-compiled binaries.
+- Remove the unreachable legacy branch in `go-build` (the `architecture` default of `linux/amd64` made the `os`-based branch dead code). The `os` parameter is kept for backward compatibility but is now ignored; use `architectures` instead.
+- Fail loudly when the GitHub repository visibility check returns a non-200 status or an unparseable body. Previously a rate-limited or errored API response caused the image to be silently treated as private, skipping pushes to public registries.
+- Pin `setup_remote_docker` to `docker24` in `push-to-registries` and `push-to-registries-multiarch` to keep image builds reproducible across CircleCI default-version drift.
+- `image-login-to-registries`: turn off shell xtrace before resolving registry credentials so passwords are no longer printed into CI logs by the `set -x` trace.
 
 ### Deprecated
 

--- a/docs/job/go-build.md
+++ b/docs/job/go-build.md
@@ -44,9 +44,9 @@ COPY myapp /usr/local/bin/myapp
 ENTRYPOINT ["/usr/local/bin/myapp"]
 ```
 
-### Multi-architecture (recommended — single job, `architectures` plural)
+### Multi-architecture
 
-Builds all listed architectures in one job and writes `.platforms` to the workspace. Downstream `push-to-registries` (with `multiarch: true`) auto-derives `--platform` from `.platforms`, so no platform list needs to be repeated.
+Use the `architectures` (plural) parameter to build all listed targets in one job. The job writes the resolved list to `.platforms`, and `push-to-registries` (with `multiarch: true`) auto-derives `--platform` from it — no platform list needs to be repeated.
 
 ```yaml
 version: 2.1
@@ -63,19 +63,13 @@ workflows:
           multiarch: true
 ```
 
-This is the simplest setup for the common case. Tests run once (not per arch), CircleCI startup overhead is paid once, and the platform list lives in one place.
+Tests run once (not per arch), CircleCI startup overhead is paid once, and the platform list lives in one place.
 
-### Multi-architecture (CircleCI matrix — singular `architecture`)
+#### Override: CircleCI matrix on singular `architecture`
 
-Matrix mode is still supported for callers that want each architecture to run on a different `resource_class`, or that already wire it up this way. Pass `platforms` explicitly to `push-to-registries` since matrix mode does not write `.platforms`.
+For callers that want each architecture to run on a different `resource_class`, or that already wire it up this way, the matrix form is still supported. Pass `platforms` explicitly since matrix mode does not write `.platforms`.
 
 ```yaml
-version: 2.1
-orbs:
-  architect: giantswarm/architect@x.y.z
-workflows:
-  build-multiarch:
-    jobs:
       - architect/go-build:
           matrix:
             parameters:

--- a/docs/job/go-build.md
+++ b/docs/job/go-build.md
@@ -67,7 +67,7 @@ This is the simplest setup for the common case. Tests run once (not per arch), C
 
 ### Multi-architecture (CircleCI matrix — singular `architecture`)
 
-Useful when you want each architecture to run on a different `resource_class` (for example, `arm.medium` to avoid QEMU when compiling inside the Dockerfile). Pass `platforms` explicitly to `push-to-registries`.
+Matrix mode is still supported for callers that want each architecture to run on a different `resource_class`, or that already wire it up this way. Pass `platforms` explicitly to `push-to-registries` since matrix mode does not write `.platforms`.
 
 ```yaml
 version: 2.1

--- a/docs/job/go-build.md
+++ b/docs/job/go-build.md
@@ -4,16 +4,18 @@ This job builds Go binaries for one or more target architectures and operating s
 
 **How it works:**
 - Runs `go-test` (with optional `pre_test_target` and `test_target`)
-- Builds the binary for the specified architecture using the `go-build` command
-- If `architecture` is set (e.g., linux/amd64), the binary will be named `<binary>-<GOOS>-<GOARCH>`. If the architecture is linux/amd64, a copy will also be made as `<binary>` for compatibility with legacy workflows.
-- All produced binaries are persisted to the workspace (using a wildcard pattern)
+- Builds the binary for one or more architectures using the `go-build` command
+- Each binary is named `<binary>-<GOOS>-<GOARCH>`. For `linux/amd64` a copy is also written to `<binary>` for backward compatibility.
+- When `architectures` (plural) is set, the resolved list is also written to `.platforms` in the workspace so downstream `push-to-registries` jobs can auto-derive `--platform`.
+- All produced binaries (and `.platforms`) are persisted to the workspace.
 
 ## Parameters
 
 - `binary`: Name of the output binary (required).
-- `architecture`: Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64"). Defaults to "linux/amd64". If set, will split into GOOS/GOARCH and name the binary accordingly. If linux/amd64, also copies to `<binary>`.
-- `os`: **Deprecated.** Use `architecture` instead for multi-arch support.
-- `path`: Path to the Go package to build (default: ".").
+- `architectures`: Comma-separated list of target architectures (e.g., `"linux/amd64,linux/arm64"`). When set, builds all listed targets in this single job and writes the list to `.platforms`. Takes precedence over `architecture`.
+- `architecture`: Single target architecture (e.g., `"linux/amd64"`). Default: `linux/amd64`. Kept for callers using a CircleCI matrix.
+- `os`: **Deprecated.** Ignored. Use `architectures` instead.
+- `path`: Path to the Go package to build (default: `"."`).
 - `pre_test_target`: Makefile target to run before tests/lints (optional).
 - `tags`: Additional Go build tags (optional).
 - `test_target`: Makefile target to run for tests (optional).
@@ -33,7 +35,6 @@ workflows:
     jobs:
       - architect/go-build:
           binary: myapp
-          architecture: "linux/amd64"
 ```
 
 Dockerfile example:
@@ -43,7 +44,9 @@ COPY myapp /usr/local/bin/myapp
 ENTRYPOINT ["/usr/local/bin/myapp"]
 ```
 
-### Multi-architecture (multiple jobs, different resource_class)
+### Multi-architecture (recommended — single job, `architectures` plural)
+
+Builds all listed architectures in one job and writes `.platforms` to the workspace. Downstream `push-to-registries` (with `multiarch: true`) auto-derives `--platform` from `.platforms`, so no platform list needs to be repeated.
 
 ```yaml
 version: 2.1
@@ -54,23 +57,17 @@ workflows:
     jobs:
       - architect/go-build:
           binary: myapp
-          architecture: "linux/amd64"
-          resource_class: medium
-      - architect/go-build:
-          binary: myapp
-          architecture: "linux/arm64"
-          resource_class: arm.medium
-      - architect/go-build:
-          binary: myapp
-          architecture: "darwin/amd64"
-          resource_class: macos.xlarge
+          architectures: "linux/amd64,linux/arm64"
+      - architect/push-to-registries:
+          requires: [architect/go-build]
+          multiarch: true
 ```
 
-This will run the `go-build` job in parallel for each architecture, and you can specify a different executor or resource_class for each if needed (e.g., to use ARM or macOS runners).
+This is the simplest setup for the common case. Tests run once (not per arch), CircleCI startup overhead is paid once, and the platform list lives in one place.
 
-### Multi-architecture (using CircleCI matrix, recommended for push-to-registries-multiarch)
+### Multi-architecture (CircleCI matrix — singular `architecture`)
 
-For best results and maintainability, we recommend using a CircleCI matrix to build all required architectures in parallel. This is especially useful when using `push-to-registries-multiarch`, as it ensures all binaries are built and available for the multi-arch image build step.
+Useful when you want each architecture to run on a different `resource_class` (for example, `arm.medium` to avoid QEMU when compiling inside the Dockerfile). Pass `platforms` explicitly to `push-to-registries`.
 
 ```yaml
 version: 2.1
@@ -84,21 +81,26 @@ workflows:
             parameters:
               architecture: ["linux/amd64", "linux/arm64"]
           binary: myapp
+      - architect/push-to-registries:
+          requires: [architect/go-build]
+          multiarch: true
+          platforms: "linux/amd64,linux/arm64"
 ```
-
-This approach is scalable and makes it easy to add or remove architectures. Each job runs in parallel, and you can use the `requires` field in your workflow to ensure all builds complete before running `push-to-registries-multiarch`.
-
-## Migrating from `os` to `architecture`
-
-The `os` parameter is now deprecated. For multi-arch builds, use the `architecture` parameter and run the job multiple times (once per architecture). For single-arch, you can omit `architecture` (defaults to `linux/amd64`).
 
 ## Preparing for multi-arch container images
 
-If you plan to use the output binaries in a multi-arch Docker image (see [`push-to-registries-multiarch`](./push-to-registries-multiarch.md)), ensure your Dockerfile uses the `TARGETPLATFORM` build argument to select the correct binary at build time. See the multi-arch Dockerfile example in the `push-to-registries-multiarch` documentation.
+If you plan to use the output binaries in a multi-arch Docker image (see [`push-to-registries`](./push-to-registries.md)), ensure your Dockerfile uses the `TARGETARCH` (or `TARGETPLATFORM`) build argument to select the correct binary at build time:
 
-- All referenced binaries (e.g., `myapp-linux-amd64`, `myapp-linux-arm64`) must be present in the workspace before the image build step.
+```dockerfile
+FROM gcr.io/distroless/static
+ARG TARGETARCH
+COPY myapp-linux-${TARGETARCH} /usr/local/bin/myapp
+ENTRYPOINT ["/usr/local/bin/myapp"]
+```
+
+All referenced binaries (e.g., `myapp-linux-amd64`, `myapp-linux-arm64`) must be present in the workspace before the image build step — `go-build` persists them automatically.
 
 ## Notes
-- Backward compatible: existing single-arch workflows do not need to change.
-- For classic single-arch Dockerfiles, use the default or specify a single architecture.
-- For true multi-arch images, use this job with multiple architectures and update your Dockerfile accordingly.
+- Backward compatible: existing single-arch and matrix-based workflows do not need to change.
+- For classic single-arch Dockerfiles, use the default or specify a single `architecture`.
+- For true multi-arch images, prefer `architectures` (plural) so the platform list is auto-discovered downstream.

--- a/docs/job/push-to-registries.md
+++ b/docs/job/push-to-registries.md
@@ -30,9 +30,9 @@ workflows:
           image: myapp
 ```
 
-### Multi-arch
+### Multi-arch (recommended — single `go-build` job)
 
-Use a CircleCI matrix to build all required architectures in parallel, then run the job with `multiarch: true` after all builds complete.
+Use the `architectures` (plural) parameter on `go-build` to build all targets in one job. The job writes `.platforms` to the workspace, and `push-to-registries` auto-derives `--platform` from it — no need to repeat the platform list.
 
 ```yaml
 version: 2.1
@@ -43,19 +43,41 @@ workflows:
   my-workflow:
     jobs:
       - architect/go-build:
+          binary: myapp
+          architectures: "linux/amd64,linux/arm64"
+      - architect/push-to-registries:
+          requires: [architect/go-build]
+          image: giantswarm/myapp
+          multiarch: true
+```
+
+### Multi-arch (CircleCI matrix)
+
+Useful when each architecture should run on a different `resource_class` (e.g., `arm.medium` to avoid QEMU when compiling inside the Dockerfile). Pass `platforms` explicitly since matrix mode does not write `.platforms`.
+
+```yaml
+workflows:
+  my-workflow:
+    jobs:
+      - architect/go-build:
           matrix:
             parameters:
               architecture: ["linux/amd64", "linux/arm64"]
           binary: myapp
       - architect/push-to-registries:
-          name: push-to-registries
-          requires:
-            - architect/go-build
+          requires: [architect/go-build]
           image: giantswarm/myapp
           multiarch: true
-          # platforms defaults to "linux/amd64,linux/arm64", so this can be omitted:
-          # platforms: "linux/amd64,linux/arm64"
+          platforms: "linux/amd64,linux/arm64"
 ```
+
+### Platform resolution order
+
+When `multiarch: true`, the platform list is resolved in this order:
+
+1. Explicit `platforms:` parameter (if non-empty).
+2. `.platforms` file in the workspace (written by `go-build` when `architectures` is set).
+3. Built-in default `linux/amd64,linux/arm64`.
 
 ### Multi-arch with OCI manifest annotations
 
@@ -136,6 +158,17 @@ The list of private registries is set as a parameter in the `image-push-to-regis
 
 If it's required to push an image that uses a private code to public registries, one can set the parameter `force-public` to true, then the whole check will be skipped and the image will be pushed to any registry.
 
+## OCI image labels
+
+By default, the job emits standard OCI image labels (and matching index annotations in multi-arch mode):
+
+- `org.opencontainers.image.source` — `https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}`
+- `org.opencontainers.image.revision` — `${CIRCLE_SHA1}`
+- `org.opencontainers.image.version` — the tag from `architect project version`
+- `org.opencontainers.image.created` — RFC 3339 build timestamp
+
+Set `oci-labels: false` to skip them.
+
 ## Migrating from `push-to-registries-multiarch`
 
 `push-to-registries-multiarch` is deprecated. Replace it with `push-to-registries` and add `multiarch: true`:
@@ -151,4 +184,4 @@ If it's required to push an image that uses a private code to public registries,
     multiarch: true
 ```
 
-The `platforms` parameter defaults to `"linux/amd64,linux/arm64"` in both jobs, so it does not need to be specified explicitly when migrating.
+The `platforms` parameter is auto-derived from `.platforms` (written by `go-build` when `architectures` is set), and falls back to `linux/amd64,linux/arm64` when neither is available — so it usually does not need to be specified.

--- a/docs/job/push-to-registries.md
+++ b/docs/job/push-to-registries.md
@@ -30,7 +30,7 @@ workflows:
           image: myapp
 ```
 
-### Multi-arch (recommended — single `go-build` job)
+### Multi-arch
 
 Use the `architectures` (plural) parameter on `go-build` to build all targets in one job. The job writes `.platforms` to the workspace, and `push-to-registries` auto-derives `--platform` from it — no need to repeat the platform list.
 
@@ -51,14 +51,11 @@ workflows:
           multiarch: true
 ```
 
-### Multi-arch (CircleCI matrix)
+#### Override: CircleCI matrix on singular `architecture`
 
-Matrix mode is still supported for callers that want each architecture to run on a different `resource_class`, or that already wire it up this way. Pass `platforms` explicitly since matrix mode does not write `.platforms`.
+For callers that want each architecture to run on a different `resource_class`, or that already wire it up this way, the matrix form is still supported. Pass `platforms` explicitly since matrix mode does not write `.platforms`.
 
 ```yaml
-workflows:
-  my-workflow:
-    jobs:
       - architect/go-build:
           matrix:
             parameters:

--- a/docs/job/push-to-registries.md
+++ b/docs/job/push-to-registries.md
@@ -53,7 +53,7 @@ workflows:
 
 ### Multi-arch (CircleCI matrix)
 
-Useful when each architecture should run on a different `resource_class` (e.g., `arm.medium` to avoid QEMU when compiling inside the Dockerfile). Pass `platforms` explicitly since matrix mode does not write `.platforms`.
+Matrix mode is still supported for callers that want each architecture to run on a different `resource_class`, or that already wire it up this way. Pass `platforms` explicitly since matrix mode does not write `.platforms`.
 
 ```yaml
 workflows:

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -1,11 +1,18 @@
 # Command: go-build
 #
-# Builds a Go binary for the architecture given by `architecture` and persists it to the workspace
-# as `<binary>-<GOOS>-<GOARCH>`. For linux/amd64 a copy is also written to `<binary>`.
+# Builds Go binaries for one or more target architectures and persists them to the workspace.
+# Each binary is named `<binary>-<GOOS>-<GOARCH>`. For linux/amd64 a copy is also written to
+# `<binary>` for backward compatibility.
+#
+# When `architectures` (plural, comma-separated) is set, all listed targets are built in this
+# single job (no matrix needed) and the list is written to `.platforms` in the workspace so
+# downstream `push-to-registries` jobs can auto-derive `--platform`.
 #
 # Parameters:
 #   binary: Name of the binary to produce.
-#   architecture: Target architecture (e.g., linux/amd64, linux/arm64, darwin/amd64). Default: linux/amd64.
+#   architectures: Comma-separated list of target architectures (e.g.,
+#       "linux/amd64,linux/arm64,darwin/amd64"). Takes precedence over `architecture` when set.
+#   architecture: Single target architecture (e.g., linux/amd64). Kept for matrix-based callers.
 #   os: **Deprecated.** Ignored.
 #   path: Path to the Go package to build (default: ".").
 #   pre_test_target: Makefile target to run before tests/lints (optional).
@@ -14,7 +21,9 @@
 #
 # Behavior:
 #   - Runs go-test first (with pre_test_target and test_target if set).
-#   - Builds the binary for the specified architecture.
+#   - If `architectures` is set: loops over each entry, builds `<binary>-<GOOS>-<GOARCH>`, and
+#     writes the architecture list to `.platforms`.
+#   - Otherwise: builds the single `architecture` target.
 #   - For linux/amd64, also copies the binary to <binary>.
 
 parameters:
@@ -24,7 +33,7 @@ parameters:
     type: "string"
     default: ""
     description: |
-      **Deprecated.** Ignored. Use `architecture` instead.
+      **Deprecated.** Ignored. Use `architectures` (plural) instead.
   path:
     default: "."
     type: "string"
@@ -46,9 +55,15 @@ parameters:
   architecture:
     default: "linux/amd64"
     description: |
-      Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64").
-      Split into GOOS and GOARCH for the build. Produces `<binary>-<GOOS>-<GOARCH>`. For
-      `linux/amd64` a copy is also written to `<binary>` for backward compatibility.
+      Single target architecture for Go build (e.g., "linux/amd64"). Kept for callers using
+      a CircleCI matrix. For multi-arch builds in one job, prefer `architectures`.
+    type: string
+  architectures:
+    default: ""
+    description: |
+      Comma-separated list of target architectures to build in this job (e.g.,
+      "linux/amd64,linux/arm64"). When set, takes precedence over `architecture` and writes
+      `.platforms` to the workspace for downstream auto-discovery in `push-to-registries`.
     type: string
 steps:
   - go-test:
@@ -58,19 +73,38 @@ steps:
   - run:
       name: Build binaries
       command: |
-        ARCH="<<parameters.architecture>>"
-        GOOS="${ARCH%%/*}"
-        GOARCH="${ARCH##*/}"
-        binary_name="<< parameters.binary >>-${GOOS}-${GOARCH}"
-
         LD_FLAGS="-s -w"
         if [ -f .ldflags ]; then
           LD_FLAGS="$(cat .ldflags)"
         fi
 
-        CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LD_FLAGS" -tags "<< parameters.tags >>" -o "$binary_name" << parameters.path >>
+        build_one() {
+          local arch="$1"
+          local goos="${arch%%/*}"
+          local goarch="${arch##*/}"
+          local binary_name="<<parameters.binary>>-${goos}-${goarch}"
 
-        # If linux/amd64, also create/copy to <<parameters.binary>>
-        if [[ "$GOOS" == "linux" && "$GOARCH" == "amd64" ]]; then
-          cp "$binary_name" "<< parameters.binary >>"
+          echo "Building ${binary_name}..."
+          CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build -ldflags "$LD_FLAGS" -tags "<<parameters.tags>>" -o "$binary_name" "<<parameters.path>>"
+
+          # If linux/amd64, also create/copy to <<parameters.binary>>
+          if [[ "$goos" == "linux" && "$goarch" == "amd64" ]]; then
+            cp "$binary_name" "<<parameters.binary>>"
+          fi
+        }
+
+        # .platforms is written only in plural mode. In singular/matrix mode it stays empty so
+        # downstream auto-derive falls back to its built-in default.
+        : > .platforms
+        architectures="<<parameters.architectures>>"
+        if [[ -n "$architectures" ]]; then
+          # Replace commas with spaces; bash word-splitting handles the rest.
+          for raw in ${architectures//,/ }; do
+            arch="$(echo "$raw" | tr -d '[:space:]')"
+            [[ -z "$arch" ]] && continue
+            build_one "$arch"
+            echo "$arch" >> .platforms
+          done
+        else
+          build_one "<<parameters.architecture>>"
         fi

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -98,6 +98,10 @@ steps:
         : > .platforms
         architectures="<<parameters.architectures>>"
         if [[ -n "$architectures" ]]; then
+          if [[ ! "$architectures" =~ ^[a-zA-Z0-9/_,-]+$ ]]; then
+            echo "ERROR: 'architectures' must be a comma-separated list of GOOS/GOARCH pairs (e.g., linux/amd64,linux/arm64)."
+            exit 1
+          fi
           # Replace commas with spaces; bash word-splitting handles the rest.
           for raw in ${architectures//,/ }; do
             arch="$(echo "$raw" | tr -d '[:space:]')"

--- a/src/commands/image-build-and-push-multiarch.yaml
+++ b/src/commands/image-build-and-push-multiarch.yaml
@@ -24,9 +24,13 @@ parameters:
     type: boolean
     default: false
   platforms:
-    description: "Comma-separated string of platforms for multi-arch image build (e.g., 'linux/amd64,linux/arm64'). If not set, defaults to 'linux/amd64,linux/arm64'."
+    description: |
+      Comma-separated list of platforms for multi-arch image build (e.g.,
+      'linux/amd64,linux/arm64'). When empty, the list is auto-derived from the `.platforms`
+      file written by `go-build` to the workspace. Falls back to 'linux/amd64,linux/arm64'
+      if neither is available.
     type: string
-    default: "linux/amd64,linux/arm64"
+    default: ""
   annotations:
     description: |
       Newline-separated OCI annotations passed to 'docker buildx build --annotation'.
@@ -50,7 +54,19 @@ steps:
         TAG_VALUE="${DOCKER_IMAGE_TAG}"
         tag_suffix="<<parameters.tag-suffix>>"
         tag_latest_branch="<<parameters.tag-latest-branch>>"
-        platforms=$(IFS=,; echo "<<parameters.platforms>>")
+
+        # Resolve platforms: explicit param > .platforms in workspace > built-in default
+        platforms="<<parameters.platforms>>"
+        if [[ -z "$platforms" && -f .platforms ]]; then
+          platforms=$(paste -sd, .platforms | tr -d '[:space:]')
+        fi
+        if [[ -z "$platforms" ]]; then
+          platforms="linux/amd64,linux/arm64"
+        fi
+        echo "Building for platforms: $platforms"
+
+        oci_source="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+        oci_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
         # If image is forced to be pushed as a public one,
         # we shouldn't check whether the source is public
@@ -158,6 +174,10 @@ steps:
             --platform "$platforms" \
             "${all_tags[@]}" \
             "${annotation_flags[@]}" \
+            --label "org.opencontainers.image.source=${oci_source}" \
+            --label "org.opencontainers.image.revision=${CIRCLE_SHA1}" \
+            --label "org.opencontainers.image.version=${TAG_VALUE}" \
+            --label "org.opencontainers.image.created=${oci_created}" \
             -f "<<parameters.dockerfile>>" \
             "<<parameters.build-context>>" \
             --progress=plain \

--- a/src/commands/image-build-and-push-multiarch.yaml
+++ b/src/commands/image-build-and-push-multiarch.yaml
@@ -75,18 +75,23 @@ steps:
         oci_label_flags=()
         if [[ "<<parameters.oci-labels>>" == "true" ]]; then
           oci_source="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-          oci_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          oci_version="${TAG_VALUE:-unknown}"
+          # Prefer the commit timestamp so rebuilds of the same SHA produce identical labels.
+          oci_created="$(git show -s --format=%cI "$CIRCLE_SHA1" 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
+          oci_version="${TAG_VALUE:-}"
           oci_label_flags+=(
             --label "org.opencontainers.image.source=${oci_source}"
             --label "org.opencontainers.image.revision=${CIRCLE_SHA1}"
-            --label "org.opencontainers.image.version=${oci_version}"
             --label "org.opencontainers.image.created=${oci_created}"
             --annotation "index:org.opencontainers.image.source=${oci_source}"
             --annotation "index:org.opencontainers.image.revision=${CIRCLE_SHA1}"
-            --annotation "index:org.opencontainers.image.version=${oci_version}"
             --annotation "index:org.opencontainers.image.created=${oci_created}"
           )
+          if [[ -n "$oci_version" ]]; then
+            oci_label_flags+=(
+              --label "org.opencontainers.image.version=${oci_version}"
+              --annotation "index:org.opencontainers.image.version=${oci_version}"
+            )
+          fi
         fi
 
         # If image is forced to be pushed as a public one,

--- a/src/commands/image-build-and-push-multiarch.yaml
+++ b/src/commands/image-build-and-push-multiarch.yaml
@@ -41,6 +41,13 @@ parameters:
         key=value (no prefix)         - defaults to index for multi-platform builds
     type: string
     default: ""
+  oci-labels:
+    description: |
+      Emit standard OCI image labels and matching index annotations
+      (org.opencontainers.image.{source,revision,version,created}) derived from the
+      CircleCI build context.
+    type: boolean
+    default: true
   split-china-push:
     description: Use self-hosted CircleCI runner in China for pushing image to Aliyun.
     type: boolean
@@ -65,8 +72,22 @@ steps:
         fi
         echo "Building for platforms: $platforms"
 
-        oci_source="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-        oci_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        oci_label_flags=()
+        if [[ "<<parameters.oci-labels>>" == "true" ]]; then
+          oci_source="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+          oci_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          oci_version="${TAG_VALUE:-unknown}"
+          oci_label_flags+=(
+            --label "org.opencontainers.image.source=${oci_source}"
+            --label "org.opencontainers.image.revision=${CIRCLE_SHA1}"
+            --label "org.opencontainers.image.version=${oci_version}"
+            --label "org.opencontainers.image.created=${oci_created}"
+            --annotation "index:org.opencontainers.image.source=${oci_source}"
+            --annotation "index:org.opencontainers.image.revision=${CIRCLE_SHA1}"
+            --annotation "index:org.opencontainers.image.version=${oci_version}"
+            --annotation "index:org.opencontainers.image.created=${oci_created}"
+          )
+        fi
 
         # If image is forced to be pushed as a public one,
         # we shouldn't check whether the source is public
@@ -174,10 +195,7 @@ steps:
             --platform "$platforms" \
             "${all_tags[@]}" \
             "${annotation_flags[@]}" \
-            --label "org.opencontainers.image.source=${oci_source}" \
-            --label "org.opencontainers.image.revision=${CIRCLE_SHA1}" \
-            --label "org.opencontainers.image.version=${TAG_VALUE}" \
-            --label "org.opencontainers.image.created=${oci_created}" \
+            "${oci_label_flags[@]}" \
             -f "<<parameters.dockerfile>>" \
             "<<parameters.build-context>>" \
             --progress=plain \

--- a/src/commands/image-build-with-docker.yaml
+++ b/src/commands/image-build-with-docker.yaml
@@ -5,17 +5,30 @@ parameters:
   dockerfile:
     type: "string"
     default: "./Dockerfile"
+  oci-labels:
+    description: |
+      Emit standard OCI image labels (org.opencontainers.image.{source,revision,version,created})
+      derived from the CircleCI build context.
+    type: boolean
+    default: true
 steps:
   - run:
       name: Build the container image using 'docker build'
       command: |
-        oci_source="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-        oci_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        label_flags=()
+        if [[ "<<parameters.oci-labels>>" == "true" ]]; then
+          oci_source="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+          oci_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          oci_version="${DOCKER_IMAGE_TAG:-unknown}"
+          label_flags+=(
+            --label "org.opencontainers.image.source=${oci_source}"
+            --label "org.opencontainers.image.revision=${CIRCLE_SHA1}"
+            --label "org.opencontainers.image.version=${oci_version}"
+            --label "org.opencontainers.image.created=${oci_created}"
+          )
+        fi
         docker build \
-          --label "org.opencontainers.image.source=${oci_source}" \
-          --label "org.opencontainers.image.revision=${CIRCLE_SHA1}" \
-          --label "org.opencontainers.image.version=${DOCKER_IMAGE_TAG}" \
-          --label "org.opencontainers.image.created=${oci_created}" \
+          "${label_flags[@]}" \
           -f "<<parameters.dockerfile>>" \
           "<<parameters.build-context>>" \
           --progress plain 2>&1 | tee .docker.log

--- a/src/commands/image-build-with-docker.yaml
+++ b/src/commands/image-build-with-docker.yaml
@@ -9,7 +9,16 @@ steps:
   - run:
       name: Build the container image using 'docker build'
       command: |
-        docker build -f "<<parameters.dockerfile>>" "<<parameters.build-context>>" --progress plain 2>&1 | tee .docker.log
+        oci_source="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+        oci_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        docker build \
+          --label "org.opencontainers.image.source=${oci_source}" \
+          --label "org.opencontainers.image.revision=${CIRCLE_SHA1}" \
+          --label "org.opencontainers.image.version=${DOCKER_IMAGE_TAG}" \
+          --label "org.opencontainers.image.created=${oci_created}" \
+          -f "<<parameters.dockerfile>>" \
+          "<<parameters.build-context>>" \
+          --progress plain 2>&1 | tee .docker.log
   - run:
       name: Save container image SHA256 to temp file
       command: |

--- a/src/commands/image-build-with-docker.yaml
+++ b/src/commands/image-build-with-docker.yaml
@@ -18,14 +18,17 @@ steps:
         label_flags=()
         if [[ "<<parameters.oci-labels>>" == "true" ]]; then
           oci_source="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-          oci_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          oci_version="${DOCKER_IMAGE_TAG:-unknown}"
+          # Prefer the commit timestamp so rebuilds of the same SHA produce identical labels.
+          oci_created="$(git show -s --format=%cI "$CIRCLE_SHA1" 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
+          oci_version="${DOCKER_IMAGE_TAG:-}"
           label_flags+=(
             --label "org.opencontainers.image.source=${oci_source}"
             --label "org.opencontainers.image.revision=${CIRCLE_SHA1}"
-            --label "org.opencontainers.image.version=${oci_version}"
             --label "org.opencontainers.image.created=${oci_created}"
           )
+          if [[ -n "$oci_version" ]]; then
+            label_flags+=(--label "org.opencontainers.image.version=${oci_version}")
+          fi
         fi
         docker build \
           "${label_flags[@]}" \

--- a/src/commands/image-login-to-registries.yaml
+++ b/src/commands/image-login-to-registries.yaml
@@ -39,21 +39,30 @@ steps:
 
         echo "${REGISTRIES_DATA}" > .registries_data
         cat .registries_data | while read -r _ reg username password _; do
+          # Validate env-var names (defence against malicious registries-data input).
+          case "$username" in *[!a-zA-Z0-9_]*) echo "Invalid username variable name: $username"; exit 1 ;; esac
+          case "$password" in *[!a-zA-Z0-9_]*) echo "Invalid password variable name: $password"; exit 1 ;; esac
+
+          username_val="${!username}"
+          password_val="${!password}"
+
           if [[ "<<parameters.client>>" == "docker" ]]; then
-            CMD="docker login $reg --username '${!username}' --password '${!password}'"
-            for i in {1..3}; do [[ $i -gt 1 ]] && sleep 1;  bash -c "${CMD}" && s=0 && break || s=$?; done; (exit $s)
+            for i in 1 2 3; do
+              [[ $i -gt 1 ]] && sleep 1
+              if printf '%s' "$password_val" | docker login "$reg" --username "$username_val" --password-stdin; then
+                s=0; break
+              fi
+              s=$?
+            done
+            (exit $s)
           elif [[ "<<parameters.client>>" == "regctl" ]]; then
-            case "$username" in
-            *[!a-zA-Z0-9_]*) echo "Invalid variable name"; exit 1 ;;
-            *) eval "username=\$$username" ;;
-            esac
-
-            case "$password" in
-            *[!a-zA-Z0-9_]*) echo "Invalid variable name"; exit 1 ;;
-            *) eval "password=\$$password" ;;
-            esac
-
-            CMD="regctl registry login $reg -u '${username}' -p '${password}'"
-            for i in $(seq 1 3); do [[ $i -gt 1 ]] && sleep 1;  sh -c "${CMD}" && s=0 && break || s=$?; done; (exit $s)
+            for i in 1 2 3; do
+              [[ $i -gt 1 ]] && sleep 1
+              if printf '%s' "$password_val" | regctl registry login "$reg" -u "$username_val" --pass-stdin; then
+                s=0; break
+              fi
+              s=$?
+            done
+            (exit $s)
           fi
         done

--- a/src/commands/image-login-to-registries.yaml
+++ b/src/commands/image-login-to-registries.yaml
@@ -38,7 +38,14 @@ steps:
         fi
 
         echo "${REGISTRIES_DATA}" > .registries_data
-        cat .registries_data | while read -r _ reg username password _; do
+
+        # Disable xtrace before resolving credentials so passwords don't leak into CI logs.
+        set +x
+
+        # Read the file directly (no pipe) so the loop runs in the current shell and a failed
+        # login terminates the script, instead of being trapped in a subshell.
+        rc=0
+        while read -r _ reg username password _; do
           # Validate env-var names (defence against malicious registries-data input).
           case "$username" in *[!a-zA-Z0-9_]*) echo "Invalid username variable name: $username"; exit 1 ;; esac
           case "$password" in *[!a-zA-Z0-9_]*) echo "Invalid password variable name: $password"; exit 1 ;; esac
@@ -54,7 +61,6 @@ steps:
               fi
               s=$?
             done
-            (exit $s)
           elif [[ "<<parameters.client>>" == "regctl" ]]; then
             for i in 1 2 3; do
               [[ $i -gt 1 ]] && sleep 1
@@ -63,6 +69,7 @@ steps:
               fi
               s=$?
             done
-            (exit $s)
           fi
-        done
+          [[ "$s" -ne 0 ]] && rc=$s
+        done < .registries_data
+        exit "$rc"

--- a/src/commands/image-login-to-registries.yaml
+++ b/src/commands/image-login-to-registries.yaml
@@ -46,6 +46,8 @@ steps:
         # login terminates the script, instead of being trapped in a subshell.
         rc=0
         while read -r _ reg username password _; do
+          # Default to success so misconfigured client values don't leave $s unset.
+          s=0
           # Validate env-var names (defence against malicious registries-data input).
           case "$username" in *[!a-zA-Z0-9_]*) echo "Invalid username variable name: $username"; exit 1 ;; esac
           case "$password" in *[!a-zA-Z0-9_]*) echo "Invalid password variable name: $password"; exit 1 ;; esac

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -9,14 +9,18 @@ description: |
 #
 # Job: go-build
 #
-# This job runs go-test and then builds a Go binary for the specified architecture using the go-build command.
-# If the architecture is set (e.g., linux/amd64), the binary will be named <binary>-<GOOS>-<GOARCH> and, if linux/amd64, also as <binary>.
-# All produced binaries are persisted to the workspace.
+# This job runs go-test and then builds Go binaries for one or more architectures.
+# When `architectures` (plural, comma-separated) is set, all listed targets are built in this
+# single job and the list is written to `.platforms` in the workspace so downstream
+# `push-to-registries` jobs can auto-derive `--platform`. Otherwise the singular `architecture`
+# parameter is used (suitable for matrix-based callers).
 #
 # Parameters:
 #   binary: Name of the binary produced by the job. It is also persisted to the workspace.
-#   architecture: Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64"). Default: linux/amd64.
-#   os: (Deprecated) Use architecture instead for multi-arch support.
+#   architectures: Comma-separated list of target architectures (e.g.,
+#       "linux/amd64,linux/arm64"). Takes precedence over `architecture` when set.
+#   architecture: Single target architecture for Go build (e.g., "linux/amd64"). Default: linux/amd64.
+#   os: (Deprecated) Ignored.
 #   path: Path where the Go package to build is located (default: ".").
 #   pre_test_target: Makefile target to run before lints and tests (optional).
 #   resource_class: CircleCI resource class for the job.
@@ -27,20 +31,28 @@ description: |
 # Behavior:
 #   - Runs go-build command with all parameters.
 #   - Persists all binaries (including multi-arch and default) to the workspace.
+#   - When `architectures` is set, also persists `.platforms` for downstream auto-discovery.
 parameters:
   binary:
     description: "Name of the binary produced by the job. It is also persisted to the workspace."
     type: "string"
+  architectures:
+    description: |
+      Comma-separated list of target architectures to build in this single job (e.g.,
+      "linux/amd64,linux/arm64"). When set, takes precedence over `architecture` and writes
+      `.platforms` to the workspace for downstream auto-discovery in `push-to-registries`.
+    type: string
+    default: ""
   architecture:
     description: |
-      Target architecture for Go build (e.g., "linux/amd64", "linux/arm64", or "darwin/amd64").
-      This will be split into GOOS and GOARCH for the build. Example: "linux/amd64".
+      Single target architecture for Go build (e.g., "linux/amd64"). Kept for callers using
+      a CircleCI matrix. For multi-arch builds in one job, prefer `architectures`.
     type: string
     default: "linux/amd64"
   os:
-    description: "**Deprecated.** Use architecture instead for multi-arch support."
+    description: "**Deprecated.** Ignored. Use `architectures` instead."
     type: string
-    default: "linux"
+    default: ""
   path:
     default: "."
     description: |
@@ -106,6 +118,7 @@ steps:
       tags: << parameters.tags >>
       test_target: << parameters.test_target >>
       architecture: << parameters.architecture >>
+      architectures: << parameters.architectures >>
   # Persist only the binaries produced by go-build, not unrelated repo files
   # that share the binary name as a prefix (e.g. `<binary>-manifest.yaml`).
   # The previous `./<binary>*` glob caused matrix builds to fail with
@@ -128,4 +141,14 @@ steps:
             root: .
             paths:
               - ./<< parameters.binary >>
+  # `.platforms` is only written in plural-mode (`architectures` non-empty),
+  # which runs as a single job, so persisting it then avoids the matrix
+  # "Concurrent upstream jobs persisted the same file(s)" failure.
+  - when:
+      condition: << parameters.architectures >>
+      steps:
+        - persist_to_workspace:
+            root: .
+            paths:
+              - ./.platforms
   - go-cache-save

--- a/src/jobs/push-to-registries-multiarch.yaml
+++ b/src/jobs/push-to-registries-multiarch.yaml
@@ -42,9 +42,12 @@ parameters:
     default: ""
     type: string
   platforms:
-    description: "Comma-separated string of platforms for multi-arch image build (e.g., 'linux/amd64,linux/arm64'). If not set, defaults to 'linux/amd64,linux/arm64'."
+    description: |
+      Comma-separated list of platforms for multi-arch image build. When empty, the list is
+      auto-derived from the `.platforms` file written by `go-build` to the workspace. Falls
+      back to `linux/amd64,linux/arm64` if neither is available.
     type: string
-    default: "linux/amd64,linux/arm64"
+    default: ""
   annotations:
     description: |
       Newline-separated OCI annotations passed to 'docker buildx build --annotation'.
@@ -71,8 +74,8 @@ steps:
   - run:
       name: Validate platforms parameter
       command: |
-        if [ -z "<<parameters.platforms>>" ] || [[ ! "<<parameters.platforms>>" =~ ^[a-zA-Z0-9/_,-]+$ ]]; then
-          echo "ERROR: The 'platforms' parameter must be a non-empty, comma-separated list of valid platform strings (e.g., linux/amd64,linux/arm64)."
+        if [ -n "<<parameters.platforms>>" ] && [[ ! "<<parameters.platforms>>" =~ ^[a-zA-Z0-9/_,-]+$ ]]; then
+          echo "ERROR: The 'platforms' parameter, if set, must be a comma-separated list of valid platform strings (e.g., linux/amd64,linux/arm64)."
           exit 1
         fi
   - image-build-and-push-multiarch:

--- a/src/jobs/push-to-registries-multiarch.yaml
+++ b/src/jobs/push-to-registries-multiarch.yaml
@@ -58,6 +58,12 @@ parameters:
         key=value (no prefix)         - defaults to index for multi-platform builds
     type: string
     default: ""
+  oci-labels:
+    description: |
+      Emit standard OCI image labels and matching index annotations
+      (org.opencontainers.image.{source,revision,version,created}).
+    type: boolean
+    default: true
 steps:
   - checkout
   - setup_remote_docker:
@@ -88,3 +94,4 @@ steps:
       registries-data: <<parameters.registries-data>>
       platforms: <<parameters.platforms>>
       annotations: <<parameters.annotations>>
+      oci-labels: <<parameters.oci-labels>>

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -51,10 +51,12 @@ parameters:
     default: false
   platforms:
     description: |
-      Comma-separated list of platforms for multi-arch image build.
-      Only used when multiarch: true.
+      Comma-separated list of platforms for multi-arch image build (only used when
+      multiarch: true). When empty, the list is auto-derived from the `.platforms` file
+      written by `go-build` to the workspace. Falls back to `linux/amd64,linux/arm64` if
+      neither is available.
     type: string
-    default: "linux/amd64,linux/arm64"
+    default: ""
   annotations:
     description: |
       Newline-separated OCI annotations passed to 'docker buildx build --annotation'.
@@ -107,8 +109,8 @@ steps:
         - run:
             name: Validate platforms parameter
             command: |
-              if [ -z "<<parameters.platforms>>" ] || [[ ! "<<parameters.platforms>>" =~ ^[a-zA-Z0-9/_,-]+$ ]]; then
-                echo "ERROR: The 'platforms' parameter must be a non-empty, comma-separated list of valid platform strings (e.g., linux/amd64,linux/arm64)."
+              if [ -n "<<parameters.platforms>>" ] && [[ ! "<<parameters.platforms>>" =~ ^[a-zA-Z0-9/_,-]+$ ]]; then
+                echo "ERROR: The 'platforms' parameter, if set, must be a comma-separated list of valid platform strings (e.g., linux/amd64,linux/arm64)."
                 exit 1
               fi
         - image-build-and-push-multiarch:

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -68,6 +68,12 @@ parameters:
       Only used when multiarch: true.
     type: string
     default: ""
+  oci-labels:
+    description: |
+      Emit standard OCI image labels (and matching index annotations in multi-arch mode):
+      org.opencontainers.image.{source,revision,version,created}.
+    type: boolean
+    default: true
 steps:
   - checkout
   - setup_remote_docker:
@@ -87,6 +93,7 @@ steps:
         - image-build-with-docker:
             build-context: <<parameters.build-context>>
             dockerfile: <<parameters.dockerfile>>
+            oci-labels: <<parameters.oci-labels>>
         - image-push-to-registries:
             image-sha256_envvar: DOCKER_IMAGE_SHA256
             image: <<parameters.image>>
@@ -123,6 +130,7 @@ steps:
             registries-data: <<parameters.registries-data>>
             platforms: <<parameters.platforms>>
             annotations: <<parameters.annotations>>
+            oci-labels: <<parameters.oci-labels>>
             split-china-push: <<parameters.split-china-push>>
   - when:
       condition: <<parameters.split-china-push>>


### PR DESCRIPTION
Target version: **v8.1.0**.

### Added

- `architectures` (CSV) parameter on `go-build`. Builds all targets in one job, writes `.platforms` to the workspace. Removes the need for a CircleCI matrix at the consumer.
- `push-to-registries` auto-derives `--platform` from `.platforms` when the explicit `platforms` parameter is empty.
- Standard OCI image labels (and matching index annotations in multi-arch mode): `org.opencontainers.image.{source,revision,version,created}`. `created` is taken from the commit timestamp so rebuilds of the same SHA produce identical labels; `version` is omitted when no tag is available. Opt out with `oci-labels: false`.

### Changed

- `image-login-to-registries`: `--password-stdin` / `--pass-stdin` instead of building shell command strings; bash indirect expansion instead of `eval`; read the file directly so a failed login propagates out of the loop.

### Fixed

- `image-login-to-registries`: turn off `set -x` before resolving credentials so passwords no longer leak into CI logs.

### Deprecated

- `os` parameter on `go-build` is now ignored; use `architectures` (or singular `architecture` for matrix callers).