### PR TITLE
feat(run-tests-with-ats): run app-test-suite container directly, drop dats.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `run-tests-with-ats` runs the `app-test-suite` container directly with `docker run` instead of
+  downloading and executing the `dats.sh` wrapper, which has been removed from the `app-test-suite` repository.
+  The `app-test-suite_version` parameter is removed (it only selected the `dats.sh` ref); use
+  `app-test-suite_container_tag` to pick the image. Requires a new major version.
+
 ## [9.4.2] - 2026-06-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **BREAKING:** `run-tests-with-ats` runs the `app-test-suite` container directly with `docker run` instead of
   downloading and executing the `dats.sh` wrapper, which has been removed from the `app-test-suite` repository.
-  The `app-test-suite_version` parameter is removed (it only selected the `dats.sh` ref); use
-  `app-test-suite_container_tag` to pick the image. Requires a new major version.
+  The `app-test-suite_container_tag` parameter is renamed to `app-test-suite_version` and now selects the
+  container image tag (previously it selected the `dats.sh` git ref). Its default is `"1.0.0"`.
+  Requires a new major version.
 
 ## [9.4.2] - 2026-06-17
 

--- a/docs/job/run-tests-with-ats.md
+++ b/docs/job/run-tests-with-ats.md
@@ -35,7 +35,7 @@ workflows:
 
 - [common parameters](common.md#parameters) shared in all jobs.
 - [chart_archive_prefix](#chart_archive_prefix-optional-string-default)
-- [app-test-suite_container_tag](#app-test-suite_container_tag)
+- [app-test-suite_version](#app-test-suite_version)
 - [additional_app-test-suite_flags](#additional_app-test-suite_flags)
 
 ### chart_archive_prefix (optional string, default="")
@@ -48,12 +48,12 @@ Actual implementation is:
 find -name "<< parameters.chart_archive_prefix >>*.tgz" -print -quit
 ```
 
-### app-test-suite_container_tag
+### app-test-suite_version
 
-Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite).
+app-test-suite container image tag to run (check gsoci.azurecr.io/giantswarm/app-test-suite).
 The job runs this container image directly with `docker run`.
 
-(Default: "0.15.0")
+(Default: "1.0.0")
 
 ### additional_app-test-suite_flags
 

--- a/docs/job/run-tests-with-ats.md
+++ b/docs/job/run-tests-with-ats.md
@@ -35,7 +35,6 @@ workflows:
 
 - [common parameters](common.md#parameters) shared in all jobs.
 - [chart_archive_prefix](#chart_archive_prefix-optional-string-default)
-- [app-test-suite_version](#app-test-suite_version)
 - [app-test-suite_container_tag](#app-test-suite_container_tag)
 - [additional_app-test-suite_flags](#additional_app-test-suite_flags)
 
@@ -49,23 +48,12 @@ Actual implementation is:
 find -name "<< parameters.chart_archive_prefix >>*.tgz" -print -quit
 ```
 
-### app-test-suite_version
-
-Version of app-test-suite `dabs.sh` container wrapper to use (git tag or commit).
-Use this parameter if you have some changes lined up in `dats.sh` which is not released yet.
-For git tags, the same container tag of app-test-suite will be used.
-
-**Attention:** For git commits or branches, `latest` will be used as container tag.
-This can be circumvented by also setting the parameter [`app-test-suite_container_tag`](#app-test-suite_container_tag).
-
-(Default: "v0.10.6")
-
 ### app-test-suite_container_tag
 
 Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite).
-This parameter allows to specify the used container tag of app-test-suite.
+The job runs this container image directly with `docker run`.
 
-(Default: "0.10.6")
+(Default: "0.15.0")
 
 ### additional_app-test-suite_flags
 

--- a/src/commands/run-tests-with-ats.yaml
+++ b/src/commands/run-tests-with-ats.yaml
@@ -3,9 +3,6 @@ parameters:
     description: "Prefix for the chart archive file to execute tests for."
     type: string
     default: ""
-  app-test-suite_version:
-    description: "Version of app-test-suite dats.sh container wrapper to use (git tag or commit)"
-    type: string
   app-test-suite_container_tag:
     description: "Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite)"
     type: string
@@ -17,21 +14,23 @@ steps:
   - attach_workspace:
       at: build
   - run:
-      name: "Download dats.sh script"
-      command: |
-        wget -O dats.sh "https://raw.githubusercontent.com/giantswarm/app-test-suite/<< parameters.app-test-suite_version >>/dats.sh"
-        chmod +x dats.sh
-  - run:
-      name: "Execute app-test-suite with dats.sh wrapper"
+      name: "Execute app-test-suite"
       command: |
         set -x
 
-        export DATS_TAG=<< parameters.app-test-suite_container_tag >>
         # find the chart archive file name
         chart_archive=$(find build -name "<< parameters.chart_archive_prefix >>*.tgz" -print -quit)
         # move chart archive from build directory to root
         # we're doing this to make sure .ats/main.yaml is picked up
         cp "$chart_archive" "${chart_archive##*/}"
 
-        # execute dats wrapper
-        ./dats.sh --chart-file "${chart_archive##*/}" << parameters.additional_app-test-suite_flags >>
+        # run the app-test-suite container directly
+        docker run --rm \
+          -e USE_UID="$(id -u)" \
+          -e USE_GID="$(id -g)" \
+          -e DOCKER_GID="$(getent group docker | cut -d: -f3)" \
+          -v "$(pwd):/ats/workdir" \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          --network host \
+          "gsoci.azurecr.io/giantswarm/app-test-suite:<< parameters.app-test-suite_container_tag >>" \
+          --chart-file "${chart_archive##*/}" << parameters.additional_app-test-suite_flags >>

--- a/src/commands/run-tests-with-ats.yaml
+++ b/src/commands/run-tests-with-ats.yaml
@@ -3,8 +3,8 @@ parameters:
     description: "Prefix for the chart archive file to execute tests for."
     type: string
     default: ""
-  app-test-suite_container_tag:
-    description: "Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite)"
+  app-test-suite_version:
+    description: "app-test-suite container image tag to run (check gsoci.azurecr.io/giantswarm/app-test-suite)"
     type: string
   additional_app-test-suite_flags:
     description: "Additional app-test-suite flags to use"
@@ -32,5 +32,5 @@ steps:
           -v "$(pwd):/ats/workdir" \
           -v /var/run/docker.sock:/var/run/docker.sock \
           --network host \
-          "gsoci.azurecr.io/giantswarm/app-test-suite:<< parameters.app-test-suite_container_tag >>" \
+          "gsoci.azurecr.io/giantswarm/app-test-suite:<< parameters.app-test-suite_version >>" \
           --chart-file "${chart_archive##*/}" << parameters.additional_app-test-suite_flags >>

--- a/src/jobs/run-tests-with-ats.yaml
+++ b/src/jobs/run-tests-with-ats.yaml
@@ -3,10 +3,10 @@ parameters:
     description: "Prefix for the chart archive file to execute tests for."
     type: string
     default: ""
-  app-test-suite_container_tag:
-    description: "Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite)"
+  app-test-suite_version:
+    description: "app-test-suite container image tag to run (check gsoci.azurecr.io/giantswarm/app-test-suite)"
     type: string
-    default: "0.15.0"
+    default: "1.0.0"
   additional_app-test-suite_flags:
     description: "Additional app-test-suite flags to use"
     type: string
@@ -25,5 +25,5 @@ steps:
   - checkout
   - run-tests-with-ats:
       chart_archive_prefix: << parameters.chart_archive_prefix >>
-      app-test-suite_container_tag: << parameters.app-test-suite_container_tag >>
+      app-test-suite_version: << parameters.app-test-suite_version >>
       additional_app-test-suite_flags: << parameters.additional_app-test-suite_flags >>

--- a/src/jobs/run-tests-with-ats.yaml
+++ b/src/jobs/run-tests-with-ats.yaml
@@ -3,10 +3,6 @@ parameters:
     description: "Prefix for the chart archive file to execute tests for."
     type: string
     default: ""
-  app-test-suite_version:
-    description: "Version of app-test-suite dabs.sh container wrapper to use (git tag or commit)"
-    type: string
-    default: "v0.15.0"
   app-test-suite_container_tag:
     description: "Container tag of app-test-suite to use (check gsoci.azurecr.io/giantswarm/app-test-suite)"
     type: string
@@ -29,6 +25,5 @@ steps:
   - checkout
   - run-tests-with-ats:
       chart_archive_prefix: << parameters.chart_archive_prefix >>
-      app-test-suite_version: << parameters.app-test-suite_version >>
       app-test-suite_container_tag: << parameters.app-test-suite_container_tag >>
       additional_app-test-suite_flags: << parameters.additional_app-test-suite_flags >>


### PR DESCRIPTION
## What

`run-tests-with-ats` no longer downloads and runs the `dats.sh` wrapper from the `app-test-suite` repo. It runs the `app-test-suite` container image directly with `docker run`.

## Why

`app-test-suite` has removed `dats.sh` (giantswarm/app-test-suite#642). The command currently does `wget https://raw.githubusercontent.com/giantswarm/app-test-suite/<version>/dats.sh`, which now 404s for any consumer pinning to a current ref. `dats.sh` was only a thin `docker run` wrapper, so the orb can invoke the container itself.

## Changes

- `src/commands/run-tests-with-ats.yaml`: replace the `Download dats.sh` + `./dats.sh` steps with a direct `docker run gsoci.azurecr.io/giantswarm/app-test-suite:<tag> --chart-file ... <flags>` (same uid/gid, docker.sock, and `--network host` the wrapper used; `-it` dropped for CI).
- Rename parameter `app-test-suite_container_tag` to `app-test-suite_version` (it now selects the container image tag; previously `app-test-suite_version` selected the `dats.sh` git ref). Default `1.0.0`.
- Update `docs/job/run-tests-with-ats.md`.

## Migration (BREAKING, requires major → v10.0.0)

- Consumers setting `app-test-suite_container_tag:` must rename it to `app-test-suite_version:`.
- Consumers who previously set `app-test-suite_version:` to a `dats.sh` git ref must change the value to a container image tag (e.g. `1.0.0`).
- `giantswarm/architect@9` keeps the old `dats.sh` path; bump to `@10` for direct container execution.

Cut the release via the `main#release#major` trigger. CircleCI orb pack/validate runs in CI (no local `circleci` CLI).