### PR TITLE
fix(cosign-prepare): self-install cosign on executors that don't ship it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `cosign-prepare` now self-installs the official `cosign` static binary into `${HOME}/.local/bin` when `cosign` is not already on `PATH`, with SHA-256 verification against the upstream `cosign_checksums.txt`. The v8.2.0 default of `sign: true` on `push-to-app-catalog` broke every consumer that uses `executor: app-build-suite` (the `gsoci.azurecr.io/giantswarm/app-build-suite:1.8.0-circleci` image ships no `cosign`) with `cosign: command not found` on the new `Mint Sigstore OIDC token` step. Existing consumers that worked around the breakage with `sign: false` can drop that line on the next orb bump and pick up signing again. The `architect` executor path is unchanged — its baked-in `cosign` is detected and reused. Pinned version is exposed via a new `cosign_version` command parameter (default `3.0.6`) and tracked by Renovate (`sigstore/cosign` GitHub releases). Closes #769.
+
 ## [8.2.1] - 2026-05-19
 
 ### Fixed

--- a/renovate.json5
+++ b/renovate.json5
@@ -105,6 +105,18 @@
       datasourceTemplate: 'github-releases',
       extractVersionTemplate: '^v(?<version>.+)$',
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/commands/cosign-prepare\\.yaml$/',
+      ],
+      matchStrings: [
+        'cosign_version:[\\s\\S]*?default:\\s*"(?<currentValue>[^"]+)"',
+      ],
+      depNameTemplate: 'sigstore/cosign',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+    },
   ],
   packageRules: [
     {

--- a/src/commands/cosign-prepare.yaml
+++ b/src/commands/cosign-prepare.yaml
@@ -1,21 +1,90 @@
 # Command: cosign-prepare
 #
-# Mints a CircleCI OIDC token with audience=sigstore via
-# `circleci run oidc get --claims '{"aud":"sigstore"}' --root-issuer` and
-# exports it as SIGSTORE_ID_TOKEN through BASH_ENV so subsequent run steps in
-# the same job can `cosign sign` / `cosign verify` without additional setup.
+# Ensures cosign is on PATH (self-installing the official static binary into a
+# writable location when missing — needed for executors such as `app-build-suite`
+# whose image does not ship cosign), then mints a CircleCI OIDC token with
+# audience=sigstore via `circleci run oidc get --claims '{"aud":"sigstore"}'
+# --root-issuer` and exports it as SIGSTORE_ID_TOKEN through BASH_ENV so
+# subsequent run steps in the same job can `cosign sign` / `cosign verify`
+# without additional setup.
 #
 # The auto-injected CIRCLE_OIDC_TOKEN_V2 has an audience claim that Fulcio's
 # CircleCI federation doesn't accept, so a fresh sigstore-audience token is
 # required for `cosign sign` to retrieve a Fulcio signing cert successfully.
 
+parameters:
+  cosign_version:
+    description: |
+      Pinned cosign version (without the `v` prefix) to download when cosign is
+      not pre-installed on the executor. Ignored when cosign is already on PATH
+      (e.g. the `architect` executor ships it). Verified against the official
+      `cosign_checksums.txt` published with the GitHub release.
+    type: string
+    default: "3.0.6"
+
 steps:
+  - run:
+      name: Ensure cosign is on PATH
+      command: |
+        set -euo pipefail
+
+        if command -v cosign >/dev/null 2>&1; then
+          echo "cosign already installed: $(command -v cosign)"
+          cosign version 2>&1 | head -3 || true
+          exit 0
+        fi
+
+        version="<<parameters.cosign_version>>"
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64) goarch="amd64" ;;
+          aarch64|arm64) goarch="arm64" ;;
+          *)
+            echo "ERROR: unsupported arch '$arch' for cosign self-install" >&2
+            exit 1
+            ;;
+        esac
+
+        install_dir="${HOME}/.local/bin"
+        mkdir -p "$install_dir"
+
+        base="https://github.com/sigstore/cosign/releases/download/v${version}"
+        echo "cosign not found on executor; downloading v${version} (linux/${goarch})"
+
+        curl --silent --show-error --fail --location \
+          --retry 5 --retry-delay 2 \
+          -o "$install_dir/cosign" \
+          "${base}/cosign-linux-${goarch}"
+
+        curl --silent --show-error --fail --location \
+          --retry 5 --retry-delay 2 \
+          -o /tmp/cosign_checksums.txt \
+          "${base}/cosign_checksums.txt"
+
+        expected_sum="$(awk -v f="cosign-linux-${goarch}" '$2 == f {print $1}' /tmp/cosign_checksums.txt)"
+        if [ -z "$expected_sum" ]; then
+          echo "ERROR: no checksum for cosign-linux-${goarch} in cosign_checksums.txt" >&2
+          exit 1
+        fi
+        actual_sum="$(sha256sum "$install_dir/cosign" | awk '{print $1}')"
+        if [ "$expected_sum" != "$actual_sum" ]; then
+          echo "ERROR: cosign checksum mismatch (expected $expected_sum, got $actual_sum)" >&2
+          exit 1
+        fi
+
+        chmod +x "$install_dir/cosign"
+        echo "export PATH=\"${install_dir}:\$PATH\"" >> "$BASH_ENV"
+        # shellcheck disable=SC1090
+        . "$BASH_ENV"
+
+        echo "cosign installed: $(command -v cosign)"
+        cosign version 2>&1 | head -3 || true
   - run:
       name: Mint Sigstore OIDC token
       command: |
         set -euo pipefail
 
