### PR TITLE
feat(upload-release-assets): use TAYLORBOT_GITHUB_ACTION by default, fall back to App token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `upload-release-assets`: defaults to `TAYLORBOT_GITHUB_ACTION` (available org-wide in the `architect` context) for GitHub authentication instead of the GitHub App token. Falls back to the App token when the variable is absent or empty. The `github-token-env-var` parameter allows overriding the token source.
+- `generate-github-token`: new `token-env-var` parameter. When the named environment variable is non-empty at runtime, its value is exported as `GITHUB_TOKEN` and App token generation is skipped.
+
 ## [9.0.2] - 2026-06-02
 
 ### Changed

--- a/docs/job/upload-release-assets.md
+++ b/docs/job/upload-release-assets.md
@@ -11,6 +11,7 @@ Helm charts and container images are not uploaded here — they live in the OCI 
 - `binary`: Binary name as passed to `go-build` (required). The job uploads all matching files from the workspace: `<binary>-<GOOS>-<GOARCH>` and any `<binary>-<GOOS>-<GOARCH>.bundle` cosign signature bundles.
 - `attempts`: Maximum number of upload attempts (default: `12`). Each attempt waits 5s before retrying.
 - `resource_class`: CircleCI resource class (default: `small`).
+- `github-token-env-var`: Name of the environment variable holding a GitHub token with `contents:write` on the target repository (default: `TAYLORBOT_GITHUB_ACTION`). Falls back to the GitHub App token when the variable is absent or empty.
 
 ## Example usage
 
@@ -48,7 +49,7 @@ workflows:
 ## Notes
 
 - The job requires a `CIRCLE_TAG` to be set — always pair it with a tag filter.
-- Uses the `GITHUB_TOKEN` minted by `generate-github-token`; no extra credentials needed.
+- By default uses `TAYLORBOT_GITHUB_ACTION` from the `architect` context (org-wide). Falls back to the GitHub App token if that variable is absent or empty.
 - If signing is disabled (`sign: false` on `go-build`), no `.bundle` files are present and only the bare binaries are uploaded.
 
 See [Cosign signing](../cosign-signing.md) for how to verify the `.bundle` files after download.

--- a/src/commands/generate-github-token.yaml
+++ b/src/commands/generate-github-token.yaml
@@ -8,10 +8,30 @@ parameters:
   installation_id_env_var:
     type: string
     default: CIRCLECI_ARCHITECT_GITHUB_APP_INSTALLATION_ID
+  token-env-var:
+    description: |
+      Name of an environment variable holding a pre-minted GitHub token. When
+      the named variable is non-empty at runtime, it is exported as GITHUB_TOKEN
+      and App token generation is skipped. Falls back to the GitHub App when
+      the variable is absent or empty.
+    type: string
+    default: ""
 steps:
   - run:
       name: Generate temporary GitHub token
       command: |
+        # If a pre-minted token env var is specified and populated, use it directly.
+        TOKEN_ENV_VAR="<< parameters.token-env-var >>"
+        if [[ -n "$TOKEN_ENV_VAR" ]]; then
+          TOKEN="${!TOKEN_ENV_VAR:-}"
+          if [[ -n "$TOKEN" ]]; then
+            echo "Using token from \$${TOKEN_ENV_VAR}."
+            echo "export GITHUB_TOKEN=\"$TOKEN\"" >> "$BASH_ENV"
+            exit 0
+          fi
+          echo "Warning: \$${TOKEN_ENV_VAR} is set as token-env-var but the variable is empty; falling back to GitHub App token." >&2
+        fi
+
         if [[ -z "${<< parameters.private_key_base64_env_var >>:-}" ]]; then
           echo "ERROR: << parameters.private_key_base64_env_var >> is not set." >&2
           echo "Add 'context: architect' to this job in .circleci/config.yml to enable artifact signing." >&2

--- a/src/jobs/upload-release-assets.yaml
+++ b/src/jobs/upload-release-assets.yaml
@@ -34,11 +34,20 @@ parameters:
       for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
+  github-token-env-var:
+    description: |
+      Name of an environment variable holding a GitHub token with contents:write
+      on the target repository. Defaults to TAYLORBOT_GITHUB_ACTION, which is
+      available in the architect CircleCI context org-wide. Falls back to the
+      GitHub App token when the variable is absent or empty.
+    type: string
+    default: "TAYLORBOT_GITHUB_ACTION"
 steps:
   - checkout
   - attach_workspace:
       at: .
-  - generate-github-token
+  - generate-github-token:
+      token-env-var: << parameters.github-token-env-var >>
   - run:
       name: Upload release assets to GitHub
       command: |


### PR DESCRIPTION
`upload-release-assets` was failing with HTTP 403 when trying to upload binaries to GitHub Releases. The GitHub App used by `generate-github-token` is installed org-wide but does not have `contents:write`, and granting it that permission org-wide is too broad a blast radius.

`TAYLORBOT_GITHUB_ACTION` is already available in the `architect` CircleCI context org-wide and has the required `contents:write` scope.

**Changes:**

- `generate-github-token`: new `token-env-var` parameter. When the named env var is non-empty at runtime, exports it as `GITHUB_TOKEN` and skips App token generation entirely.
- `upload-release-assets`: new `github-token-env-var` parameter (default: `TAYLORBOT_GITHUB_ACTION`), wired through to `generate-github-token`. Falls back to the App token when the variable is absent or empty.

Existing callers need no changes. Any project using the `architect` context will automatically pick up `TAYLORBOT_GITHUB_ACTION`.