### PR TITLE
fix(image-login-to-registries): use POSIX sh so sync-china-registry works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `image-login-to-registries` now uses POSIX-portable shell syntax (`[ ... ]`, `eval "var=\${name}"` for indirect expansion) instead of bash-only constructs (`[[ ... ]]`, `${!var}`). The bash dependency was introduced in v8.1.0 (#736) and silently broke the `sync-china-registry` job, which runs on the `regctl` executor (alpine + BusyBox `/bin/sh`). Every `sync-china-registry` invocation across all consumers that had migrated to `split-china-push: true` was failing on its very first step with `/bin/sh: syntax error: bad substitution`, before any login attempt could be made -- so no image was ever mirrored to Aliyun. The env-var-name validation that already restricted `username` / `password` to `[A-Za-z0-9_]` makes the `eval` indirection safe; the credential **value** is never re-evaluated. Closes #765.
+
 ## [8.2.0] - 2026-05-19
 
 ### Added

--- a/src/commands/image-login-to-registries.yaml
+++ b/src/commands/image-login-to-registries.yaml
@@ -23,18 +23,22 @@ parameters:
 steps:
   - run:
       name: Login to registries
+      # Use POSIX sh syntax only. This command is shared between the
+      # architect/architect executor (bash) and the regctl executor (alpine
+      # `/bin/sh`, BusyBox), and bash-only constructs (`${!var}`, `[[ ... ]]`)
+      # silently break on the latter -- see giantswarm/architect-orb#765.
       command: |
         set -x
 
-        if [[ "<<parameters.registries-data>>" ]]; then
-          REGISTRIES_DATA="<<parameters.registries-data>>";
+        if [ -n "<<parameters.registries-data>>" ]; then
+          REGISTRIES_DATA="<<parameters.registries-data>>"
         else
-          echo "Using registries data from the circle.ci environment settings.";
-          if ! [[ "${REGISTRIES_DATA_BASE64}" ]]; then
+          echo "Using registries data from the circle.ci environment settings."
+          if [ -z "${REGISTRIES_DATA_BASE64}" ]; then
             echo "Environment variable REGISTRIES_DATA_BASE64 is not set properly in circleci's context."
             exit 1
           fi
-          REGISTRIES_DATA=$(echo $REGISTRIES_DATA_BASE64 | base64 -d)
+          REGISTRIES_DATA=$(echo "${REGISTRIES_DATA_BASE64}" | base64 -d)
         fi
 
         echo "${REGISTRIES_DATA}" > .registries_data
@@ -48,30 +52,35 @@ steps:
         while read -r _ reg username password _; do
           # Default to success so misconfigured client values don't leave $s unset.
           s=0
-          # Validate env-var names (defence against malicious registries-data input).
+          # Validate env-var names (defence against malicious registries-data
+          # input). The eval below relies on these constraints to stay safe.
           case "$username" in *[!a-zA-Z0-9_]*) echo "Invalid username variable name: $username"; exit 1 ;; esac
           case "$password" in *[!a-zA-Z0-9_]*) echo "Invalid password variable name: $password"; exit 1 ;; esac
 
-          username_val="${!username}"
-          password_val="${!password}"
+          # POSIX-portable indirect expansion. `${!var}` is bash-only; alpine
+          # /bin/sh aborts with "bad substitution" before any login is
+          # attempted. The case-statements above restrict $username and
+          # $password to [A-Za-z0-9_], so the eval input is fully constrained.
+          eval "username_val=\${$username}"
+          eval "password_val=\${$password}"
 
-          if [[ "<<parameters.client>>" == "docker" ]]; then
+          if [ "<<parameters.client>>" = "docker" ]; then
             for i in 1 2 3; do
-              [[ $i -gt 1 ]] && sleep 1
+              [ "$i" -gt 1 ] && sleep 1
               if printf '%s' "$password_val" | docker login "$reg" --username "$username_val" --password-stdin; then
                 s=0; break
               fi
               s=$?
             done
-          elif [[ "<<parameters.client>>" == "regctl" ]]; then
+          elif [ "<<parameters.client>>" = "regctl" ]; then
             for i in 1 2 3; do
