### PR TITLE
fix(cosign-sign-verify): retry transient signing-backend errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   including these transient ones, fell straight through to `exit 1`, so a single flake on one of N per-arch
   signatures failed the job and forced a manual rerun. Every cosign network call (`sign`, `verify`,
   `sign-blob`, `verify-blob`, `attest`, `verify-attestation`) is now retried up to 4 times (backoff 5s, 10s,
-  20s) when the error matches a known transient pattern, with clear per-attempt logging. Permanent errors
-  (4xx auth/config, bad refs) are not retried and still fail fast; the existing HTTP 409 duplicate handling
-  is preserved.
+  20s) when the error matches a known transient pattern, with clear per-attempt logging. Auth/config 4xx
+  (401/403/404) and bad refs are not retried and still fail fast (408/425/429 and 5xx are treated as
+  transient); the existing HTTP 409 duplicate handling is preserved.
 - `cosign-sign-verify`: the `blob` signing loop no longer fails when Rekor rejects the upload with
   "an equivalent entry already exists in the transparency log" (HTTP 409). This extends the v9.3.0 fix
   for `oci`/`attest` to binaries. Unlike OCI signing, the duplicate cannot simply be skipped because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- `cosign-sign-verify`: transient signing-backend failures are now retried with exponential backoff instead
+  of failing the whole publish job. The keyless flow talks to Fulcio, Rekor and the OCI registry over HTTP/2,
+  and the public-good Sigstore infrastructure intermittently aborts a stream mid-request (e.g. `signing
+  bundle: error signing bundle: stream error: stream ID 1; INTERNAL_ERROR; received from peer`) or returns a
+  5xx/timeout. Previously only Rekor duplicate-entry conflicts (HTTP 409) were handled — any other error,
+  including these transient ones, fell straight through to `exit 1`, so a single flake on one of N per-arch
+  signatures failed the job and forced a manual rerun. Every cosign network call (`sign`, `verify`,
+  `sign-blob`, `verify-blob`, `attest`, `verify-attestation`) is now retried up to 4 times (backoff 5s, 10s,
+  20s) when the error matches a known transient pattern, with clear per-attempt logging. Permanent errors
+  (4xx auth/config, bad refs) are not retried and still fail fast; the existing HTTP 409 duplicate handling
+  is preserved.
 - `cosign-sign-verify`: the `blob` signing loop no longer fails when Rekor rejects the upload with
   "an equivalent entry already exists in the transparency log" (HTTP 409). This extends the v9.3.0 fix
   for `oci`/`attest` to binaries. Unlike OCI signing, the duplicate cannot simply be skipped because
   the local bundle file (needed by `verify-blob` and uploaded as a release asset) is only written on
-  success — instead `cosign sign-blob` is retried up to 3 times, which succeeds because each invocation
+  success — instead `cosign sign-blob` is retried up to 4 times, which succeeds because each invocation
   generates fresh ephemeral keys and thus a new, non-equivalent Rekor entry.
 
 ## [9.3.0] - 2026-06-09

--- a/docs/cosign-signing.md
+++ b/docs/cosign-signing.md
@@ -83,6 +83,25 @@ signature isn't actually verifiable (wrong audience, wrong issuer, identity
 mismatch). Without it we'd ship "signed" artifacts that no consumer can
 verify and only find out from a downstream report.
 
+## Resilience to transient backend errors
+
+The keyless flow talks to Fulcio, Rekor and the OCI registry over HTTP/2, and
+the public-good Sigstore infrastructure intermittently aborts a stream
+mid-request (e.g. `signing bundle: error signing bundle: stream error: stream
+ID 1; INTERNAL_ERROR; received from peer`) or returns a 5xx/timeout. Because a
+publish job signs many artifacts (each registry, each architecture, each SBOM),
+a single such flake used to fail the whole job and force a manual rerun.
+
+Every cosign network call (`sign`, `verify`, `sign-blob`, `verify-blob`,
+`attest`, `verify-attestation`) is therefore retried up to `MAX_ATTEMPTS` (4)
+times with exponential backoff (5s, 10s, 20s) when the error matches a known
+transient pattern. Permanent errors — 4xx auth/config failures, a bad
+reference — are deliberately **not** retried, so genuine misconfiguration still
+fails fast. Rekor duplicate-entry conflicts (HTTP 409) keep their existing
+handling: skipped for `oci`/`attest` (the signature already exists), retried
+with fresh ephemeral keys for `blob` (where the bundle file must be produced
+locally).
+
 ## Verifying signatures as a consumer
 
 ### Container image

