### PR TITLE
feat: add branch-tag for per-branch image and chart tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- New `branch-tag` parameter on `push-to-registries` (off by default). When `true`, the job pushes an additional, branch-keyed tag `<image>:branch-<slug>-<CIRCLE_BUILD_NUM>` alongside the standard `<semver>-<sha>` tag, where `<slug>` is `CIRCLE_BRANCH` with `/` replaced by `-`. The slug is validated against the DNS-1123 label regex (`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`) and the job fails early if it doesn't match — catches non-path-safe branch names before any image is built. Intended for per-branch deployments where Flux Image Update Automation needs a numerically-sortable tag stream keyed on the branch. Existing callers see no behavior change.
+
 ## [8.3.0] - 2026-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - New `branch-tag` parameter on `push-to-registries` (off by default). When `true`, the job pushes an additional, branch-keyed tag `<image>:branch-<slug>-<CIRCLE_BUILD_NUM>` alongside the standard `<semver>-<sha>` tag, where `<slug>` is `CIRCLE_BRANCH` with `/` replaced by `-`. The slug is validated against the DNS-1123 label regex (`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`) and the job fails early if it doesn't match — catches non-path-safe branch names before any image is built. Intended for per-branch deployments where Flux Image Update Automation needs a numerically-sortable tag stream keyed on the branch. Existing callers see no behavior change.
