### PR TITLE
renovate: track app-test-suite version and container tag

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,11 +3,39 @@
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/run-tests-with-ats\\.yaml$"],
+      "matchStrings": [
+        "app-test-suite_version:[\\s\\S]*?default:\\s*\"(?<currentValue>v[^\"]+)\"",
+      ],
+      "depNameTemplate": "giantswarm/app-test-suite",
+      "datasourceTemplate": "github-tags",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/run-tests-with-ats\\.yaml$"],
+      "matchStrings": [
+        "app-test-suite_container_tag:[\\s\\S]*?default:\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+      "depNameTemplate": "gsoci.azurecr.io/giantswarm/app-test-suite",
+      "datasourceTemplate": "docker",
+    },
+  ],
   "packageRules": [
     {
       "description": "Only allow -circleci tagged versions of app-build-suite",
       "matchPackageNames": ["gsoci.azurecr.io/giantswarm/app-build-suite"],
-      "allowedVersions": "/-circleci$/"
-    }
+      "allowedVersions": "/-circleci$/",
+    },
+    {
+      "description": "Group app-test-suite git tag and container tag bumps",
+      "matchPackageNames": [
+        "giantswarm/app-test-suite",
+        "gsoci.azurecr.io/giantswarm/app-test-suite",
+      ],
+      "groupName": "app-test-suite",
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Add Renovate `customManagers` covering the `app-test-suite_version` (git tag, prefixed `v`) and `app-test-suite_container_tag` (container tag, no prefix) defaults in `src/jobs/run-tests-with-ats.yaml`.
- Group both into a single Renovate PR via `packageRules.groupName: app-test-suite` so the git tag and container tag stay in lockstep.
- Replaces the manual bump in #720; once merged, future ATS releases land via Renovate.

## Notes

- Datasources: `github-tags` for `giantswarm/app-test-suite`, `docker` for `gsoci.azurecr.io/giantswarm/app-test-suite`.
- The two `matchStrings` are scoped to the job file so unrelated `default:` lines aren't matched.
- `app-build-suite` already has a `packageRule` and is picked up by the standard CircleCI/Docker manager via `src/executors/app-build-suite.yaml` — no change needed there.