--- a/docs/cosign-signing.md
+++ b/docs/cosign-signing.md
@@ -95,9 +95,10 @@ a single such flake used to fail the whole job and force a manual rerun.
 Every cosign network call (`sign`, `verify`, `sign-blob`, `verify-blob`,
 `attest`, `verify-attestation`) is therefore retried up to `MAX_ATTEMPTS` (4)
 times with exponential backoff (5s, 10s, 20s) when the error matches a known
-transient pattern. Permanent errors — 4xx auth/config failures, a bad
-reference — are deliberately **not** retried, so genuine misconfiguration still
-fails fast. Rekor duplicate-entry conflicts (HTTP 409) keep their existing
+transient pattern. Auth/config 4xx (401/403/404) and bad references are
+deliberately **not** retried, so genuine misconfiguration still fails fast;
+408/425/429 (timeout / too-early / rate-limit) and 5xx, by contrast, are
+treated as transient. Rekor duplicate-entry conflicts (HTTP 409) keep their existing
 handling: skipped for `oci`/`attest` (the signature already exists), retried
 with fresh ephemeral keys for `blob` (where the bundle file must be produced
 locally).

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -75,16 +75,24 @@ steps:
         # keyless flow talks to Fulcio, Rekor and the OCI registry over HTTP/2,
         # and the public-good infrastructure intermittently aborts a stream
         # mid-request (e.g. `signing bundle: error signing bundle: stream error:
-        # stream ID 1; INTERNAL_ERROR; received from peer`) or returns a
-        # 5xx/timeout. These are unrelated to the artifact or our config, so a
-        # fresh attempt almost always succeeds. Without this, a single flake on
-        # any one of N per-arch signatures fails the whole publish job and forces
-        # a manual rerun. Auth/config 4xx (401/403/404) and bad refs are
-        # deliberately NOT listed, so genuine misconfiguration still fails fast;
-        # 408/425/429 are timeout/too-early/rate-limit codes and ARE transient.
-        TRANSIENT_PATTERN='INTERNAL_ERROR|stream error|connection reset|connection refused|broken pipe'
-        TRANSIENT_PATTERN+='|unexpected EOF|TLS handshake|i/o timeout|context deadline exceeded|timeout'
-        TRANSIENT_PATTERN+='|408 |425 |429 |500 |502 |503 |504 |Service Unavailable|Bad Gateway|Gateway Time-?out|too many requests'
+        # stream ID 1; INTERNAL_ERROR; received from peer`) or returns a 5xx/429.
+        # These are unrelated to the artifact or our config, so a fresh attempt
+        # almost always succeeds; without this a single flake on one of N per-arch
+        # signatures fails the whole publish job and forces a manual rerun.
+        #
+        # Every alternative below is a SPECIFIC network/transport signal or an
+        # HTTP status in a form Go actually emits — a 5xx/429/408 reason phrase
+        # (resp.Status from net/http & go-containerregistry) or an anchored
+        # `status NNN` (the go-openapi Rekor client). It deliberately avoids bare
+        # tokens like `timeout` or `500 `: those match permanent-error text too
+        # (a "timeout policy" message, or `500` inside a digest), which would burn
+        # the whole ~35s backoff budget retrying something doomed to fail anyway.
+        # Auth/config 4xx (401/403/404) and bad refs are NOT listed, so genuine
+        # misconfiguration still fails fast.
+        TRANSIENT_PATTERN='INTERNAL_ERROR|stream error|GOAWAY|connection reset|connection refused|broken pipe'
+        TRANSIENT_PATTERN+='|unexpected EOF|TLS handshake timeout|i/o timeout|context deadline exceeded|Client\.Timeout'
+        TRANSIENT_PATTERN+='|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|Too Many Requests|Request Timeout'
+        TRANSIENT_PATTERN+='|[Ss]tatus:? (408|425|429|5[0-9][0-9])'
 
         # Attempts per cosign network call (1 initial try + up to 3 retries).
         MAX_ATTEMPTS=4

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -71,23 +71,77 @@ steps:
         # alternatives are needed.
         REKOR_DUP_PATTERN='createLogEntryConflict|an equivalent entry already exists'
 
