### PR TITLE
feat(go-build): append .exe to Windows binary names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- `go-build`: Windows targets now produce `<binary>-windows-<arch>.exe` instead of `<binary>-windows-<arch>`. The cosign signing glob and `upload-release-assets` glob both match `.exe` files without changes.
 - `cosign-sign-verify`: new `attest` kind alongside `oci`/`blob`. Reads a `<ref> <type> <predicate-file>` file and runs `cosign attest` + `cosign verify-attestation` for signed SBOM/in-toto attestations, keeping the CircleCI OIDC issuer/identity regex pair in one place.
 - `push-to-registries`: **behavior change for public CycloneDX SBOMs.** On public images with `sign: true`, the CycloneDX SBOM (`sbom-cyclonedx: true`) is now a *signed* cosign attestation (a sigstore-bundle referrer, `application/vnd.dev.sigstore.bundle.v0.3+json`) rather than the unsigned `application/vnd.cyclonedx+json` OCI referrer that v9.0.2 attached. Consumers discovering it via `oras discover --artifact-type application/vnd.cyclonedx+json` will no longer find it on public images — verify it with `cosign verify-attestation --type cyclonedx` instead (see [docs/cosign-signing.md](docs/cosign-signing.md)). Private images (and `sign: false`) are unchanged: still an unsigned `application/vnd.cyclonedx+json` referrer.
 - `upload-release-assets`: new `github-token-env-var` parameter. Uses the GitHub App token by default; set the parameter to an env var name (e.g. `TAYLORBOT_GITHUB_ACTION`) to use a pre-minted token instead.

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -86,13 +86,15 @@ steps:
           local goos="${arch%%/*}"
           local goarch="${arch##*/}"
           local binary_name="<<parameters.binary>>-${goos}-${goarch}"
+          local output_name="$binary_name"
+          [[ "$goos" == "windows" ]] && output_name="${binary_name}.exe"
 
-          echo "Building ${binary_name}..."
-          CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build "${build_flags[@]}" -ldflags "$LD_FLAGS" -tags "<<parameters.tags>>" -o "$binary_name" "<<parameters.path>>"
+          echo "Building ${output_name}..."
+          CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build "${build_flags[@]}" -ldflags "$LD_FLAGS" -tags "<<parameters.tags>>" -o "$output_name" "<<parameters.path>>"
 
           # If linux/amd64, also create/copy to <<parameters.binary>>
           if [[ "$goos" == "linux" && "$goarch" == "amd64" ]]; then
-            cp "$binary_name" "<<parameters.binary>>"
+            cp "$output_name" "<<parameters.binary>>"
           fi
         }
 


### PR DESCRIPTION
## What

`go-build` now produces `<binary>-windows-<arch>.exe` instead of `<binary>-windows-<arch>` when `GOOS=windows`.

The cosign signing loop and `upload-release-assets` both use the `<binary>-*-*` glob, which matches `.exe` files — no changes needed downstream.

## Why

The architect executor cross-compiles correctly with `GOOS=windows`, but the output filename lacked the `.exe` extension. Windows executes PE binaries without `.exe` from a terminal, but the missing extension breaks convention and prevents double-click execution. klausctl worked around this by omitting Windows targets entirely.