### PR TITLE
fix(cosign-sign-verify): retry sign-blob on Rekor duplicate entry conflict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,16 +11,17 @@ binaries, Docker images, and Helm charts to Giant Swarm's image and chart regist
 There are no local build or test commands — the orb is developed by pushing branches and testing against
 CircleCI.
 
-**Testing changes**: Each branch push publishes a dev version tagged with the full commit SHA, plus
-`dev:alpha` pointing at the latest dev publish. Reference it in a consuming repo's
-`.circleci/config.yml` (get the SHA with `git rev-parse HEAD`):
+**Testing changes**: Each branch push publishes the dev orb under three tags: `dev:<branch-name>`,
+`dev:<full-commit-sha>`, and `dev:alpha` (latest dev publish of any branch). Reference the branch-name
+tag in a consuming repo's `.circleci/config.yml` — it always points at the latest push of the branch:
 
 ```yaml
 orbs:
-  architect: giantswarm/architect@dev:f913fe73fffd5342ea25f8d431a3c76f2d699e41
+  architect: giantswarm/architect@dev:my-branch-name
 ```
 
-Dev versions are mutable and auto-deleted after 90 days. There is no `dev:<branch-name>` tag.
+Use the commit-SHA tag instead when a run must be pinned to an exact revision. Dev versions are mutable
+and auto-deleted after 90 days.
 
 **CI pipeline** (`.circleci/config.yml`):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,16 @@ binaries, Docker images, and Helm charts to Giant Swarm's image and chart regist
 There are no local build or test commands — the orb is developed by pushing branches and testing against
 CircleCI.
 
-**Testing changes**: Reference the dev version in a consuming repo's `.circleci/config.yml`:
+**Testing changes**: Each branch push publishes a dev version tagged with the full commit SHA, plus
+`dev:alpha` pointing at the latest dev publish. Reference it in a consuming repo's
+`.circleci/config.yml` (get the SHA with `git rev-parse HEAD`):
 
 ```yaml
 orbs:
-  architect: giantswarm/architect@dev:your-branch-name
+  architect: giantswarm/architect@dev:f913fe73fffd5342ea25f8d431a3c76f2d699e41
 ```
 
-Dev versions are mutable and auto-deleted after 90 days.
+Dev versions are mutable and auto-deleted after 90 days. There is no `dev:<branch-name>` tag.
 
 **CI pipeline** (`.circleci/config.yml`):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - CI: branch pushes now additionally publish the dev orb as `dev:<branch-name>` (alongside the existing
   `dev:<commit-sha>` and `dev:alpha`), giving a stable per-branch reference for testing in consuming repos.
 
+### Fixed
+
+- `cosign-sign-verify`: the `blob` signing loop no longer fails when Rekor rejects the upload with
+  "an equivalent entry already exists in the transparency log" (HTTP 409). This extends the v9.3.0 fix
+  for `oci`/`attest` to binaries. Unlike OCI signing, the duplicate cannot simply be skipped because
+  the local bundle file (needed by `verify-blob` and uploaded as a release asset) is only written on
+  success — instead `cosign sign-blob` is retried up to 3 times, which succeeds because each invocation
+  generates fresh ephemeral keys and thus a new, non-equivalent Rekor entry.
+
 ## [9.3.0] - 2026-06-09
 
 ### Added

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -65,13 +65,19 @@ steps:
         ISSUER_REGEX='^https://oidc\.circleci\.com'
         IDENTITY_REGEX='^https://circleci\.com/api/v2/projects/[a-f0-9-]+/pipeline-definitions/[a-f0-9-]+$'
 
+        # Rekor duplicate-entry rejection (HTTP 409). Matched with `grep -E`.
+        # The structured token (createLogEntryConflict) appears in sign-blob
+        # errors; the prose is all the `oci`/`attest` errors carry, so both
+        # alternatives are needed.
+        REKOR_DUP_PATTERN='createLogEntryConflict|an equivalent entry already exists'
+
         case "<<parameters.kind>>" in
           oci)
             while IFS= read -r ref; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign sign $ref"
               if ! out=$(cosign sign --yes "$ref" 2>&1); then
