### PR TITLE
renovate: track integration-test, kyverno and yq tool versions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,72 @@
       "depNameTemplate": "gsoci.azurecr.io/giantswarm/app-test-suite",
       "datasourceTemplate": "docker",
     },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/commands/integration-test-install-tools\\.yaml$"],
+      "matchStrings": [
+        "kind\\.sigs\\.k8s\\.io/dl/(?<currentValue>v[^/]+)/kind-",
+      ],
+      "depNameTemplate": "kubernetes-sigs/kind",
+      "datasourceTemplate": "github-releases",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/integration-test\\.yaml$"],
+      "matchStrings": [
+        "apptestctl-version:[\\s\\S]*?default:\\s*\"(?<currentValue>v[^\"]+)\"",
+      ],
+      "depNameTemplate": "giantswarm/apptestctl",
+      "datasourceTemplate": "github-releases",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/integration-test\\.yaml$"],
+      "matchStrings": [
+        "helm-version:[\\s\\S]*?default:\\s*\"(?<currentValue>v[^\"]+)\"",
+      ],
+      "depNameTemplate": "helm/helm",
+      "datasourceTemplate": "github-releases",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/integration-test\\.yaml$"],
+      "matchStrings": [
+        "kubernetes-version:[\\s\\S]*?default:\\s*\"(?<currentValue>v[^\"]+)\"",
+      ],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-tags",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/run-kyverno-tests\\.yaml$"],
+      "matchStrings": [
+        "kyverno_version:[\\s\\S]*?default:\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+      "depNameTemplate": "kyverno/kyverno",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/run-kyverno-tests\\.yaml$"],
+      "matchStrings": [
+        "kyverno-policies_version:[\\s\\S]*?default:\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+      "depNameTemplate": "kyverno-policies",
+      "datasourceTemplate": "helm",
+      "registryUrlTemplate": "https://giantswarm.github.io/giantswarm-catalog",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/commands/run-kyverno\\.yaml$"],
+      "matchStrings": [
+        "yq_version:[\\s\\S]*?default:\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+      "depNameTemplate": "mikefarah/yq",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$",
+    },
   ],
   "packageRules": [
     {
@@ -36,6 +102,30 @@
         "gsoci.azurecr.io/giantswarm/app-test-suite",
       ],
       "groupName": "app-test-suite",
+    },
+    {
+      "description": "Group integration-test tooling defaults",
+      "matchPackageNames": [
+        "giantswarm/apptestctl",
+        "helm/helm",
+        "kubernetes/kubernetes",
+        "kubernetes-sigs/kind",
+      ],
+      "groupName": "integration-test tools",
+    },
+    {
+      "description": "Limit kubernetes-version default to patch updates to avoid PR churn across minor branches",
+      "matchPackageNames": ["kubernetes/kubernetes"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false,
+    },
+    {
+      "description": "Group kyverno tooling defaults",
+      "matchPackageNames": [
+        "kyverno/kyverno",
+        "kyverno-policies",
+      ],
+      "groupName": "kyverno",
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,11 +3,39 @@
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/run-tests-with-ats\\.yaml$"],
+      "matchStrings": [
+        "app-test-suite_version:[\\s\\S]*?default:\\s*\"(?<currentValue>v[^\"]+)\"",
+      ],
+      "depNameTemplate": "giantswarm/app-test-suite",
+      "datasourceTemplate": "github-tags",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/jobs/run-tests-with-ats\\.yaml$"],
+      "matchStrings": [
+        "app-test-suite_container_tag:[\\s\\S]*?default:\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+      "depNameTemplate": "gsoci.azurecr.io/giantswarm/app-test-suite",
+      "datasourceTemplate": "docker",
+    },
+  ],
   "packageRules": [
     {
       "description": "Only allow -circleci tagged versions of app-build-suite",
       "matchPackageNames": ["gsoci.azurecr.io/giantswarm/app-build-suite"],
-      "allowedVersions": "/-circleci$/"
-    }
+      "allowedVersions": "/-circleci$/",
+    },
+    {
+      "description": "Group app-test-suite git tag and container tag bumps",
+      "matchPackageNames": [
+        "giantswarm/app-test-suite",
+        "gsoci.azurecr.io/giantswarm/app-test-suite",
+      ],
+      "groupName": "app-test-suite",
+    },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -114,12 +114,6 @@
       "groupName": "integration-test tools",
     },
     {
-      "description": "Limit kubernetes-version default to patch updates to avoid PR churn across minor branches",
-      "matchPackageNames": ["kubernetes/kubernetes"],
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false,
-    },
-    {
       "description": "Group kyverno tooling defaults",
       "matchPackageNames": [
         "kyverno/kyverno",

--- a/renovate.json5
+++ b/renovate.json5
@@ -133,6 +133,13 @@
       groupName: 'integration-test tools',
     },
     {
+      // Pin helm to major 3.x until we validate the orb and downstream
+      // integration tests against helm 4.
+      description: 'Restrict helm to major 3.x for now',
+      matchPackageNames: ['helm/helm'],
+      allowedVersions: '<4',
+    },
+    {
       description: 'Group kyverno tooling defaults',
       matchPackageNames: [
         'kyverno/kyverno',

--- a/renovate.json5
+++ b/renovate.json5
@@ -25,6 +25,86 @@
       depNameTemplate: 'gsoci.azurecr.io/giantswarm/app-test-suite',
       datasourceTemplate: 'docker',
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/commands/integration-test-install-tools\\.yaml$/',
+      ],
+      matchStrings: [
+        'kind\\.sigs\\.k8s\\.io/dl/(?<currentValue>v[^/]+)/kind-',
+      ],
+      depNameTemplate: 'kubernetes-sigs/kind',
+      datasourceTemplate: 'github-releases',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/jobs/integration-test\\.yaml$/',
+      ],
+      matchStrings: [
+        'apptestctl-version:[\\s\\S]*?default:\\s*"(?<currentValue>v[^"]+)"',
+      ],
+      depNameTemplate: 'giantswarm/apptestctl',
+      datasourceTemplate: 'github-releases',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/jobs/integration-test\\.yaml$/',
+      ],
+      matchStrings: [
+        'helm-version:[\\s\\S]*?default:\\s*"(?<currentValue>v[^"]+)"',
+      ],
+      depNameTemplate: 'helm/helm',
+      datasourceTemplate: 'github-releases',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/jobs/integration-test\\.yaml$/',
+      ],
+      matchStrings: [
+        'kubernetes-version:[\\s\\S]*?default:\\s*"(?<currentValue>v[^"]+)"',
+      ],
+      depNameTemplate: 'kubernetes/kubernetes',
+      datasourceTemplate: 'github-tags',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/jobs/run-kyverno-tests\\.yaml$/',
+      ],
+      matchStrings: [
+        'kyverno_version:[\\s\\S]*?default:\\s*"(?<currentValue>[^"]+)"',
+      ],
+      depNameTemplate: 'kyverno/kyverno',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/jobs/run-kyverno-tests\\.yaml$/',
+      ],
+      matchStrings: [
+        'kyverno-policies_version:[\\s\\S]*?default:\\s*"(?<currentValue>[^"]+)"',
+      ],
+      depNameTemplate: 'kyverno-policies',
+      datasourceTemplate: 'helm',
+      registryUrlTemplate: 'https://giantswarm.github.io/giantswarm-catalog',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/commands/run-kyverno\\.yaml$/',
+      ],
+      matchStrings: [
+        'yq_version:[\\s\\S]*?default:\\s*"(?<currentValue>[^"]+)"',
+      ],
+      depNameTemplate: 'mikefarah/yq',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+    },
   ],
   packageRules: [
     {
@@ -41,6 +121,24 @@
         'gsoci.azurecr.io/giantswarm/app-test-suite',
       ],
       groupName: 'app-test-suite',
+    },
+    {
+      description: 'Group integration-test tooling defaults',
+      matchPackageNames: [
+        'giantswarm/apptestctl',
+        'helm/helm',
+        'kubernetes/kubernetes',
+        'kubernetes-sigs/kind',
+      ],
+      groupName: 'integration-test tools',
+    },
+    {
+      description: 'Group kyverno tooling defaults',
+      matchPackageNames: [
+        'kyverno/kyverno',
+        'kyverno-policies',
+      ],
+      groupName: 'kyverno',
     },
   ],
 }


