### PR TITLE
fix(nancy): Use `go list -json -m all` for producing the dependency list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Nancy: Use `go list -json -m all` for producing the dependency list.
+
 ## [9.4.0] - 2026-06-11
 
 ### Added

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -97,7 +97,7 @@ steps:
         CGO_ENABLED: "0"
       command: |
         set +e
-        go list -json -deps ./... \
+        go list -json -m all \
           | nancy sleuth --skip-update-check \
             --quiet --exclude-vulnerability-file ./.nancy-ignore \
             --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 \


### PR DESCRIPTION
Building `cluster-standup-teardown` started to give me the following error:

```
Error: stdin input exceeded 10 MB limit; ensure you are piping valid 'go list' output
```

According to Claude, Nancy does also work with `go list -json -m all`, which produces a much smaller output.

Tested here: https://github.com/giantswarm/cluster-standup-teardown/pull/424.