### PR TITLE
fix: migrate to gitsemver v2.0.0 (version → get)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking**. Adapt to `gitsemver` v2.0.0, which renamed the `version` subcommand to `get` (to avoid
+  confusion with the `--version` flag). All `gitsemver version` invocations are now `gitsemver get`:
+  - `image-prepare-tag`: compute the Docker image tag with `gitsemver get`.
+  - `push-to-app-catalog` (executor `app-build-suite`): compute the chart/app version with `gitsemver get`.
+- Bump the `architect` executor image from `8.0.0` to `8.1.0`, which bundles `gitsemver` v2.0.0 (the version
+  that provides the `get` subcommand). Dev-build versions are now deterministic — they derive the timestamp
+  from the resolved commit's committer date (UTC) instead of wall-clock time, so the same commit always
+  produces an identical version string. The `tools-info` `gitsemver --version` call is unchanged (the
+  `--version` flag still works).
+
 ## [9.0.1] - 2026-06-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- **Breaking**. Adapt to `gitsemver` v2.0.0, which renamed the `version` subcommand to `get` (to avoid
-  confusion with the `--version` flag). All `gitsemver version` invocations are now `gitsemver get`:
+- Adapt to `gitsemver` v2.0.0, which renamed the `version` subcommand to `get` (to avoid confusion with the
+  `--version` flag). All `gitsemver version` invocations are now `gitsemver get`:
   - `image-prepare-tag`: compute the Docker image tag with `gitsemver get`.
   - `push-to-app-catalog` (executor `app-build-suite`): compute the chart/app version with `gitsemver get`.
 - Bump the `architect` executor image from `8.0.0` to `8.1.0`, which bundles `gitsemver` v2.0.0 (the version
@@ -24,9 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - `generate-github-token`: fail with a clear, actionable error when the required env var
-  (`CIRCLECI_ARCHITECT_GITHUB_APP_PRIVATE_KEY_B64`) is not set, instead of a cryptic RSA/PEM
-  parse error. The new message tells users to add `context: architect` to the job in
-  `.circleci/config.yml`.
+  (`CIRCLECI_ARCHITECT_GITHUB_APP_PRIVATE_KEY_B64`) is not set, instead of a cryptic RSA/PEM parse error. The
+  new message tells users to add `context: architect` to the job in `.circleci/config.yml`.
 
 ## [9.0.0] - 2026-06-01
 
@@ -51,11 +50,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     Required by app-build-suite v2.0.0, which replaced `HelmGitVersionSetter` with `HelmVersionSetter` and no
     longer derives chart/app versions from git state automatically.
 - **Breaking**. `push-to-app-catalog`: `executor` parameter now only accepts `app-build-suite` (previously
-  `architect` was the default). Consumers using the default or `executor: architect` explicitly must remove the
-  parameter or set it to `app-build-suite`. The `architect`-executor code path (running `helm-chart-template`,
-  `helm-lint`, `kubeconform`, and `helm package` directly) has been removed; packaging is now always handled by
-  app-build-suite. The `executor` parameter is kept for backwards compatibility and will be removed in a future
-  version.
+  `architect` was the default). Consumers using the default or `executor: architect` explicitly must remove
+  the parameter or set it to `app-build-suite`. The `architect`-executor code path (running
+  `helm-chart-template`, `helm-lint`, `kubeconform`, and `helm package` directly) has been removed; packaging
+  is now always handled by app-build-suite. The `executor` parameter is kept for backwards compatibility and
+  will be removed in a future version.
 - **Breaking**. `push-to-registries`: make tag-latest-branch opt-in with empty default
 - **Breaking.** `image-build-and-push-multiarch` command renamed to `image-build-and-push` — multi-arch is no
   longer a distinguishing trait. Direct callers of the command need to update the name; consumers of the
@@ -81,12 +80,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Breaking.** `image-build-with-docker` and `image-push-to-registries` commands (the single-arch
   `docker build` / `docker push` path). The single-arch path is collapsed into the buildx path; nothing else
   in the orb referenced these commands.
-- **Breaking.** `registry_url`, `password_envar`, `username_envar` parameters from `push-to-app-catalog`.
-  The current OCI push flow uses `generate-github-token` + the giantswarm OCI authenticator instead.
+- **Breaking.** `registry_url`, `password_envar`, `username_envar` parameters from `push-to-app-catalog`. The
+  current OCI push flow uses `generate-github-token` + the giantswarm OCI authenticator instead.
 - `password_envar`, `username_envar`, `registry_url` parameters from `push-helm` and the two `[deprecated]`
   legacy OCI auth/push run steps that used them.
-- `ct_config` parameter on `push-to-app-catalog` is now silently ignored — the `helm-lint` step it
-  controlled has been removed along with the `architect`-executor path.
+- `ct_config` parameter on `push-to-app-catalog` is now silently ignored — the `helm-lint` step it controlled
+  has been removed along with the `architect`-executor path.
 
 > **Upgrading from v8.x?** See [docs/migration-v8-to-v9.md](docs/migration-v8-to-v9.md) for breaking changes
 > and the defaults that change. See [docs/cosign-signing.md](docs/cosign-signing.md) for the supply-chain