-                if echo "$out" | grep -q "an equivalent entry already exists"; then
+                if echo "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
                   echo "Rekor: entry already exists for $ref, skipping sign."
                 else
                   echo "$out" >&2; exit 1
@@ -95,12 +101,13 @@ steps:
             while IFS=' ' read -r file bundle; do
               [[ -z "$file" || "$file" =~ ^# ]] && continue
               echo "cosign sign-blob $file → $bundle"
-              for attempt in 1 2 3; do
+              attempts=3
+              for attempt in $(seq 1 "$attempts"); do
                 rm -f "$bundle"
                 if out=$(cosign sign-blob --yes --bundle "$bundle" "$file" 2>&1); then
                   break
                 fi
-                if echo "$out" | grep -q "an equivalent entry already exists" && [[ "$attempt" -lt 3 ]]; then
+                if echo "$out" | grep -Eq "$REKOR_DUP_PATTERN" && [[ "$attempt" -lt "$attempts" ]]; then
                   echo "Rekor: duplicate entry conflict for $file (attempt $attempt), retrying with fresh keys."
                 else
                   echo "$out" >&2; exit 1
@@ -126,7 +133,7 @@ steps:
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign attest --type $type $ref (predicate: $predicate)"
               if ! out=$(cosign attest --yes --type "$type" --predicate "$predicate" "$ref" 2>&1); then
-                if echo "$out" | grep -q "an equivalent entry already exists"; then
+                if echo "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
                   echo "Rekor: entry already exists for $ref ($type), skipping attest."
                 else
                   echo "$out" >&2; exit 1

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -85,10 +85,27 @@ steps:
             done < "$refs_file"
             ;;
           blob)
+            # Rekor can reject the upload with "an equivalent entry already
+            # exists" (HTTP 409) when its client retries a POST that already
+            # succeeded server-side. Unlike `oci`/`attest`, the duplicate cannot
+            # be skipped: the bundle file is only written on success, and
+            # verify-blob needs it. But sign-blob mints fresh ephemeral keys per
+            # invocation — a retry produces a new, non-equivalent entry — so a
+            # full re-run resolves the conflict.
             while IFS=' ' read -r file bundle; do
               [[ -z "$file" || "$file" =~ ^# ]] && continue
               echo "cosign sign-blob $file → $bundle"
-              cosign sign-blob --yes --bundle "$bundle" "$file"
+              for attempt in 1 2 3; do
+                rm -f "$bundle"
+                if out=$(cosign sign-blob --yes --bundle "$bundle" "$file" 2>&1); then
+                  break
+                fi
+                if echo "$out" | grep -q "an equivalent entry already exists" && [[ "$attempt" -lt 3 ]]; then
+                  echo "Rekor: duplicate entry conflict for $file (attempt $attempt), retrying with fresh keys."
+                else
+                  echo "$out" >&2; exit 1
+                fi
+              done
               echo "cosign verify-blob $file"
               cosign verify-blob \
                 --bundle "$bundle" \


### PR DESCRIPTION
## What

`cosign sign-blob` in `cosign-sign-verify` (kind `blob`) fails with:

```
[POST /api/v1/log/entries][409] createLogEntryConflict {"code":409,"message":"an equivalent entry already exists in the transparency log ..."}
```

Example: https://app.circleci.com/pipelines/github/giantswarm/search-mcp/396/workflows/21503f6f-dca3-43c6-b980-8c902ce233b6/jobs/782

## Why

#814 fixed this for `oci` and `attest` but left `blob` unchanged on the assumption that sign-blob has no Rekor dedup path. That assumption was wrong: with cosign v3, the sigstore bundle embeds the transparency log entry, so the Rekor upload happens inside `sign-blob` itself. The 409 occurs when the Rekor client retries a POST that already succeeded server-side.

## Fix

The skip-on-duplicate approach from #814 cannot be reused here: on a 409 the bundle file is never written, and `verify-blob --bundle` (and the release-asset upload) needs it. Instead, `cosign sign-blob` is retried up to 3 times. Each invocation generates fresh ephemeral keys, so a retry produces a new, non-equivalent Rekor entry and succeeds. Any non-409 error still fails immediately, and a persistent 409 after 3 attempts still fails the job.