### PR TITLE
fix(cosign-sign-verify): handle Rekor duplicate entry error as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `cosign-sign-verify`: `oci` and `attest` signing loops no longer fail when Rekor rejects a duplicate entry ("an equivalent entry already exists in the transparency log"). This happens when a deterministic build produces the same image digest across two CI runs (e.g., a dev build followed by a release build with identical content). The duplicate is now treated as success and the verify step still runs.
+
 ## [9.2.0] - 2026-06-09
 
 ### Changed

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -70,7 +70,13 @@ steps:
             while IFS= read -r ref; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign sign $ref"
-              cosign sign --yes "$ref"
+              if ! out=$(cosign sign --yes "$ref" 2>&1); then
+                if echo "$out" | grep -q "an equivalent entry already exists"; then
+                  echo "Rekor: entry already exists for $ref, skipping sign."
+                else
+                  echo "$out" >&2; exit 1
+                fi
+              fi
               echo "cosign verify $ref"
               cosign verify \
                 --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
@@ -102,7 +108,13 @@ steps:
             while IFS=' ' read -r ref type predicate; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign attest --type $type $ref (predicate: $predicate)"
-              cosign attest --yes --type "$type" --predicate "$predicate" "$ref"
+              if ! out=$(cosign attest --yes --type "$type" --predicate "$predicate" "$ref" 2>&1); then
+                if echo "$out" | grep -q "an equivalent entry already exists"; then
+                  echo "Rekor: entry already exists for $ref ($type), skipping attest."
+                else
+                  echo "$out" >&2; exit 1
+                fi
+              fi
               echo "cosign verify-attestation --type $type $ref"
               cosign verify-attestation \
                 --type "$type" \


### PR DESCRIPTION
## What

`cosign sign` and `cosign attest` in `cosign-sign-verify` fail with:

```
error: uploading to rekor: an equivalent entry already exists in the transparency log
```

The step runs under `set -euo pipefail`, so this hard-fails the CI job even though the image was pushed successfully and the signature/attestation is already present in Rekor.

## Why

Rekor is content-addressed. When a deterministic build produces the same image digest across two CI runs (e.g., a dev pipeline followed by a release pipeline with no intervening code change), the second cosign submission is rejected as a duplicate. Retrying makes no difference.

Reported against architect 9.2 in docs-indexer: both dev and release builds affected.

## Fix

Both the `oci` and `attest` loops now capture cosign's output and check for the specific Rekor message. A match logs a diagnostic and continues; any other error still propagates as a failure. The verify step always runs (the entry is in Rekor regardless of who put it there).

`blob` is unchanged — it writes a local bundle file, no Rekor dedup path.