### PR TITLE
fix: Raise `no_output_timeout` for multi-arch image build to avoid cross-platform Go builds from timing out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- `image-build-and-push`: raise `no_output_timeout` to 20m for the multi-arch build step to accommodate slower cross-platform Go builds.
 - `push-to-registries`: persists the computed image tag to `.build_version` in the workspace after `image-prepare-tag` runs.
 - `push-to-app-catalog`: reads `.build_version` from the workspace if present and uses it as the chart/app version instead of calling `gitsemver get`. Falls back to `gitsemver get` when the file is absent (no workspace attached, or `push-to-registries` did not run upstream). To use: set `attach_workspace: true` on `push-to-app-catalog` and add `push-to-registries` to its `requires` list — both jobs then stamp the same version, eliminating the wall-clock drift that caused `ImagePullBackoff` in ATS chart tests.
 

--- a/src/commands/image-build-and-push.yaml
+++ b/src/commands/image-build-and-push.yaml
@@ -95,6 +95,10 @@ steps:
   - generate-github-token
   - run:
       name: Build and push multi-arch image to all registries
+
+      # Cross-platform builds may be slower (e.g. `GOARCH=arm64 go build` from another architecture)
+      no_output_timeout: 20m
+
       command: |
         # Determine tag value from tag_envvar or fallback
         TAG_VALUE="${DOCKER_IMAGE_TAG}"


### PR DESCRIPTION
Otherwise we may get errors like this even for small projects:

```
[...]
#31 [linux/arm64 builder 10/10] RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o manager main.go

Too long with no output (exceeded 10m0s): context deadline exceeded
```