### PR TITLE
fix: share computed version between push-to-registries and push-to-app-catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `push-to-registries`: persists the computed image tag to `.build_version` in the workspace after `image-prepare-tag` runs.
+- `push-to-app-catalog`: reads `.build_version` from the workspace if present and uses it as the chart/app version instead of calling `gitsemver get`. Falls back to `gitsemver get` when the file is absent (no workspace attached, or `push-to-registries` did not run upstream). To use: set `attach_workspace: true` on `push-to-app-catalog` and add `push-to-registries` to its `requires` list — both jobs then stamp the same version, eliminating the wall-clock drift that caused `ImagePullBackoff` in ATS chart tests.
+
 ## [9.1.0] - 2026-06-03
 
 ### Added

--- a/src/commands/image-prepare-tag.yaml
+++ b/src/commands/image-prepare-tag.yaml
@@ -9,3 +9,10 @@ steps:
         gitsemver get | tr -d "\n" | tee /tmp/.docker_image_tag
         echo -n "<<parameters.tag-suffix>>" | tee -a /tmp/.docker_image_tag
         echo 'export DOCKER_IMAGE_TAG=$(cat /tmp/.docker_image_tag)' >> $BASH_ENV
+  - run:
+      name: "architect/image-prepare-tag: Write computed version to .build_version"
+      command: cp /tmp/.docker_image_tag .build_version
+  - persist_to_workspace:
+      root: .
+      paths:
+        - .build_version

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -108,7 +108,11 @@ steps:
   - run:
       name: "architect/package-helm-with-abs: Execute App Build Suite"
       command: |
-        VERSION=$(gitsemver get | tr -d "\n")
+        if [ -f .build_version ]; then
+          VERSION=$(tr -d "\n" < .build_version)
+        else
+          VERSION=$(gitsemver get | tr -d "\n")
+        fi
         OVERRIDES="--override-chart-version ${VERSION} --override-app-version ${VERSION}"
         mkdir build && python -m app_build_suite \
           --chart-dir ./helm/<< parameters.chart >> \


### PR DESCRIPTION
## What

`push-to-registries` now persists the image tag it computed to `.build_version` in the workspace. `push-to-app-catalog` reads `.build_version` when present instead of calling `gitsemver get` again.

## Why

`gitsemver` embeds the wall-clock time in dev version strings. When the two jobs run in parallel they each call `gitsemver` independently and get different timestamps. The chart's `appVersion` ends up pointing at a tag that was never pushed to the registry — ATS deploys the chart, the pod goes `ImagePullBackoff`, and the smoke test times out.

## How to opt in

In your workflow:

1. Add `attach_workspace: true` to `push-to-app-catalog`.
2. Add `push-to-registries` to `push-to-app-catalog`'s `requires` list.

Both jobs then stamp the same version. Repos that don't change their config keep the existing behaviour (fall back to `gitsemver get`).