### PR TITLE
fix: Add new error from OSS Index/Sonatype API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Add new error from OSS index/Sonatype API
+
 ## [9.4.2] - 2026-06-17
 
 ### Changed

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -102,7 +102,10 @@ steps:
             --quiet --exclude-vulnerability-file ./.nancy-ignore \
             --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 \
             | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
-        grep -q 'error accessing OSS Index' nancy-results.txt; grep_result=$?
+        grep -qF \
+            -e 'error accessing OSS Index' \
+            -e 'Error: guide API request failed' \
+            nancy-results.txt; grep_result=$?
         set -e
         # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.
         if [[ $nancy_result -ne 0 && $grep_result -eq 0 ]]; then


### PR DESCRIPTION
This PR adds a new error yield by the OSS Index/Sonatype API which should be ignored to avoid build failures.

The current behavior already ignore error related to API access ('error accessing OSS Index') here I am only adding a the new `Error: guide API request failed` error to the list.
I've also added `-F` which ensure grep matches with a fixed string rather than regex.

### Before

This is a local test run to assess the problem

```
$ ./test-old.sh
WARNING: OSS Index credentials are deprecated and will be removed in v3.x.
         Obtain a Sonatype Guide Bearer token at https://guide.sonatype.com
         and use --guide-token (or GUIDE_TOKEN env var) instead.
Error: guide API request failed: json: cannot unmarshal object into Go value of type []sonatypeguide.ComponentReportPost

For more information, check the log file at /home/theo/.ossindex/nancy.combined.log
nancy version: 2.1.0

Usage:
  nancy sleuth [flags]

Examples:
  go list -json -deps ./... | nancy sleuth --username your_user --token your_token

Flags:
  -a, --additional-exclude-vulnerability-files strings   Path to additional files containing newline separated CVEs or OSS Index IDs to be excluded
  -e, --exclude-vulnerability CveListFlag                Comma separated list of CVEs or OSS Index IDs to exclude (default [])
  -x, --exclude-vulnerability-file string                Path to a file containing newline separated CVEs or OSS Index IDs to be excluded (default "./.nancy-ignore")
  -h, --help                                             help for sleuth
  -n, --no-color                                         indicate output should not be colorized
      --no-fail                                          Exit 0 even when vulnerabilities are found (useful for informational CI steps)
  -o, --output string                                    Styling for output format. json, json-pretty, text, csv (default "text")

Global Flags:
  -v, -- count                       Set log level, multiple v's is more verbose
  -d, --db-cache-path string         Specify an alternate path for caching responses from OSS Index, example: /tmp
  -g, --guide-token string           Specify Sonatype Guide Bearer token for request
      --loud                         indicate output should include non-vulnerable packages
      --max-go-list-input-size int   Maximum size, in MB, of 'go list' output to read from stdin (default 100)
      --ossindex-url string          Specify an alternate OSS Index URL/host
  -q, --quiet                        indicate output should contain only packages with vulnerabilities (default true)
      --skip-update-check            Skip the check for updates.
  -t, --token string                 Specify OSS Index API token for request (Deprecated: use --guide-token)
  -u, --username string              Specify OSS Index username for request (Deprecated: use --guide-token)
  -V, --version                      Get the version

$ echo $?
1
```

### After

Here's fixed version ran locally.

```
$ ./test.sh
WARNING: OSS Index credentials are deprecated and will be removed in v3.x.
         Obtain a Sonatype Guide Bearer token at https://guide.sonatype.com
         and use --guide-token (or GUIDE_TOKEN env var) instead.
Error: guide API request failed: json: cannot unmarshal object into Go value of type []sonatypeguide.ComponentReportPost

For more information, check the log file at /home/theo/.ossindex/nancy.combined.log
nancy version: 2.1.0

Usage:
  nancy sleuth [flags]

Examples:
  go list -json -deps ./... | nancy sleuth --username your_user --token your_token

Flags:
  -a, --additional-exclude-vulnerability-files strings   Path to additional files containing newline separated CVEs or OSS Index IDs to be excluded
  -e, --exclude-vulnerability CveListFlag                Comma separated list of CVEs or OSS Index IDs to exclude (default [])
  -x, --exclude-vulnerability-file string                Path to a file containing newline separated CVEs or OSS Index IDs to be excluded (default "./.nancy-ignore")
  -h, --help                                             help for sleuth
  -n, --no-color                                         indicate output should not be colorized
      --no-fail                                          Exit 0 even when vulnerabilities are found (useful for informational CI steps)
  -o, --output string                                    Styling for output format. json, json-pretty, text, csv (default "text")

Global Flags:
  -v, -- count                       Set log level, multiple v's is more verbose
  -d, --db-cache-path string         Specify an alternate path for caching responses from OSS Index, example: /tmp
  -g, --guide-token string           Specify Sonatype Guide Bearer token for request
      --loud                         indicate output should include non-vulnerable packages
      --max-go-list-input-size int   Maximum size, in MB, of 'go list' output to read from stdin (default 100)
      --ossindex-url string          Specify an alternate OSS Index URL/host
  -q, --quiet                        indicate output should contain only packages with vulnerabilities (default true)
      --skip-update-check            Skip the check for updates.
  -t, --token string                 Specify OSS Index API token for request (Deprecated: use --guide-token)
  -u, --username string              Specify OSS Index username for request (Deprecated: use --guide-token)
  -V, --version                      Get the version

Ignoring failed scan due to problem with the external scanner.
$ echo $?
0
```