### PR DESCRIPTION
Stacks on top of #738.

## Summary

Adds Renovate `customManagers` for the version defaults that callers of the orb inherit, plus their grouping rules.

| Manager | File | Datasource | Notes |
|---|---|---|---|
| `kubernetes-sigs/kind` | `src/commands/integration-test-install-tools.yaml` | github-releases | Currently hardcoded `v0.30.0` in URL — only versioned thing in the file. |
| `giantswarm/apptestctl` | `src/jobs/integration-test.yaml` | github-releases | Default `v0.24.0` |
| `helm/helm` | `src/jobs/integration-test.yaml` | github-releases | Default `v3.18.6` |
| `kubernetes/kubernetes` | `src/jobs/integration-test.yaml` | github-tags | Default `v1.31.12`. Major/minor/patch all tracked. |
| `kyverno/kyverno` | `src/jobs/run-kyverno-tests.yaml` | github-releases | Default `1.13.4` (no `v`); `extractVersionTemplate` strips `v` from upstream tags. |
| `kyverno-policies` | `src/jobs/run-kyverno-tests.yaml` | helm | Registry: `https://giantswarm.github.io/giantswarm-catalog` |
| `mikefarah/yq` | `src/commands/run-kyverno.yaml` | github-releases | Default `4.45.1` (no `v`); same `extractVersionTemplate` trick. |

Grouping:
- `kubernetes-sigs/kind`, `giantswarm/apptestctl`, `helm/helm`, `kubernetes/kubernetes` → single PR titled `integration-test tools`
- `kyverno/kyverno`, `kyverno-policies` → single PR titled `kyverno`
- `yq` stays standalone (used in a different command).

## Out of scope

- `src/executors/regctl.yaml` (China-mirror image with `-alpine` suffix) — needs a `-alpine`-only `allowedVersions` filter and an upstream override; tackling separately to avoid risking the executor.
- `src/commands/machine-install-go.yaml` Go version + paired `archive_sha` — needs a post-upgrade hook to recompute the SHA; out of scope for a config-only PR.
- `.github/workflows/zz_generated.*.yaml` — these are regenerated upstream by `giantswarm/github-workflows`, so bumps here would be reverted. Address upstream instead.