--- a/docs/job/push-to-registries.md
+++ b/docs/job/push-to-registries.md
@@ -4,7 +4,7 @@ Builds a multi-architecture container image with `docker buildx` and pushes it t
 
 By default it uses the `Dockerfile` at the workspace root and the root directory as the build context; pass `dockerfile` and `build-context` to override.
 
-The image is tagged with the version produced by `gitsemver version`. The registry hosts come from `registries-data` (or the `REGISTRIES_DATA_BASE64` environment variable) — `image` should only be `repository/image`, no host.
+The image is tagged with the version produced by `gitsemver get`. The registry hosts come from `registries-data` (or the `REGISTRIES_DATA_BASE64` environment variable) — `image` should only be `repository/image`, no host.
 
 `tag-suffix` adds a suffix to the generated tag.
 
@@ -141,7 +141,7 @@ Emitted by default and configurable via `oci-labels: true|false`:
 
 - `org.opencontainers.image.source` — `https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}`
 - `org.opencontainers.image.revision` — `${CIRCLE_SHA1}`
-- `org.opencontainers.image.version` — the tag from `gitsemver version`
+- `org.opencontainers.image.version` — the tag from `gitsemver get`
 - `org.opencontainers.image.created` — commit timestamp (RFC 3339, deterministic per commit)
 
 In multi-arch mode the same values are also emitted as OCI manifest index annotations.

--- a/src/commands/image-prepare-tag.yaml
+++ b/src/commands/image-prepare-tag.yaml
@@ -4,8 +4,8 @@ parameters:
     default: ""
 steps:
   - run:
-      name: Generate container tag from 'gitsemver version' and tag-suffix parameter
+      name: Generate container tag from 'gitsemver get' and tag-suffix parameter
       command: |
-        gitsemver version | tr -d "\n" | tee /tmp/.docker_image_tag
+        gitsemver get | tr -d "\n" | tee /tmp/.docker_image_tag
         echo -n "<<parameters.tag-suffix>>" | tee -a /tmp/.docker_image_tag
         echo 'export DOCKER_IMAGE_TAG=$(cat /tmp/.docker_image_tag)' >> $BASH_ENV

--- a/src/executors/architect.yaml
+++ b/src/executors/architect.yaml
@@ -1,4 +1,4 @@
 docker:
   - entrypoint: /bin/bash
     # registry: gsoci.azurecr.io/giantswarm/architect
-    image: gsoci.azurecr.io/giantswarm/architect:8.0.0
+    image: gsoci.azurecr.io/giantswarm/architect:8.1.0

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -108,7 +108,7 @@ steps:
   - run:
       name: "architect/package-helm-with-abs: Execute App Build Suite"
       command: |
-        VERSION=$(gitsemver version | tr -d "\n")
+        VERSION=$(gitsemver get | tr -d "\n")
         OVERRIDES="--override-chart-version ${VERSION} --override-app-version ${VERSION}"
         mkdir build && python -m app_build_suite \
           --chart-dir ./helm/<< parameters.chart >> \


### PR DESCRIPTION
## What

[gitsemver](https://github.com/giantswarm/gitsemver) had a **breaking** v2.0.0 release that renamed the `version` subcommand to `get` (to avoid confusion with the `--version` flag) and made dev-build versions deterministic (timestamp derived from the resolved commit's committer date in UTC rather than wall-clock time).

This is the same breaking change handled in [architect#v8.1.0](https://github.com/giantswarm/architect/releases/tag/v8.1.0), [devctl#v8.3.1](https://github.com/giantswarm/devctl/releases/tag/v8.3.1), and [opsctl#v12.0.1](https://github.com/giantswarm/opsctl/releases/tag/v12.0.1). This PR applies the equivalent fix to the orb.

## Changes

- **`gitsemver version` → `gitsemver get`** in:
  - `src/commands/image-prepare-tag.yaml` — Docker image tag generation
  - `src/jobs/push-to-app-catalog.yaml` — chart/app version for app-build-suite
- **Bump executor image** `architect:8.0.0` → `architect:8.1.0` in `src/executors/architect.yaml`. The `get` subcommand only exists in gitsemver v2.0.0, which is first bundled in the architect image at v8.1.0 — so the rename and the image bump must land together.
- Updated `docs/job/push-to-registries.md` and `CHANGELOG.md`.

The `tools-info` `gitsemver --version` call is **unchanged** — the `--version` flag still works in v2.0.0.

## Testing

- All modified YAML files validate with `yq`.
- No remaining `gitsemver version` invocations in `src/` or `docs/`.
- Full validation (lint/pack/publish) runs in CircleCI on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)