### PR TITLE
feat(go-build): cache GOCACHE and add opt-in parallel arch builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `go-build`: `build_concurrency` parameter to compile multiple architectures concurrently (`"1"` sequential by default, `"auto"`, or an integer).
+
+### Changed
+
+- `go-build`: persist the Go build cache (`GOCACHE`) across runs in addition to the module cache, so warm builds only recompile changed packages.
+
 ## [9.4.2] - 2026-06-17
 
 ### Changed

--- a/docs/job/go-build.md
+++ b/docs/job/go-build.md
@@ -75,12 +75,13 @@ See [`push-to-registries`](./push-to-registries.md) for the full Dockerfile cont
 
 ## Build speed and concurrency
 
-The job persists two caches across runs: the Go module cache (`/go/pkg/mod`,
-keyed on `go.sum`) and the Go build cache (`GOCACHE`, keyed on `go.sum` plus
-branch and revision with prefix fallbacks). The build cache holds compiled
-stdlib and dependency objects for every GOOS/GOARCH, so a warm cache only
-recompiles packages that actually changed. This is the largest single factor in
-build time; the first run after a `go.sum` change is cold and slower.
+The job persists two caches across runs, both keyed on `go.sum`: the Go module
+cache (`/go/pkg/mod`) and the Go build cache (`GOCACHE`). The build cache holds
+compiled stdlib and dependency objects for every GOOS/GOARCH, which are the bulk
+of build time and only change when `go.sum` changes; keying on `go.sum` keeps one
+cache object per dependency set rather than one per commit. The first run after a
+`go.sum` change is cold and slower; subsequent runs reuse the compiled stdlib and
+dependencies and only recompile the repo's own changed packages.
 
 Cross-compiling each architecture is independent work. `build_concurrency`
 controls how many run at once:

--- a/docs/job/go-build.md
+++ b/docs/job/go-build.md
@@ -16,6 +16,7 @@ Builds Go binaries for one or more target architectures in a single job and pers
 - `pre_test_target`: Makefile target to run before tests/lints (optional).
 - `tags`: Additional Go build tags (optional).
 - `test_target`: Makefile target to run for tests (optional).