+        # Transient backend failures that warrant a retry with backoff. The
+        # keyless flow talks to Fulcio, Rekor and the OCI registry over HTTP/2,
+        # and the public-good infrastructure intermittently aborts a stream
+        # mid-request (e.g. `signing bundle: error signing bundle: stream error:
+        # stream ID 1; INTERNAL_ERROR; received from peer`) or returns a
+        # 5xx/timeout. These are unrelated to the artifact or our config, so a
+        # fresh attempt almost always succeeds. Without this, a single flake on
+        # any one of N per-arch signatures fails the whole publish job and forces
+        # a manual rerun. Permanent errors (4xx auth/config, bad ref) are NOT
+        # listed here on purpose, so they still fail fast.
+        TRANSIENT_PATTERN='INTERNAL_ERROR|stream error|connection reset|connection refused|broken pipe'
+        TRANSIENT_PATTERN+='|unexpected EOF|TLS handshake|i/o timeout|context deadline exceeded|timeout'
+        TRANSIENT_PATTERN+='|408 |425 |429 |500 |502 |503 |504 |Service Unavailable|Bad Gateway|Gateway Time-?out|too many requests'
+
+        # Attempts per cosign network call (1 initial try + up to 3 retries).
+        MAX_ATTEMPTS=4
+
+        # backoff <attempt> — exponential delay (5s, 10s, 20s, …) before retry.
+        backoff() {
+          local delay=$(( 5 * (2 ** ($1 - 1)) ))
+          echo "    └─ retrying in ${delay}s …" >&2
+          sleep "$delay"
+        }
+
+        # cosign_retry <label> <cmd…> — run a cosign network operation, retrying
+        # ONLY transient backend errors (see TRANSIENT_PATTERN) with exponential
+        # backoff. Output is captured rather than streamed so it can be
+        # classified; on success it is discarded to keep happy-path logs quiet
+        # (matching the previous behaviour). Exit status:
+        #   0  success
+        #   42 Rekor reports the entry already exists (caller decides to skip)
+        #   1  permanent failure (captured output already printed to stderr)
+        cosign_retry() {
+          local label="$1"; shift
+          local attempt out
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if out=$("$@" 2>&1); then
+              return 0
+            fi
+            if printf '%s' "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
+              return 42
+            fi
+            if printf '%s' "$out" | grep -Eq "$TRANSIENT_PATTERN" && [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+              echo "WARNING: ${label}: transient signing-backend error (attempt ${attempt}/${MAX_ATTEMPTS})" >&2
+              printf '%s\n' "$out" | sed 's/^/    │ /' >&2
+              backoff "$attempt"
+              continue
+            fi
+            printf '%s\n' "$out" >&2
+            return 1
+          done
+          return 1
+        }
+
         case "<<parameters.kind>>" in
           oci)
             while IFS= read -r ref; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign sign $ref"
-              if ! out=$(cosign sign --yes "$ref" 2>&1); then
-                if echo "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
-                  echo "Rekor: entry already exists for $ref, skipping sign."
-                else
-                  echo "$out" >&2; exit 1
-                fi
+              rc=0; cosign_retry "sign $ref" cosign sign --yes "$ref" || rc=$?
+              if [[ "$rc" -eq 42 ]]; then
+                echo "Rekor: entry already exists for $ref, skipping sign."
+              elif [[ "$rc" -ne 0 ]]; then
+                exit 1
               fi
               echo "cosign verify $ref"
