### PR TITLE
Revert setup_remote_docker docker24 pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert the v8.0.1 `setup_remote_docker version: docker24` pin in `push-to-registries` and `push-to-registries-multiarch` back to `default`. The pin only covered the daemon side; the architect executor's Docker client (installed via Alpine's `apk add docker`) tracks Alpine stable and is now Docker 28.x (API 1.52), which the pinned daemon (API 1.43 max) refused with `client version 1.52 is too new. Maximum supported API version is 1.43`. Letting the daemon track CircleCI's default lets the two sides stay compatible.
+
 ## [8.0.1] - 2026-05-07
 
 ### Fixed

--- a/src/jobs/push-to-registries-multiarch.yaml
+++ b/src/jobs/push-to-registries-multiarch.yaml
@@ -58,7 +58,7 @@ parameters:
 steps:
   - checkout
   - setup_remote_docker:
-      version: docker24
+      version: default
   - attach_workspace:
       at: .
   - run:

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -69,7 +69,7 @@ parameters:
 steps:
   - checkout
   - setup_remote_docker:
-      version: docker24
+      version: default
   - attach_workspace:
       at: .
   - run:


### PR DESCRIPTION
Hotfix for v8.0.1. Target version: **v8.0.2.0**.

### What's broken in v8.0.1

\`push-to-registries\` and \`push-to-registries-multiarch\` fail at \`docker login\`:

\`\`\`
Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.43
\`\`\`

### Why

v8.0.1 added \`setup_remote_docker version: docker24\` for "reproducibility". That pinned the **daemon** (max API 1.43). But the **client** ships in the architect executor image via Alpine's \`apk add docker\`, which floats with Alpine's stable channel and is now Docker 28.x (API 1.52). The two sides stopped speaking the same dialect.

### Fix

Revert the pin back to \`version: default\`. CircleCI keeps its remote-docker daemon current; both sides stay in step.

### Why not pin both sides

Real reproducibility would require pinning the apk \`docker\` package version in the architect image too, with Renovate tracking it. That's more maintenance than this orb is meant to carry, and "exact-Docker-version-reproducible CI builds" wasn't a stated goal — keeping CI working as Alpine bumps Docker is.