### PR TITLE
feat(ci): publish dev orb under dev:<branch-name> as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ workflows:
           vcs_type: github
           enable_pr_comment: false
           circleci_token: CIRCLECI_DEV_API_TOKEN
+          # Tags are expanded with `circleci env subst`; dev:${CIRCLE_BRANCH}
+          # gives a stable per-branch reference for testing in consuming repos.
+          dev_tags: dev:${CIRCLE_SHA1},dev:alpha,dev:${CIRCLE_BRANCH}
           requires:
             - "orb-tools/pack"
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- CI: branch pushes now additionally publish the dev orb as `dev:<branch-name>` (alongside the existing
+  `dev:<commit-sha>` and `dev:alpha`), giving a stable per-branch reference for testing in consuming repos.
+
 ## [9.3.0] - 2026-06-09
 
 ### Added


### PR DESCRIPTION
## What

Adds `dev_tags: dev:${CIRCLE_SHA1},dev:alpha,dev:${CIRCLE_BRANCH}` to the `publish-branch` job, so each branch push additionally publishes the dev orb as `giantswarm/architect@dev:<branch-name>`.

## Why

Until now dev versions were only addressable by full commit SHA (or the shared `dev:alpha`), so a consuming repo's test config had to be updated after every push. The branch-name tag is mutable and always points at the latest push of that branch — a stable reference while iterating.

The `dev_tags` parameter of `orb-tools/publish` runs each tag through `circleci env subst`, so `${CIRCLE_BRANCH}` expands at publish time. The existing `dev:<sha>` and `dev:alpha` tags are kept.

## Notes

- This branch itself serves as the end-to-end test: if `publish-branch` succeeds here, `giantswarm/architect@dev:add-branch-dev-tag` exists.
- Branch names with slashes (e.g. `renovate/...`) should be checked once before relying on them; CircleCI dev labels are permissive, but slashed labels haven't been verified end to end.
- Follow-up: once this and #820 are both merged, the dev-version note in `AGENTS.md` should mention the branch-name tag (kept out of this PR to avoid conflicting with #820's edit of the same lines).