+- `build_concurrency`: Maximum number of architectures to compile concurrently. `"1"` (default) builds sequentially; `"auto"` uses the number of available CPUs; an integer caps it. See [Build speed and concurrency](#build-speed-and-concurrency).
 - `resource_class`: CircleCI resource class for the job.
 - `clone_depth`: Commits to keep in local git history after checkout (default: `1`, i.e. CircleCI's default shallow clone). Use `0` for full history. Greater than `1` deepens to that many commits. Set to `0` when build steps rely on `git log` / `git rev-list` (e.g. `go generate` embedding the commit SHA of the last change to a template).
 - `sign`: Sign each produced binary with cosign keyless OIDC (default: `true`). Public repos only — private repos are skipped at runtime. See [Signing](#signing).
@@ -71,6 +72,39 @@ ENTRYPOINT ["/myapp"]
 A Dockerfile that does `COPY myapp myapp` (no per-arch selector) will silently ship the same binary for both architectures and the arm64 variant will crash with `exec format error` on arm64 hosts.
 
 See [`push-to-registries`](./push-to-registries.md) for the full Dockerfile contract, including the compile-in-Dockerfile pattern (`--platform=$BUILDPLATFORM` builder).
+
+## Build speed and concurrency
+
+The job persists two caches across runs: the Go module cache (`/go/pkg/mod`,
+keyed on `go.sum`) and the Go build cache (`GOCACHE`, keyed on `go.sum` plus
+branch and revision with prefix fallbacks). The build cache holds compiled
+stdlib and dependency objects for every GOOS/GOARCH, so a warm cache only
+recompiles packages that actually changed. This is the largest single factor in
+build time; the first run after a `go.sum` change is cold and slower.
+
+Cross-compiling each architecture is independent work. `build_concurrency`
+controls how many run at once:
+
+- `"1"` (default): sequential, one `go build` at a time. A single `go build`
+  already saturates both cores of a `medium` executor (2 vCPU), so on `medium`
+  parallelism buys little and risks OOM.
+- `"auto"` or an integer `> 1`: compile that many architectures concurrently.
+  Worth it only with spare CPU and RAM, i.e. a larger `resource_class`.
+
+For three or more architectures, set `resource_class: large` (4 vCPU) or
+`xlarge` (8 vCPU) and `build_concurrency` to roughly the vCPU count. CircleCI
+Docker credit rates scale with the class (medium 10/min, large 20/min, xlarge
+40/min), so a larger class that finishes proportionally faster is often cheaper
+as well as quicker: a 10-minute `medium` build (100 credits) that drops to 4
+minutes on `large` costs 80 credits.
+
+```yaml
+- architect/go-build:
+    binary: myapp
+    architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64"
+    resource_class: large
+    build_concurrency: "4"
+```
 
 ## Signing
 

--- a/src/commands/go-build.yaml
+++ b/src/commands/go-build.yaml
@@ -16,6 +16,7 @@
 #   pre_test_target: Makefile target to run before tests/lints (optional).
 #   tags: Additional Go build tags (optional).
 #   test_target: Makefile target to run for tests (optional).
+#   build_concurrency: Max architectures to compile concurrently ("1" = sequential, "auto" = nproc).
 
 parameters:
   binary:
@@ -44,6 +45,17 @@ parameters:
       Comma-separated list of target architectures to build in this job (e.g.,
       "linux/amd64,linux/arm64"). The resolved list is written to `.platforms` in the
       workspace for downstream auto-discovery in `push-to-registries`.
+    type: string
+  build_concurrency:
+    default: "1"
+    description: |
+      Maximum number of architectures to compile concurrently. "1" builds
+      sequentially (the default; no extra CPU/RAM pressure on a `medium`
+      executor). "auto" uses the number of available CPUs. Raise it alongside
+      `resource_class` (roughly to the vCPU count) when building three or more
+      architectures: each concurrent `go build` can occupy ~1 vCPU and a
+      significant amount of RAM, so an under-provisioned executor will thrash
+      or OOM.
     type: string
   sign:
     description: |
@@ -90,7 +102,13 @@ steps:
           [[ "$goos" == "windows" ]] && output_name="${binary_name}.exe"
 
           echo "Building ${output_name}..."
-          CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build "${build_flags[@]}" -ldflags "$LD_FLAGS" -tags "<<parameters.tags>>" -o "$output_name" "<<parameters.path>>"
+          # Return the build's real status: relying on the trailing `if` would
+          # mask a failed `go build` (the `if` returns 0 when the condition is
+          # false), and `set -e` is suppressed both for backgrounded builds and
+          # inside `|| fail=1`.
+          if ! CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build "${build_flags[@]}" -ldflags "$LD_FLAGS" -tags "<<parameters.tags>>" -o "$output_name" "<<parameters.path>>"; then
+            return 1
+          fi
 
           # If linux/amd64, also create/copy to <<parameters.binary>>
           if [[ "$goos" == "linux" && "$goarch" == "amd64" ]]; then
@@ -108,13 +126,46 @@ steps:
           echo "ERROR: 'architectures' must match ^[a-zA-Z0-9/_,-]+\$ (got: $architectures)."
           exit 1
         fi
+        concurrency="<<parameters.build_concurrency>>"
+        [[ "$concurrency" == "auto" ]] && concurrency="$(nproc)"
+        if [[ ! "$concurrency" =~ ^[0-9]+$ ]] || (( concurrency < 1 )); then
+          echo "ERROR: 'build_concurrency' must be a positive integer or \"auto\" (got: $concurrency)."
+          exit 1
+        fi
+
+        # Backgrounded builds do not fail the step on their own; aggregate exit
+        # codes into $fail and propagate at the end. Each PID is waited exactly
+        # once so a fast-failing build's status is never dropped.
+        fail=0
+        pids=()
+        drain() {
+          local pid
+          for pid in "${pids[@]}"; do
+            wait "$pid" || fail=1
+          done
+          pids=()
+        }
+
         # Replace commas with spaces; bash word-splitting handles the rest.
         for raw in ${architectures//,/ }; do
           arch="$(echo "$raw" | tr -d '[:space:]')"
           [[ -z "$arch" ]] && continue
-          build_one "$arch"
+          # .platforms is written here, serially, so parallel builds never
+          # interleave the file.
           echo "$arch" >> .platforms
+          if (( concurrency <= 1 )); then
+            build_one "$arch" || fail=1
+          else
+            build_one "$arch" &
+            pids+=("$!")
+            # Once a wave reaches the concurrency limit, wait for all of it
+            # before launching the next.
+            (( ${#pids[@]} >= concurrency )) && drain
+          fi
         done
+        (( ${#pids[@]} > 0 )) && drain
+
+        exit $fail
   - when:
       condition: <<parameters.sign>>
       steps:

--- a/src/commands/go-cache-restore.yaml
+++ b/src/commands/go-cache-restore.yaml
@@ -10,6 +10,4 @@ steps:
   - restore_cache:
       name: Restore Go build cache
       keys:
-        - go-build-cache-v1-{{ checksum "go.sum" }}-{{ .Branch }}-{{ .Revision }}
-        - go-build-cache-v1-{{ checksum "go.sum" }}-{{ .Branch }}-
-        - go-build-cache-v1-{{ checksum "go.sum" }}-
+        - go-build-cache-v1-{{ checksum "go.sum" }}

--- a/src/commands/go-cache-restore.yaml
+++ b/src/commands/go-cache-restore.yaml
@@ -1,5 +1,15 @@
 steps:
+  - run:
+      name: Pin GOCACHE
+      command: |
+        echo 'export GOCACHE=/go/cache/go-build' >> "$BASH_ENV"
+  - restore_cache:
+      name: Restore Go module cache
+      keys:
+        - go-build-go-mod-v1-{{ checksum "go.sum" }}
   - restore_cache:
       name: Restore Go build cache
       keys:
-        - go-build-go-mod-v1-{{ checksum "go.sum" }}
+        - go-build-cache-v1-{{ checksum "go.sum" }}-{{ .Branch }}-{{ .Revision }}
+        - go-build-cache-v1-{{ checksum "go.sum" }}-{{ .Branch }}-
+        - go-build-cache-v1-{{ checksum "go.sum" }}-

--- a/src/commands/go-cache-save.yaml
+++ b/src/commands/go-cache-save.yaml
@@ -1,5 +1,11 @@
 steps:
   - save_cache:
+      name: Save Go module cache
       key: go-build-go-mod-v1-{{ checksum "go.sum" }}
       paths:
         - "/go/pkg/mod"
+  - save_cache:
+      name: Save Go build cache
+      key: go-build-cache-v1-{{ checksum "go.sum" }}-{{ .Branch }}-{{ .Revision }}
+      paths:
+        - "/go/cache/go-build"

--- a/src/commands/go-cache-save.yaml
+++ b/src/commands/go-cache-save.yaml
@@ -6,6 +6,6 @@ steps:
         - "/go/pkg/mod"
   - save_cache:
       name: Save Go build cache
-      key: go-build-cache-v1-{{ checksum "go.sum" }}-{{ .Branch }}-{{ .Revision }}
+      key: go-build-cache-v1-{{ checksum "go.sum" }}
       paths:
         - "/go/cache/go-build"

--- a/src/jobs/go-build.yaml
+++ b/src/jobs/go-build.yaml
@@ -20,6 +20,18 @@ parameters:
       the workspace for downstream auto-discovery in `push-to-registries`.
     type: string
     default: "linux/amd64,linux/arm64"
+  build_concurrency:
+    default: "1"
+    description: |
+      Maximum number of architectures to compile concurrently. "1" builds
+      sequentially (the default). "auto" uses the number of available CPUs.
+      Raise it alongside `resource_class` (roughly to the vCPU count) when
+      building three or more architectures. CircleCI Docker credit rates scale
+      with the resource class (medium 10/min, large 20/min, xlarge 40/min), so a
+      larger class that finishes proportionally faster is often cheaper as well
+      as quicker: a 10-minute `medium` build (100 credits) that drops to 4
+      minutes on `large` costs 80 credits.
+    type: string
   path:
     default: "."
     description: |
@@ -100,6 +112,7 @@ steps:
       tags: << parameters.tags >>
       test_target: << parameters.test_target >>
       architectures: << parameters.architectures >>
+      build_concurrency: << parameters.build_concurrency >>
       sign: << parameters.sign >>
       trimpath: << parameters.trimpath >>
   - persist_to_workspace:


### PR DESCRIPTION
## What changed

### Persist the Go build cache (the main win, on by default)
`go-cache-restore`/`go-cache-save` only cached `/go/pkg/mod` (module *downloads*). `GOCACHE` (compiled stdlib + dependency objects) was thrown away every run, so each run recompiled everything from scratch, once per `GOOS/GOARCH`.

- Pin `GOCACHE=/go/cache/go-build` (same volume as the module cache, no `$HOME` assumption) so both `go test` and `go build` populate it.
- Persist it keyed on `go.sum`, mirroring the module cache. The arch-multiplied cost is recompiling stdlib + dependencies, which only change when `go.sum` changes, so this captures the dominant win while storing **one cache object per dependency set, not one per commit** (important since this is on by default across every consuming repo). The first run after a `go.sum` change is cold; later runs reuse compiled stdlib/deps and only recompile the repo's own changed packages.

### Opt-in parallel architecture builds
- New `build_concurrency` parameter: `"1"` (default, sequential), `"auto"` (= `nproc`), or an integer.
- Default stays sequential: a single `go build` already saturates a `medium` executor's 2 vCPUs, so parallelism only pays with a larger `resource_class`. Docs recommend pairing `build_concurrency` with `large`/`xlarge` for 3+ architectures, with the credit math.

### Failure-masking fixes (surfaced by backgrounding)
- `build_one` ended on the `linux/amd64` `if` test, returning `0` even when `go build` failed for a non-amd64 target. It now returns the build's real status. The previous code only avoided this via `set -e`, which is suppressed by both `&` and `|| fail=1`.
- Exit codes are aggregated by waiting each PID exactly once (batched waves), not via `jobs -rp` (which lists only *running* jobs and dropped the status of fast-failing builds).

## Measured impact (live on muster, CircleCI `medium` = 2 vCPU)

Ran the dev orb against `giantswarm/muster` (2 arches, `build_concurrency: "2"`): one cold run, then a warm run with `go.sum` unchanged.

| go-build step | Cold (today) | Warm | Δ |
|---|---|---|---|
| Restore Go build cache | 0.1s (miss) | 15.8s (hit) | — |
| Run unit tests | 115.6s | 17.8s | 6.5× |
| Build binaries | 194.7s | 5.0s | 39× |
| Save Go build cache | 23.9s | 0.1s (key exists) | — |
| **Total job** | **392.6s** | **76.4s** | **5.1×** |

The `Save Go build cache` dropping to 0.1s on the warm run confirms the write-once `go.sum` key: no per-commit re-upload, bounded storage.

## Cost estimate

`medium` = 10 credits/min, 1 credit = $0.0006 ($0.006/min).

- **Measured (2 arches):** 392.6s → 76.4s = ~5.3 min saved per warm run ≈ **53 credits (~$0.032)**.
- **Projected to muster's real 6-arch config** (build-binaries scales ~linearly per arch, ~97s/arch cold vs ~2.5s warm; other steps arch-independent): cold ~12 min → warm ~1.5 min ≈ **~10 min, ~100 credits (~$0.06) saved per warm run**.

Per-run dollars are small; the value compounds on **frequency × fleet**. Illustrative single busy Go repo (~80 warm go-build runs/month): **~$3–5/month and ~10+ hours of CI wall-clock saved**. Across the orb's installed base (~13,660 builds / 254 projects in 30 days), every Go repo's go-build job picks this up automatically with no config change.

**Caveats:** the first build after any `go.sum` change is still cold (e.g. renovate bumps), so not every run is warm — but cold was the *only* mode before. Offsetting cost is one extra cache object per dependency set (~1–2 GB at 6 arches), refreshed only when deps change. Parallelism contributes little at the default `medium`/sequential config; the cache carries essentially all of the win.

## Notes
- Cache is on by default (transparent, same artifacts); parallelism is opt-in (needs provisioned CPU). `build_concurrency: "1"` keeps existing behaviour, so no resource/credit change for current consumers unless they opt in.
- Existing contracts unchanged: ldflags injection, the bare `<binary>` linux/amd64 copy, `.platforms`, and cosign signing all stay as-is.

## Verification
- `circleci orb pack src/` + `circleci orb validate` both pass.
- Ran the reworked build loop against a real Go module: `build_concurrency` in {1, 2, auto} each produce all per-arch binaries + the bare copy + a clean 3-line `.platforms`; a deliberately broken arch returns non-zero in all three modes.
- End-to-end on `giantswarm/muster` via a dev publish of this branch: cold then warm run, cache restore hit confirmed, timings in the table above.
