### PR TITLE
feat(push-to-app-catalog): add override_chart_version / override_app_version opt-out params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `push-to-app-catalog`: new `override_chart_version` and `override_app_version` boolean parameters (both default `true`). When `true`, App Build Suite receives `--override-chart-version` / `--override-app-version` stamped with the `gitsemver`-computed version, which is the existing default behaviour. Set either to `false` to leave the corresponding version field in `Chart.yaml` unchanged.
+- `package-helm-with-abs`: new command that encapsulates the App Build Suite invocation extracted from `push-to-app-catalog`, accepting `chart`, `override_chart_version`, and `override_app_version` parameters. The command runs with `set -euo pipefail`, guards that `.app_catalog_name` exists before proceeding, skips version computation entirely when both override flags are false, validates that the resolved version string is non-empty, and uses `mkdir -p build` for idempotency.
+
 ### Fixed
 
 - `cosign-sign-verify`: `oci` and `attest` signing loops no longer fail when Rekor rejects a duplicate entry ("an equivalent entry already exists in the transparency log"). This happens when a deterministic build produces the same image digest across two CI runs (e.g., a dev build followed by a release build with identical content). The duplicate is now treated as success and the verify step still runs.

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -64,6 +64,8 @@ documentation](https://helm.sh/blog/storing-charts-in-oci/).
 - [push_to_appcatalog](#push_to_appcatalog-optional-boolean-defaulttrue)
 - [push_to_oci_registry](#push_to_oci_registry-optional-boolean-defaulttrue)
 - [sign](#sign-optional-boolean-defaulttrue)
+- [override_chart_version](#override_chart_version-optional-boolean-defaulttrue)
+- [override_app_version](#override_app_version-optional-boolean-defaulttrue)
 
 ### attach_workspace
 
@@ -147,3 +149,16 @@ publish digest + timestamp metadata to the public Rekor transparency log).
 
 See [Cosign signing](../cosign-signing.md) for the verification command
 and the end-to-end identity model.
+
+### override_chart_version (optional boolean, default=true)
+
+When `true` (the default), passes `--override-chart-version` to App Build Suite, stamping the
+chart's `version` field with the value computed by `gitsemver` (or read from the `.build_version`
+workspace file). Set to `false` to leave the `version` field in `Chart.yaml` unchanged.
+
+### override_app_version (optional boolean, default=true)
+
+When `true` (the default), passes `--override-app-version` to App Build Suite, stamping the
+chart's `appVersion` field with the value computed by `gitsemver` (or read from the
+`.build_version` workspace file). Set to `false` to leave the `appVersion` field in `Chart.yaml`
+unchanged.

--- a/src/commands/package-helm-with-abs.yaml
+++ b/src/commands/package-helm-with-abs.yaml
@@ -1,0 +1,54 @@
+parameters:
+  chart:
+    description: "Name of the chart inside helm directory to build."
+    type: "string"
+  override_chart_version:
+    type: boolean
+    default: true
+    description: |
+      When `true`, passes `--override-chart-version <version>` to App Build Suite,
+      stamping the chart version with the value computed by `gitsemver` (or read
+      from the `.build_version` workspace file).  Set to `false` to leave the
+      version declared in `Chart.yaml` unchanged.
+  override_app_version:
+    type: boolean
+    default: true
+    description: |
+      When `true`, passes `--override-app-version <version>` to App Build Suite,
+      stamping the app version with the value computed by `gitsemver` (or read
+      from the `.build_version` workspace file).  Set to `false` to leave the
+      appVersion declared in `Chart.yaml` unchanged.
+steps:
+  - run:
+      name: "architect/package-helm-with-abs: Execute App Build Suite"
+      command: |
+        set -euo pipefail
+        if [ ! -f .app_catalog_name ]; then
+          echo "ERROR: .app_catalog_name not found — run determine-catalog-name before this command"
+          exit 1
+        fi
+        OVERRIDES=""
+        if [ "<< parameters.override_chart_version >>" = "true" ] || [ "<< parameters.override_app_version >>" = "true" ]; then
+          if [ -f .build_version ]; then
+            VERSION=$(tr -d "\n" < .build_version)
+          else
+            VERSION=$(gitsemver get | tr -d "\n")
+          fi
+          if [ -z "${VERSION}" ]; then
+            echo "ERROR: could not determine build version (.build_version is empty and gitsemver returned nothing)"
+            exit 1
+          fi
+          if [ "<< parameters.override_chart_version >>" = "true" ]; then
+            OVERRIDES="${OVERRIDES} --override-chart-version ${VERSION}"
+          fi
+          if [ "<< parameters.override_app_version >>" = "true" ]; then
+            OVERRIDES="${OVERRIDES} --override-app-version ${VERSION}"
+          fi
+        fi
+        mkdir -p build && python -m app_build_suite \
+          --chart-dir ./helm/<< parameters.chart >> \
+          --destination build \
+          --generate-metadata \
+          --catalog-base-url "https://giantswarm.github.io/$(cat .app_catalog_name)/" \
+          --keep-chart-changes \
+          ${OVERRIDES}

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -74,6 +74,20 @@ parameters:
     description: |
       This parameter has no effect anymore, it is kept for backwards compatibility.
       Will be removed in a future version.
+  override_chart_version:
+    type: boolean
+    default: true
+    description: |
+      When `true` (the default), passes `--override-chart-version` to App Build Suite,
+      stamping the chart version with the value from `gitsemver` (or `.build_version`
+      workspace file).  Set to `false` to leave the version in `Chart.yaml` unchanged.
+  override_app_version:
+    type: boolean
+    default: true
+    description: |
+      When `true` (the default), passes `--override-app-version` to App Build Suite,
+      stamping the app version with the value from `gitsemver` (or `.build_version`
+      workspace file).  Set to `false` to leave the appVersion in `Chart.yaml` unchanged.
   persist_chart_archive:
     type: boolean
     default: false
@@ -105,22 +119,10 @@ steps:
       steps:
         - attach_workspace:
             at: .
-  - run:
-      name: "architect/package-helm-with-abs: Execute App Build Suite"
-      command: |
-        if [ -f .build_version ]; then
-          VERSION=$(tr -d "\n" < .build_version)
-        else
-          VERSION=$(gitsemver get | tr -d "\n")
-        fi
-        OVERRIDES="--override-chart-version ${VERSION} --override-app-version ${VERSION}"
-        mkdir build && python -m app_build_suite \
-          --chart-dir ./helm/<< parameters.chart >> \
-          --destination build \
-          --generate-metadata \
-          --catalog-base-url "https://giantswarm.github.io/$(cat .app_catalog_name)/" \
-          --keep-chart-changes \
-          ${OVERRIDES}
+  - package-helm-with-abs:
+      chart: << parameters.chart >>
+      override_chart_version: << parameters.override_chart_version >>
+      override_app_version: << parameters.override_app_version >>
   - push-helm:
       push_to_appcatalog: << parameters.push_to_appcatalog >>
       push_to_oci_registry: << parameters.push_to_oci_registry >>


### PR DESCRIPTION
## Summary

- Extracts the App Build Suite invocation from `push-to-app-catalog` into a new reusable command `package-helm-with-abs`, fixing a guidelines violation (jobs must only call commands, no inline `run:` steps).
- Adds `override_chart_version` and `override_app_version` boolean parameters (both default `true`) to the job and command, allowing callers to opt out of having `gitsemver`-computed versions stamped into `Chart.yaml`.
- Hardens the new command based on code-review findings: strict mode, input guards, empty-version detection, idempotent `mkdir`.

## What changed

**`src/jobs/push-to-app-catalog.yaml`**
- Two new boolean params `override_chart_version` / `override_app_version` (default `true`); existing callers unaffected.
- Inline `run:` step replaced with `package-helm-with-abs:` command call.

**`src/commands/package-helm-with-abs.yaml`** (new)
- `set -euo pipefail` — consistent with all other non-trivial commands in the orb.
- Guards `.app_catalog_name` presence at the top; emits an actionable error rather than silently building a malformed catalog URL.
- Gates `VERSION` computation on whether at least one override flag is `true`; validates the resolved string is non-empty — prevents a silent argparse misparse (`--override-chart-version --override-app-version` with no value) when `.build_version` is empty or `gitsemver get` returns nothing.
- `mkdir -p build` — idempotent across job retries and workspace-attached builds.

**`docs/job/push-to-app-catalog.md`**
- Both new parameters added to the parameter list and documented with dedicated subsections.

## Test plan

- [ ] Reference dev version in a consuming repo: `architect: giantswarm/architect@dev:config-version-override`
- [ ] Verify default behaviour (both flags `true`): chart and app version are stamped by gitsemver as before.
- [ ] Verify opt-out: set `override_chart_version: false` + `override_app_version: false`; confirm `Chart.yaml` versions are left unchanged in the published chart.
- [ ] Verify guard: trigger the step without a prior `determine-catalog-name` and confirm the error message fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)