-              [[ $i -gt 1 ]] && sleep 1
+              [ "$i" -gt 1 ] && sleep 1
               if printf '%s' "$password_val" | regctl registry login "$reg" -u "$username_val" --pass-stdin; then
                 s=0; break
               fi
               s=$?
             done
           fi
-          [[ "$s" -ne 0 ]] && rc=$s
+          [ "$s" -ne 0 ] && rc=$s
         done < .registries_data
         exit "$rc"


### PR DESCRIPTION
## Summary

`image-login-to-registries` is shared between two executors:

- `architect/architect` (push-to-registries, push-to-registries-multiarch, image-build-and-push, push-helm, ...) -- bash available
- `regctl` (`sync-china-registry`) -- alpine + BusyBox `/bin/sh`, no bash

The v8.1.0 refactor (#736) introduced bash-only constructs (`${!username}`, `${!password}`, `[[ ... ]]`, `==`) in this shared command. Under the `regctl` executor BusyBox `sh` aborts on the first substitution with:

```
+ set +x
/bin/sh: syntax error: bad substitution
Exited with code exit status 2
```

`sync-china-registry` has therefore been failing on its **very first step** for every consumer that had migrated to `split-china-push: true`, before any login was attempted. The Aliyun mirror push wasn't happening at all -- see #765 for the full reproduction and the 10 downstream tag pipelines (klaus, klaus-gateway, klaus-operator, kserve, muster, vllm, mcp-capi, mcp-kubernetes, mcp-prometheus, kubectl-gs) that all hit the identical failure on 2026-05-18.

## What changed

POSIX-portable shell only, no behavioural change:

| Before (bash) | After (POSIX) |
|---|---|
| `[[ "$x" ]]`, `if ! [[ "$x" ]]` | `[ -n "$x" ]`, `[ -z "$x" ]` |
| `[[ "$a" == "$b" ]]` | `[ "$a" = "$b" ]` |
| `[[ $i -gt 1 ]]`, `[[ "$s" -ne 0 ]]` | `[ "$i" -gt 1 ]`, `[ "$s" -ne 0 ]` |
| `username_val="${!username}"` | `eval "username_val=\${$username}"` |

The `eval` is safe: the `case` statements immediately above already restrict `$username` and `$password` (the env-VAR NAMES, not their values) to `[A-Za-z0-9_]`, so no shell metacharacters can reach the eval. The credential **values** themselves are never re-evaluated -- verified locally against values containing `$$`, `$x`, double-quotes, and backticks (the backtick command does not execute; the value is preserved verbatim).

## Testing

Parse-checked the rendered command under both BusyBox `sh` and `dash` inside an `alpine:3.20` container:

```
=== busybox sh -n ===
OK
=== dash -n ===
OK
```

Functional test under BusyBox `sh` with credentials containing metacharacters:

```
$ docker run --rm -e ACR_GSOCI_USERNAME='my-acr-user' \
    -e ACR_GSOCI_PASSWORD='P@$$w%rd-with$pecials/and"quotes' \
    -e ACR_GSOCI_PASSWORD_WITH_BACKTICK='token`echo PWNED`' \
    alpine:3.20 /bin/sh -c '
      username=ACR_GSOCI_USERNAME
      password=ACR_GSOCI_PASSWORD
      pwbt=ACR_GSOCI_PASSWORD_WITH_BACKTICK
      eval "username_val=\${$username}"
      eval "password_val=\${$password}"
      eval "pwbt_val=\${$pwbt}"
      echo "username_val=[$username_val]"
      echo "password_val=[$password_val]"
      echo "pwbt_val=[$pwbt_val]"
    '
username_val=[my-acr-user]
password_val=[P@$$w%rd-with$pecials/and"quotes]
pwbt_val=[token`echo PWNED`]
```

The backtick value is preserved literally, not executed. Existing bash callers behave identically (POSIX `[ ... ]` and `=` are subsets of `[[ ... ]]` and `==`).

## Closes

- #765 -- sync-china-registry fails on Login step

## Checklist

- [x] Coding Standards reviewed
- [x] Development docs reviewed
- [x] Design and Goals reviewed
- [x] CHANGELOG updated under `[Unreleased]` `### Fixed`

Made with [Cursor](https://cursor.com)