-        cosign version
+        cosign version >/dev/null
 
         SIGSTORE_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "sigstore"}' --root-issuer)
         echo "export SIGSTORE_ID_TOKEN=\"$SIGSTORE_ID_TOKEN\"" >> "$BASH_ENV"


### PR DESCRIPTION
## Summary

Closes #769.

Since `v8.2.0` defaulted `sign: true` on `push-to-app-catalog`, every consumer that uses `executor: app-build-suite` fails on the new `Mint Sigstore OIDC token` step with:

```
/bin/bash: line 3: cosign: command not found
Exited with code exit status 127
```

because the `gsoci.azurecr.io/giantswarm/app-build-suite:1.8.0-circleci` image does not ship `cosign`. The five Bumblebee-fleet repos affected (`klaus`, `klaus-gateway`, `mcp-capi`, `mcp-kubernetes`, `mcp-prometheus`) currently work around this with `sign: false`, which leaves public charts unsigned — the exact opposite of what `v8.2.0`'s default was meant to achieve.

## What changes

`cosign-prepare` now self-installs the official static `cosign` binary into `${HOME}/.local/bin` when `cosign` is not already on `PATH`:

- Detects the executor architecture (`x86_64` → `amd64`, `aarch64`/`arm64` → `arm64`); errors out for anything else.
- Downloads the pinned `cosign-linux-<arch>` from the `sigstore/cosign` GitHub release.
- Verifies its SHA-256 against the upstream `cosign_checksums.txt` (also downloaded from the same release).
- `chmod +x`, then `export PATH=…` via `BASH_ENV` so the existing `Mint Sigstore OIDC token` step and the downstream `cosign sign` / `cosign verify` calls all pick it up.
- Skips entirely when `cosign` is already on `PATH` (the `architect` executor case — no behavior change there).

A new command parameter `cosign_version` (default `3.0.6`) exposes the pin. Renovate tracks it via a new `customManager` in `renovate.json5` (datasource `github-releases`, depName `sigstore/cosign`, same `extractVersionTemplate: '^v(?<version>.+)$'` pattern used for `kyverno_version` and `yq_version`), so the orb stays current without manual edits.

## Effect on consumers

After this ships and Renovate bumps each repo's orb pin, the five workaround PRs can drop the `sign: false` line and pick up keyless chart signing for free:

| Repo | Workaround PR |
|---|---|
| klaus | #263 |
| klaus-gateway | #48 |
| mcp-capi | #122 |
| mcp-kubernetes | #424 |
| mcp-prometheus | #158 |

## Notes

- Pure runtime change inside `cosign-prepare`. All three callers (`push-helm`, `go-build`, `image-build-and-push-multiarch`) inherit the fix without any per-call edit; the new parameter has a default so existing call sites compile as-is.
- Supply chain: the downloaded binary is SHA-256-verified against the official `cosign_checksums.txt` from the same release tag, which is what cosign's own [installation instructions](https://docs.sigstore.dev/system_config/installation/#installation-on-linux-with-the-binary) recommend for environments where Homebrew/the GitHub Action isn't applicable. We do not transitively verify `cosign_checksums.txt` itself with an older cosign (bootstrap-circular).
- The `architect` executor's baked-in `cosign` continues to be used as-is — `command -v cosign` short-circuits before any download.