-              cosign verify \
+              rc=0; cosign_retry "verify $ref" cosign verify \
                 --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
                 --certificate-identity-regexp "$IDENTITY_REGEX" \
-                "$ref" > /dev/null
+                "$ref" || rc=$?
+              [[ "$rc" -eq 0 ]] || exit 1
             done < "$refs_file"
             ;;
           blob)
@@ -97,28 +151,36 @@ steps:
             # be skipped: the bundle file is only written on success, and
             # verify-blob needs it. But sign-blob mints fresh ephemeral keys per
             # invocation — a retry produces a new, non-equivalent entry — so a
-            # full re-run resolves the conflict.
+            # full re-run resolves the conflict. Transient backend errors are
+            # retried the same way (with backoff); both share MAX_ATTEMPTS.
             while IFS=' ' read -r file bundle; do
               [[ -z "$file" || "$file" =~ ^# ]] && continue
               echo "cosign sign-blob $file → $bundle"
-              attempts=3
-              for attempt in $(seq 1 "$attempts"); do
+              for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
                 rm -f "$bundle"
                 if out=$(cosign sign-blob --yes --bundle "$bundle" "$file" 2>&1); then
                   break
                 fi
-                if echo "$out" | grep -Eq "$REKOR_DUP_PATTERN" && [[ "$attempt" -lt "$attempts" ]]; then
-                  echo "Rekor: duplicate entry conflict for $file (attempt $attempt), retrying with fresh keys."
+                if [[ "$attempt" -ge "$MAX_ATTEMPTS" ]]; then
+                  printf '%s\n' "$out" >&2; exit 1
+                fi
+                if printf '%s' "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
+                  echo "Rekor: duplicate entry for $file (attempt ${attempt}/${MAX_ATTEMPTS}), retrying with fresh keys."
+                elif printf '%s' "$out" | grep -Eq "$TRANSIENT_PATTERN"; then
+                  echo "WARNING: sign-blob $file: transient signing-backend error (attempt ${attempt}/${MAX_ATTEMPTS})" >&2
+                  printf '%s\n' "$out" | sed 's/^/    │ /' >&2
+                  backoff "$attempt"
                 else
-                  echo "$out" >&2; exit 1
+                  printf '%s\n' "$out" >&2; exit 1
                 fi
               done
               echo "cosign verify-blob $file"
-              cosign verify-blob \
+              rc=0; cosign_retry "verify-blob $file" cosign verify-blob \
                 --bundle "$bundle" \
                 --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
                 --certificate-identity-regexp "$IDENTITY_REGEX" \
-                "$file" > /dev/null
+                "$file" || rc=$?
+              [[ "$rc" -eq 0 ]] || exit 1
             done < "$refs_file"
             ;;
           attest)
@@ -132,19 +194,20 @@ steps:
             while IFS=' ' read -r ref type predicate; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign attest --type $type $ref (predicate: $predicate)"
-              if ! out=$(cosign attest --yes --type "$type" --predicate "$predicate" "$ref" 2>&1); then
-                if echo "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
-                  echo "Rekor: entry already exists for $ref ($type), skipping attest."
-                else
-                  echo "$out" >&2; exit 1
-                fi
+              rc=0; cosign_retry "attest $ref ($type)" \
+                cosign attest --yes --type "$type" --predicate "$predicate" "$ref" || rc=$?
+              if [[ "$rc" -eq 42 ]]; then
+                echo "Rekor: entry already exists for $ref ($type), skipping attest."
+              elif [[ "$rc" -ne 0 ]]; then
+                exit 1
               fi
               echo "cosign verify-attestation --type $type $ref"
-              cosign verify-attestation \
+              rc=0; cosign_retry "verify-attestation $ref ($type)" cosign verify-attestation \
                 --type "$type" \
                 --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
                 --certificate-identity-regexp "$IDENTITY_REGEX" \
-                "$ref" > /dev/null
+                "$ref" || rc=$?
+              [[ "$rc" -eq 0 ]] || exit 1
             done < "$refs_file"
             ;;
         esac

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -79,8 +79,9 @@ steps:
         # 5xx/timeout. These are unrelated to the artifact or our config, so a
         # fresh attempt almost always succeeds. Without this, a single flake on
         # any one of N per-arch signatures fails the whole publish job and forces
-        # a manual rerun. Permanent errors (4xx auth/config, bad ref) are NOT
-        # listed here on purpose, so they still fail fast.
+        # a manual rerun. Auth/config 4xx (401/403/404) and bad refs are
+        # deliberately NOT listed, so genuine misconfiguration still fails fast;
+        # 408/425/429 are timeout/too-early/rate-limit codes and ARE transient.
         TRANSIENT_PATTERN='INTERNAL_ERROR|stream error|connection reset|connection refused|broken pipe'
         TRANSIENT_PATTERN+='|unexpected EOF|TLS handshake|i/o timeout|context deadline exceeded|timeout'
         TRANSIENT_PATTERN+='|408 |425 |429 |500 |502 |503 |504 |Service Unavailable|Bad Gateway|Gateway Time-?out|too many requests'
@@ -95,25 +96,34 @@ steps:
           sleep "$delay"
         }
 
