### PR TITLE
fix: track kindest/node docker image for kubernetes-version; revert to v1.31.12

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -66,8 +66,8 @@
       matchStrings: [
         'kubernetes-version:[\\s\\S]*?default:\\s*"(?<currentValue>v[^"]+)"',
       ],
-      depNameTemplate: 'kubernetes/kubernetes',
-      datasourceTemplate: 'github-tags',
+      depNameTemplate: 'kindest/node',
+      datasourceTemplate: 'docker',
     },
     {
       customType: 'regex',
@@ -127,7 +127,7 @@
       matchPackageNames: [
         'giantswarm/apptestctl',
         'helm/helm',
-        'kubernetes/kubernetes',
+        'kindest/node',
         'kubernetes-sigs/kind',
       ],
       groupName: 'integration-test tools',

--- a/src/jobs/integration-test.yaml
+++ b/src/jobs/integration-test.yaml
@@ -30,7 +30,7 @@ parameters:
     description: "Path to kind config file."
     type: string
   kubernetes-version:
-    default: "v1.36.1"
+    default: "v1.31.12"
     description: "Kubernetes version for kind cluster."
     type: string
   setup-script:


### PR DESCRIPTION
## Root cause

Renovate was configured with `kubernetes/kubernetes` (github-tags) as the datasource for the `kubernetes-version` default in the `integration-test` job. This tracks every Kubernetes source tag, including `v1.36.1`, regardless of whether Kind has actually published a `kindest/node` image for it. Kind does not publish images for all Kubernetes releases (and lags behind), so this caused the broken bump.

## Fix

- Switch the `kubernetes-version` custom manager to use `datasourceTemplate: 'docker'` with `depNameTemplate: 'kindest/node'`. Renovate will now check Docker Hub for `kindest/node` image tags, which are the authoritative signal that a given version can actually be used with Kind.
- Also update the `packageRules` grouping to reference `kindest/node` instead of `kubernetes/kubernetes`.
- Revert the broken `v1.36.1` default to the last known-working `v1.31.12`. Renovate will propose a bump to the actual latest (`v1.35.1` as of now) in its next run.

## Test plan

- [ ] Verify Renovate correctly detects `kindest/node` as the package and proposes the correct latest tag (e.g. `v1.35.1`) after merge
- [ ] Verify downstream CI (e.g. operatorkit, apptestctl) passes with the reverted `v1.31.12` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)