+- New `branch-tag` parameter on `push-to-app-catalog` (off by default). When `true`, the chart is packaged with version `0.0.0-branch-<slug>-<CIRCLE_BUILD_NUM>` (a valid SemVer pre-release identifier) and pushed to the OCI registry under that tag, matching the per-branch image tag stream produced by `push-to-registries`. The legacy git-based app catalog push (`push_to_appcatalog`) is force-skipped when `branch-tag: true`: per-branch builds are not meant for the production catalog repo. Requires `executor: architect`. Existing callers see no behavior change.
 
 ## [8.3.0] - 2026-05-20
 

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -67,6 +67,7 @@ documentation](https://helm.sh/blog/storing-charts-in-oci/).
 - [persist_chart_archive](#persist_chart_archive-boolean-defaultfalse)
 - [push_to_appcatalog](#push_to_appcatalog-optional-boolean-defaulttrue)
 - [push_to_oci_registry](#push_to_oci_registry-optional-boolean-defaulttrue)
+- [branch-tag](#branch-tag-optional-boolean-defaultfalse)
 - [registry_url](#registry_url-optional-string)
 - [username_envar](#username_envar-optional-string)
 - [password_envar](#password_envar-optional-string)
@@ -140,6 +141,25 @@ catalog.
 
 When set to `true`, the packaged chart will be pushed to the specified OCI
 registry.
+
+### branch-tag (optional boolean, default=false)
+
+When set to `true`, the chart is packaged with version
+`0.0.0-branch-<slug>-<CIRCLE_BUILD_NUM>` (a valid SemVer pre-release identifier)
+and pushed to the OCI registry under that tag. `<slug>` is `CIRCLE_BRANCH` with
+`/` replaced by `-`. The slug is validated against the DNS-1123 label regex
+`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$` and the job fails early if it does not
+match.
+
+The legacy git-based app catalog push (`push_to_appcatalog`) is force-skipped
+when `branch-tag: true`: per-branch builds are not meant for the production
+catalog repo. Only the OCI registry push runs. Requires `executor: architect`.
+
+Intended for per-branch deployments where the chart tag must align with the
+per-branch image tag stream produced by the `push-to-registries` job's
+[`branch-tag`](push-to-registries.md#branch-tag-optional-boolean-defaultfalse)
+parameter, so that a Helm chart and its container image are co-versioned per
+push.
 
 ### registry_url (optional string)
 

--- a/docs/job/push-to-registries.md
+++ b/docs/job/push-to-registries.md
@@ -14,6 +14,8 @@ Otherwise, it is possible to specify the Dockerfile and build context to use wit
 
 Argument `tag-suffix` allows to specify a special suffix to be added after the generated container tag.
 
+Argument `branch-tag` (boolean, default `false`) is opt-in. When `true`, the job pushes an additional tag `branch-<slug>-<CIRCLE_BUILD_NUM>` alongside the standard `<semver>-<sha>` tag. The slug is derived from `CIRCLE_BRANCH` with `/` replaced by `-`, and validated against the DNS-1123 label regex `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`. The job fails early if the slug does not match — this catches non-deploy-safe branch names before any image is built. The check fires only when `branch-tag: true`, so consumers using branch names like `feat/foo` are not affected unless they opt in. Intended for per-branch deployments where Flux Image Update Automation needs a numerically-sortable tag stream keyed on the branch.
+
 ## Example usage
 
 ### Single-arch (default)

--- a/src/commands/image-build-and-push-multiarch.yaml
+++ b/src/commands/image-build-and-push-multiarch.yaml
@@ -7,6 +7,16 @@ parameters:
   tag-suffix:
     type: string
     default: ""
+  branch-tag:
+    description: |
+      When true, additionally tag the multi-arch index with
+      `branch-<slug>-<CIRCLE_BUILD_NUM>`, where `<slug>` is read from
+      /tmp/.build_branch_slug (written by `image-compute-branch-slug`).
+      The extra tag rides the same buildx push as the primary tag, so it
+      inherits the same push_dev / access-visibility gating, OCI annotations,
+      and cosign signing (signing is by index digest, tag-independent).
+    type: boolean
+    default: false
   build-context:
     type: string
     default: "."
@@ -171,6 +181,10 @@ steps:
         tags=("<<parameters.image>>:${TAG_VALUE}")
         if [[ "$CIRCLE_BRANCH" == "$tag_latest_branch" ]]; then
           tags+=("<<parameters.image>>:latest$tag_suffix")
+        fi
+        if [[ "<<parameters.branch-tag>>" == "true" ]]; then
+          BRANCH_SLUG=$(cat /tmp/.build_branch_slug)
+          tags+=("<<parameters.image>>:branch-${BRANCH_SLUG}-${CIRCLE_BUILD_NUM}")
         fi
 
         # Prepare all registry/image:tag combinations

--- a/src/commands/image-compute-branch-slug.yaml
+++ b/src/commands/image-compute-branch-slug.yaml
@@ -1,0 +1,19 @@
+steps:
+  - run:
+      name: Compute and validate branch slug for branch-keyed image tag
+      # Derives a DNS-1123-label-safe slug from CIRCLE_BRANCH and writes it to
+      # /tmp/.build_branch_slug for the push commands to consume. Fails early
+      # if the slug doesn't conform — catches non-deploy-safe branch names
+      # before any image is built. Only invoked when `branch-tag: true`, so
+      # callers using nonconforming branch names (e.g. `feat/foo`) are not
+      # affected unless they opt in.
+      command: |
+        set -euo pipefail
+        slug=$(printf '%s' "${CIRCLE_BRANCH}" | tr '/' '-')
+        if ! printf '%s' "${slug}" | grep -Eq '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$'; then
+          echo "ERROR: derived slug '${slug}' (from CIRCLE_BRANCH='${CIRCLE_BRANCH}') is not a valid DNS-1123 label." >&2
+          echo "       branch-tag requires CIRCLE_BRANCH to slugify to ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" >&2
+          exit 1
+        fi
+        printf '%s' "${slug}" > /tmp/.build_branch_slug
+        echo "branch slug: ${slug}"

--- a/src/commands/image-push-to-registries.yaml
+++ b/src/commands/image-push-to-registries.yaml
@@ -10,6 +10,14 @@ parameters:
   tag-suffix:
     type: "string"
     default: ""
+  branch-tag:
+    description: |
+      When true, additionally push `<image>:branch-<slug>-<CIRCLE_BUILD_NUM>`,
+      where `<slug>` is read from /tmp/.build_branch_slug (written by
+      `image-compute-branch-slug`). Skipped per-registry on the same
+      `push_dev` / access-visibility rules as the primary tag.
+    type: boolean
+    default: false
   build-context:
     type: "string"
     default: "."
@@ -139,6 +147,27 @@ steps:
               done
               if [[ "${SUCCESS}" == "false" ]]; then
                 echo "${reg}:latest<< parameters.tag-suffix >>" >> .failed_images
+              fi
+            fi
+            if [[ "<<parameters.branch-tag>>" == "true" ]]; then
+              BRANCH_SLUG=$(cat /tmp/.build_branch_slug)
+              BRANCH_TAG="branch-${BRANCH_SLUG}-${CIRCLE_BUILD_NUM}"
+              echo "Tagging the image as ${BRANCH_TAG}"
+              docker tag "${<<parameters.image-sha256_envvar>>}" "${reg}/<<parameters.image>>:${BRANCH_TAG}"
+              CMD="docker push \"${reg}/<<parameters.image>>:${BRANCH_TAG}\""
+              SUCCESS=false
+              for x in $(seq 1 4); do
+                echo "attempt: ${x}"
+                if bash -c "${CMD}"; then
+                  echo "Image is pushed to the registry."
+                  SUCCESS=true
+                  break
+                fi
+                echo "Waiting 5 seconds before the next attempt."
+                sleep 5
+              done
+              if [[ "${SUCCESS}" == "false" ]]; then
+                echo "${reg}:${BRANCH_TAG}" >> .failed_images
               fi
             fi
           else

--- a/src/commands/push-helm.yaml
+++ b/src/commands/push-helm.yaml
@@ -16,6 +16,15 @@ parameters:
   push_to_oci_registry:
     default: true
     type: boolean
+  branch-tag:
+    description: |
+      When true, the legacy git-based app catalog push is force-skipped regardless
+      of `push_to_appcatalog`. Only the OCI registry push runs. The chart's internal
+      version (set at `helm package` time by the caller) is expected to be a
+      branch-keyed pre-release like `0.0.0-branch-<slug>-<build-num>` so the OCI
+      tag matches that pattern.
+    type: boolean
+    default: false
   force-public:
     type: boolean
     default: false
@@ -30,7 +39,9 @@ parameters:
 steps:
   - when:
       condition:
-        equal: [<< parameters.push_to_appcatalog >>, true]
+        and:
+          - equal: [<< parameters.push_to_appcatalog >>, true]
+          - not: << parameters.branch-tag >>
       steps:
         - run:
             name: "architect/push-helm-package: Check environment variables"

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -48,6 +48,20 @@ parameters:
     description: |
       Push the chart to OCI registry if this is `true`.
     type: boolean
+  branch-tag:
+    description: |
+      When true, package the chart with version `0.0.0-branch-<slug>-<CIRCLE_BUILD_NUM>`
+      (a valid SemVer pre-release identifier) and push to the OCI registry under that
+      tag. `<slug>` is `CIRCLE_BRANCH` with `/` replaced by `-`. The slug is validated
+      against the DNS-1123 label regex `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$` and the
+      job fails early if it does not match. The legacy git-based app catalog push
+      (`push_to_appcatalog`) is force-skipped when `branch-tag: true`: per-branch
+      builds are not meant for the production catalog repo. Intended for per-branch
+      deployments where the chart tag must align with the per-branch image tag stream
+      produced by `push-to-registries`. Requires `executor: architect`. Default false
+      — no behavior change for consumers that do not opt in.
+    type: boolean
+    default: false
   force-public:
     description: Skip the repo visibility check and push the the chart to public registry
     type: boolean
@@ -125,6 +139,17 @@ steps:
       app_catalog_test: << parameters.app_catalog_test >>
       on_tag: << parameters.on_tag >>
   - when:
+      condition: << parameters.branch-tag >>
+      steps:
+        - run:
+            name: "architect/push-to-app-catalog: Guard branch-tag requires architect executor"
+            command: |
+              if [[ "<< parameters.executor >>" != "architect" ]]; then
+                echo "ERROR: branch-tag: true is only supported with executor: architect (got '<< parameters.executor >>')." >&2
+                exit 1
+              fi
+        - image-compute-branch-slug
+  - when:
       condition: << parameters.attach_workspace >>
       steps:
         - attach_workspace:
@@ -143,7 +168,12 @@ steps:
         - run:
             name: "architect/push-to-app-catalog: Package the chart archive with helm"
             command: |
-              mkdir build && helm package ./helm/<< parameters.chart >> --destination ./build
+              version_arg=""
+              if [[ "<< parameters.branch-tag >>" == "true" ]]; then
+                slug=$(cat /tmp/.build_branch_slug)
+                version_arg="--version 0.0.0-branch-${slug}-${CIRCLE_BUILD_NUM}"
+              fi
+              mkdir build && helm package ./helm/<< parameters.chart >> --destination ./build ${version_arg}
   - when:
       condition:
         equal: ["<< parameters.executor >>", "app-build-suite"]
@@ -155,6 +185,7 @@ steps:
   - push-helm:
       push_to_appcatalog: << parameters.push_to_appcatalog >>
       push_to_oci_registry: << parameters.push_to_oci_registry >>
+      branch-tag: << parameters.branch-tag >>
       force-public: <<parameters.force-public>>
       password_envar: << parameters.password_envar >>
       username_envar: << parameters.username_envar >>

--- a/src/jobs/push-to-registries.yaml
+++ b/src/jobs/push-to-registries.yaml
@@ -31,6 +31,18 @@ parameters:
   tag-suffix:
     type: string
     default: ""
+  branch-tag:
+    description: |
+      When true, additionally tag the image with `branch-<slug>-<CIRCLE_BUILD_NUM>`,
+      where `<slug>` is `CIRCLE_BRANCH` with `/` replaced by `-`. The slug is
+      validated against the DNS-1123 label regex `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`
+      and the job fails early if it does not match — catches non-deploy-safe
+      branch names before any image is built. Intended for per-branch
+      deployments where Flux Image Update Automation needs a numerically-sortable
+      tag stream keyed on the branch. Default false — no behavior change for
+      consumers that do not opt in.
+    type: boolean
+    default: false
   force-public:
     description: Skip the repo visibility check and push the the image to public registries
     type: boolean
@@ -124,6 +136,10 @@ steps:
       command: echo 'export GS_GIT_TAG_PREFIX="<<parameters.git-tag-prefix>>"' >> "$BASH_ENV"
   - image-prepare-tag:
       tag-suffix: <<parameters.tag-suffix>>
+  - when:
+      condition: <<parameters.branch-tag>>
+      steps:
+        - image-compute-branch-slug
   - unless:
       condition:
         equal: ["<<parameters.hadolint>>", "skip"]
@@ -168,6 +184,7 @@ steps:
             force-public: <<parameters.force-public>>
             tag-latest-branch: <<parameters.tag-latest-branch>>
             tag-suffix: <<parameters.tag-suffix>>
+            branch-tag: <<parameters.branch-tag>>
             split-china-push: <<parameters.split-china-push>>
             registries-data:
               <<parameters.registries-data>>
@@ -192,6 +209,7 @@ steps:
             force-public: <<parameters.force-public>>
             tag-latest-branch: <<parameters.tag-latest-branch>>
             tag-suffix: <<parameters.tag-suffix>>
+            branch-tag: <<parameters.branch-tag>>
             registries-data: <<parameters.registries-data>>
             platforms: <<parameters.platforms>>
             annotations: <<parameters.annotations>>


### PR DESCRIPTION
## Summary

Adds an opt-in `branch-tag: bool` parameter (default `false`) to both `push-to-registries` and `push-to-app-catalog` so a single push can produce a co-versioned image + chart pair keyed on the branch.

### `push-to-registries` — image tag stream
- When `true`, pushes `<image>:branch-<slug>-<CIRCLE_BUILD_NUM>` alongside the existing `<semver>-<sha>` and `:latest<suffix>` tags.
- Plumbed through both the single-arch (`image-push-to-registries`) and multi-arch (`image-build-and-push-multiarch`) paths. Same `push_dev` / access-visibility gating as the primary tag. Cosign signing is by index digest (multi-arch) — tag-independent.

### `push-to-app-catalog` — chart tag stream
- When `true`, packages the chart with `helm package --version 0.0.0-branch-<slug>-<CIRCLE_BUILD_NUM>` (valid SemVer pre-release) and pushes to the OCI registry under that tag.
- The legacy git-based app catalog push (`push_to_appcatalog`) is force-skipped: per-branch builds are not meant for the production catalog repo. Only the OCI push runs.
- Requires `executor: architect` — guard fails fast on `app-build-suite` (its packaging step doesn't honor `helm package --version`). Extending app-build-suite support is deferred.

### Shared mechanics
- Slug is `CIRCLE_BRANCH` with `/` replaced by `-`, validated against the DNS-1123 label regex `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\$`. Job fails early if it doesn't match — catches non-deploy-safe branch names before any image is built. Validation runs only when the parameter is on, so consumers with branch names like `feat/foo` are unaffected unless they opt in.
- Slug computation lives in a single command (`image-compute-branch-slug`) shared by both jobs.

## Why

For per-branch prototype deployments where Flux Image Update Automation needs a numerically-sortable tag stream keyed on the branch (build number is monotonic; SHA isn't sortable; rolling tags can't drive IUA-based reconcile because the manifest text never changes). Co-versioning the image and chart per push lets a per-branch Flux \`OCIRepository\` + \`ImagePolicy\` pair bump them together.

## Test plan

- [x] Dev orb publishes successfully (\`orb-tools/pack\` + \`circleci orb validate\` clean).
- [x] Consumer enables \`branch-tag: true\` on a DNS-1123-compliant branch → image pushed as \`branch-<slug>-<build-num>\` (verified: \`gsociprivate.azurecr.io/giantswarm/agentic-platform-ui:branch-test-branch-tag-dev-orb-70\`).
- [x] Same consumer → chart pushed as \`0.0.0-branch-<slug>-<build-num>\` (verified: \`gsociprivate.azurecr.io/charts/giantswarm/agentic-platform-ui:0.0.0-branch-test-branch-tag-dev-orb-74\`).
- [x] Legacy git appcatalog push skipped when \`branch-tag: true\` (verified: no commit to catalog repo on \`:74\` run).
- [ ] Same consumer on a non-conforming branch (e.g. \`feat/foo\`) fails with a clear error before image build / chart package.
- [ ] Existing consumers (no \`branch-tag\` set) see byte-identical orb behavior — covered by the no-op default and the gated \`when:\` blocks, but a regression run on a current production consumer would be reassuring before merge.
- [ ] Multi-arch image path: index digest is signed (cosign), all tag references resolve to the signed index.