-        # cosign_retry <label> <cmd…> — run a cosign network operation, retrying
-        # ONLY transient backend errors (see TRANSIENT_PATTERN) with exponential
-        # backoff. Output is captured rather than streamed so it can be
-        # classified; on success it is discarded to keep happy-path logs quiet
-        # (matching the previous behaviour). Exit status:
+        # cosign_retry <label> <on_success: quiet|show> <cmd…> — run a cosign
+        # network operation, retrying ONLY transient backend errors (see
+        # TRANSIENT_PATTERN) with exponential backoff. The command's stdout is
+        # discarded — it is the signature/attestation payload (e.g. a ~465 KB
+        # SBOM for verify-attestation) which we never want in the log, exactly as
+        # the old `… > /dev/null` did. Its stderr is captured so it can be
+        # classified, and with on_success=show it is re-emitted on success: this
+        # preserves the `cosign verify*` "Verification for <ref> …" summary that
+        # the verify-after-sign step deliberately surfaces as audit evidence.
+        # on_success=quiet keeps sign/attest happy paths silent (their stderr is
+        # noise on success). Exit status:
         #   0  success
         #   42 Rekor reports the entry already exists (caller decides to skip)
-        #   1  permanent failure (captured output already printed to stderr)
+        #   1  permanent failure (captured stderr already printed)
         cosign_retry() {
-          local label="$1"; shift
+          local label="$1" on_success="$2"; shift 2
           local attempt out
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-            if out=$("$@" 2>&1); then
+            if out=$("$@" 2>&1 1>/dev/null); then
+              if [[ "$on_success" == show && -n "$out" ]]; then
+                printf '%s\n' "$out" >&2
+              fi
               return 0
             fi
-            if printf '%s' "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
+            if grep -Eq "$REKOR_DUP_PATTERN" <<<"$out"; then
               return 42
             fi
-            if printf '%s' "$out" | grep -Eq "$TRANSIENT_PATTERN" && [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+            if grep -Eq "$TRANSIENT_PATTERN" <<<"$out" && [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
               echo "WARNING: ${label}: transient signing-backend error (attempt ${attempt}/${MAX_ATTEMPTS})" >&2
               printf '%s\n' "$out" | sed 's/^/    │ /' >&2
               backoff "$attempt"
@@ -130,18 +140,17 @@ steps:
             while IFS= read -r ref; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign sign $ref"
-              rc=0; cosign_retry "sign $ref" cosign sign --yes "$ref" || rc=$?
+              rc=0; cosign_retry "sign $ref" quiet cosign sign --yes "$ref" || rc=$?
               if [[ "$rc" -eq 42 ]]; then
                 echo "Rekor: entry already exists for $ref, skipping sign."
               elif [[ "$rc" -ne 0 ]]; then
                 exit 1
               fi
               echo "cosign verify $ref"
-              rc=0; cosign_retry "verify $ref" cosign verify \
+              cosign_retry "verify $ref" show cosign verify \
                 --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
                 --certificate-identity-regexp "$IDENTITY_REGEX" \
-                "$ref" || rc=$?
-              [[ "$rc" -eq 0 ]] || exit 1
+                "$ref" || exit 1
             done < "$refs_file"
             ;;
           blob)
@@ -164,9 +173,9 @@ steps:
                 if [[ "$attempt" -ge "$MAX_ATTEMPTS" ]]; then
                   printf '%s\n' "$out" >&2; exit 1
                 fi
-                if printf '%s' "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
+                if grep -Eq "$REKOR_DUP_PATTERN" <<<"$out"; then
                   echo "Rekor: duplicate entry for $file (attempt ${attempt}/${MAX_ATTEMPTS}), retrying with fresh keys."
-                elif printf '%s' "$out" | grep -Eq "$TRANSIENT_PATTERN"; then
+                elif grep -Eq "$TRANSIENT_PATTERN" <<<"$out"; then
                   echo "WARNING: sign-blob $file: transient signing-backend error (attempt ${attempt}/${MAX_ATTEMPTS})" >&2
                   printf '%s\n' "$out" | sed 's/^/    │ /' >&2
                   backoff "$attempt"
@@ -175,12 +184,11 @@ steps:
                 fi
               done
               echo "cosign verify-blob $file"
-              rc=0; cosign_retry "verify-blob $file" cosign verify-blob \
+              cosign_retry "verify-blob $file" show cosign verify-blob \
                 --bundle "$bundle" \
                 --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
                 --certificate-identity-regexp "$IDENTITY_REGEX" \
-                "$file" || rc=$?
-              [[ "$rc" -eq 0 ]] || exit 1
+                "$file" || exit 1
             done < "$refs_file"
             ;;
           attest)
@@ -194,7 +202,7 @@ steps:
             while IFS=' ' read -r ref type predicate; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign attest --type $type $ref (predicate: $predicate)"
-              rc=0; cosign_retry "attest $ref ($type)" \
+              rc=0; cosign_retry "attest $ref ($type)" quiet \
                 cosign attest --yes --type "$type" --predicate "$predicate" "$ref" || rc=$?
               if [[ "$rc" -eq 42 ]]; then
                 echo "Rekor: entry already exists for $ref ($type), skipping attest."
@@ -202,12 +210,11 @@ steps:
                 exit 1
               fi
               echo "cosign verify-attestation --type $type $ref"
-              rc=0; cosign_retry "verify-attestation $ref ($type)" cosign verify-attestation \
+              cosign_retry "verify-attestation $ref ($type)" show cosign verify-attestation \
                 --type "$type" \
                 --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
                 --certificate-identity-regexp "$IDENTITY_REGEX" \
-                "$ref" || rc=$?
-              [[ "$rc" -eq 0 ]] || exit 1
+                "$ref" || exit 1
             done < "$refs_file"
             ;;
         esac

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -128,10 +128,10 @@ steps:
               fi
               return 0
             fi
-            if grep -Eq "$REKOR_DUP_PATTERN" <<<"$out"; then
+            if printf '%s' "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
               return 42
             fi
-            if grep -Eq "$TRANSIENT_PATTERN" <<<"$out" && [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+            if printf '%s' "$out" | grep -Eq "$TRANSIENT_PATTERN" && [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
               echo "WARNING: ${label}: transient signing-backend error (attempt ${attempt}/${MAX_ATTEMPTS})" >&2
               printf '%s\n' "$out" | sed 's/^/    │ /' >&2
               backoff "$attempt"
@@ -181,9 +181,9 @@ steps:
                 if [[ "$attempt" -ge "$MAX_ATTEMPTS" ]]; then
                   printf '%s\n' "$out" >&2; exit 1
                 fi
-                if grep -Eq "$REKOR_DUP_PATTERN" <<<"$out"; then
+                if printf '%s' "$out" | grep -Eq "$REKOR_DUP_PATTERN"; then
                   echo "Rekor: duplicate entry for $file (attempt ${attempt}/${MAX_ATTEMPTS}), retrying with fresh keys."
-                elif grep -Eq "$TRANSIENT_PATTERN" <<<"$out"; then
+                elif printf '%s' "$out" | grep -Eq "$TRANSIENT_PATTERN"; then
                   echo "WARNING: sign-blob $file: transient signing-backend error (attempt ${attempt}/${MAX_ATTEMPTS})" >&2
                   printf '%s\n' "$out" | sed 's/^/    │ /' >&2
                   backoff "$attempt"


### PR DESCRIPTION
## Problem

A happa publish job ([push-fe-docs-to-registries](https://app.circleci.com/pipelines/github/giantswarm/happa/19489/workflows/c1c911e9-384c-4a56-bfc3-67296c9cbb05/jobs/143064)) failed in the **Cosign sign + verify (attest)** step. The `linux/amd64` SBOM attestation succeeded, then the very next call — `linux/arm64` — died with:

```
Error: signing …/fe-docs@sha256:bb1a24…: signing bundle: error signing bundle:
  stream error: stream ID 1; INTERNAL_ERROR; received from peer
```

This is a **transient** error from Sigstore's public-good keyless backend (an HTTP/2 `RST_STREAM(INTERNAL_ERROR)` from the peer), not a config/auth/artifact problem — auth would have failed the amd64 call too, and its `verify-attestation` passed.

The `cosign-sign-verify` command only retried Rekor **duplicate-entry** conflicts (HTTP 409); any other error — including these transient stream/5xx/timeout failures — fell straight through to `exit 1`. So a single flake on one of N per-arch signatures failed the whole publish job and forced a manual rerun.

## Change

- Add a `TRANSIENT_PATTERN` (HTTP/2 stream resets / `INTERNAL_ERROR`, connection resets, `unexpected EOF`, TLS handshake, `i/o timeout`, `context deadline exceeded`, 408/425/429/5xx) and a `cosign_retry` helper with exponential backoff (5s → 10s → 20s, `MAX_ATTEMPTS=4`).
- Wire it into **all six** cosign network calls across the `oci`, `blob`, and `attest` branches.
- **Preserved semantics:** Rekor 409 duplicates are still *skipped* for `oci`/`attest` and *retried-with-fresh-keys* for `blob`. Permanent errors (4xx auth/config, bad refs) are deliberately **not** matched, so they still fail fast.
- Better UX: each failed attempt logs an indented, prefixed warning + the captured error excerpt + the backoff delay, instead of a bare `exit 1` dump.

Failed-attempt output now looks like:

```
WARNING: attest …/fe-docs@sha256:bb1a24… (spdxjson): transient signing-backend error (attempt 1/4)
    │ Error: signing …: signing bundle: … stream error: stream ID 1; INTERNAL_ERROR; received from peer
    └─ retrying in 5s …
```

## Validation

- `yamllint` (repo config) clean; `shellcheck` clean (only the pre-existing SC2194 orb-template false positive on `case "<<parameters.kind>>"`).
- Stubbed-`cosign` test under `set -euo pipefail` confirms each path: success = 1 try; transient-then-ok = 2 tries; always-transient = 4 tries → fail; 409 duplicate → skip (rc 42); permanent (403) → fail fast on 1 try.

## How to smoke-test the dev orb

This branch publishes `giantswarm/architect@dev:retry-transient-cosign-errors`. Point a happa branch's `.circleci/config.yml` at that tag and re-run the publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)