### PR TITLE
fix: fail with clear error when architect context is missing for signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.0.1] - 2026-06-01
+
+### Fixed
+
+- `generate-github-token`: gracefully skip token generation when the required env vars
+  (`CIRCLECI_ARCHITECT_GITHUB_APP_PRIVATE_KEY_B64` etc.) are not set, instead of failing with a
+  PEM-parse error. Jobs that don't attach the `architect` CircleCI context now emit a clear warning
+  and continue without signing rather than hard-failing.
+- `go-build`: treat missing `GITHUB_TOKEN` after `generate-github-token` as "skip signing" (writes
+  `private` to the visibility marker file) instead of exiting with an error. This makes binary
+  signing opt-in by attaching the context, not a hard requirement.
+
 ## [9.0.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- `generate-github-token`: gracefully skip token generation when the required env vars
-  (`CIRCLECI_ARCHITECT_GITHUB_APP_PRIVATE_KEY_B64` etc.) are not set, instead of failing with a
-  PEM-parse error. Jobs that don't attach the `architect` CircleCI context now emit a clear warning
-  and continue without signing rather than hard-failing.
-- `go-build`: treat missing `GITHUB_TOKEN` after `generate-github-token` as "skip signing" (writes
-  `private` to the visibility marker file) instead of exiting with an error. This makes binary
-  signing opt-in by attaching the context, not a hard requirement.
+- `generate-github-token`: fail with a clear, actionable error when the required env var
+  (`CIRCLECI_ARCHITECT_GITHUB_APP_PRIVATE_KEY_B64`) is not set, instead of a cryptic RSA/PEM
+  parse error. The new message tells users to add `context: architect` to the job in
+  `.circleci/config.yml`.
 
 ## [9.0.0] - 2026-06-01
 

--- a/src/commands/generate-github-token.yaml
+++ b/src/commands/generate-github-token.yaml
@@ -12,6 +12,12 @@ steps:
   - run:
       name: Generate temporary GitHub token
       command: |
+        if [[ -z "${<< parameters.private_key_base64_env_var >>:-}" ]]; then
+          echo "WARNING: << parameters.private_key_base64_env_var >> is not set — skipping GitHub token generation."
+          echo "To enable binary/chart signing, attach the 'architect' CircleCI context to this job."
+          exit 0
+        fi
+
         echo -n "${<< parameters.private_key_base64_env_var >>}" | base64 -d > /tmp/private-key.pem
 
         TOKEN=$(gh-token generate --key /tmp/private-key.pem --app-id "${<< parameters.app_id_env_var >>}" --installation-id "${<< parameters.installation_id_env_var >>}" --token-only)

--- a/src/commands/generate-github-token.yaml
+++ b/src/commands/generate-github-token.yaml
@@ -13,9 +13,9 @@ steps:
       name: Generate temporary GitHub token
       command: |
         if [[ -z "${<< parameters.private_key_base64_env_var >>:-}" ]]; then
-          echo "WARNING: << parameters.private_key_base64_env_var >> is not set — skipping GitHub token generation."
-          echo "To enable binary/chart signing, attach the 'architect' CircleCI context to this job."
-          exit 0
+          echo "ERROR: << parameters.private_key_base64_env_var >> is not set." >&2
+          echo "Add 'context: architect' to this job in .circleci/config.yml to enable artifact signing." >&2
+          exit 1
         fi
 
         echo -n "${<< parameters.private_key_base64_env_var >>}" | base64 -d > /tmp/private-key.pem

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -125,9 +125,8 @@ steps:
               # in public Sigstore would leak filenames/timestamps into the public Rekor
               # transparency log.
               if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-                echo "GITHUB_TOKEN is not set (architect context likely not attached) — skipping binary signing."
-                echo "private" > /tmp/.binary_sign_access
-                exit 0
+                echo "ERROR: GITHUB_TOKEN is not set. Did generate-github-token succeed?" >&2
+                exit 1
               fi
               GITHUB_API_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
               HTTP_STATUS=$(curl -s -o /tmp/.gh_response_binsign -w "%{http_code}" \

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -125,8 +125,9 @@ steps:
               # in public Sigstore would leak filenames/timestamps into the public Rekor
               # transparency log.
               if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-                echo "ERROR: GITHUB_TOKEN is not set. Did generate-github-token succeed?" >&2
-                exit 1
+                echo "GITHUB_TOKEN is not set (architect context likely not attached) — skipping binary signing."
+                echo "private" > /tmp/.binary_sign_access
+                exit 0
               fi
               GITHUB_API_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
               HTTP_STATUS=$(curl -s -o /tmp/.gh_response_binsign -w "%{http_code}" \


### PR DESCRIPTION
## Summary

- `generate-github-token`: check the env var is set before decoding; fail immediately with a clear, actionable error when missing instead of letting `gh-token generate` blow up with a cryptic RSA/PEM parse error

## Background

`go-build` defaults to `sign: true` in v9.0.0. When the job runs without the `architect` CircleCI context, `CIRCLECI_ARCHITECT_GITHUB_APP_PRIVATE_KEY_B64` is empty and the build fails with:

```
Error: unable to parse key from PEM to RSA format: invalid key: Key must be a PEM encoded PKCS1 or PKCS8 key
```

Users have no idea what this means. With this fix the error is:

```
ERROR: CIRCLECI_ARCHITECT_GITHUB_APP_PRIVATE_KEY_B64 is not set.
Add 'context: architect' to this job in .circleci/config.yml to enable artifact signing.
```

The build still fails (signing is required, not optional), but users now know exactly what to fix.

Observed failing build: https://app.circleci.com/pipelines/github/giantswarm/kyverno-policy-operator/1582/workflows/e40e0fb1-bae6-4cdc-9e5f-f8875bd4d0c0/jobs/5884

## Test plan

- [ ] Verify the error message is clear when `architect` context is missing
- [ ] Verify a job WITH the `architect` context still signs binaries as expected