### PR TITLE
go-test: add run_nancy param to make the nancy scan optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `go-test`: `run_nancy` parameter (boolean, default `true`). Set it to `false` to skip the nancy vulnerability scan, for repos that run the scan elsewhere (e.g. a GitHub Actions merge-queue check). The default preserves existing behaviour.
+
 ## [9.4.3] - 2026-06-19
 
 ### Fixed

--- a/docs/job/go-test.md
+++ b/docs/job/go-test.md
@@ -8,7 +8,7 @@ This job:
 - Checks if filenames contain non-ASCII characters.
 - Runs `go vet` against the codebase.
 - Runs `go test` against the codebase.
-- Runs `nancy` against the codebase to check for known vulnerabilities in code dependencies.
+- Runs `nancy` against the codebase to check for known vulnerabilities in code dependencies. Set `run_nancy: false` to skip this when the scan runs elsewhere (e.g. a GitHub Actions merge-queue check).
 
 Example usage:
 

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -14,6 +14,12 @@ parameters:
     description: |
       Executes the requested Makefile target.
     type: string
+  run_nancy:
+    default: true
+    description: |
+      Whether to scan dependencies for known vulnerabilities with nancy. Set to false when the scan
+      runs elsewhere (e.g. a GitHub Actions merge-queue check) to avoid scanning on every build.
+    type: boolean
 steps:
   # We set `CGO_ENABLED=0` because the `architect` Docker image does not have a C compiler. Most cases
   # should work without cgo.
@@ -91,25 +97,28 @@ steps:
               CGO_ENABLED: "0"
             command: |
               go test -ldflags "$(cat .ldflags)" ./...
-  - run:
-      name: Check if dependencies have known security vulnerabilities
-      environment:
-        CGO_ENABLED: "0"
-      command: |
-        set +e
-        go list -json -m all \
-          | nancy sleuth --skip-update-check \
-            --quiet --exclude-vulnerability-file ./.nancy-ignore \
-            --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 \
-            | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
-        grep -qF \
-            -e 'error accessing OSS Index' \
-            -e 'Error: guide API request failed' \
-            nancy-results.txt; grep_result=$?
-        set -e
-        # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.
-        if [[ $nancy_result -ne 0 && $grep_result -eq 0 ]]; then
-          echo Ignoring failed scan due to problem with the external scanner.
-          exit 0
-        fi
-        exit $nancy_result
+  - when:
+      condition: <<parameters.run_nancy>>
+      steps:
+        - run:
+            name: Check if dependencies have known security vulnerabilities
+            environment:
+              CGO_ENABLED: "0"
+            command: |
+              set +e
+              go list -json -m all \
+                | nancy sleuth --skip-update-check \
+                  --quiet --exclude-vulnerability-file ./.nancy-ignore \
+                  --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 \
+                  | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
+              grep -qF \
+                  -e 'error accessing OSS Index' \
+                  -e 'Error: guide API request failed' \
+                  nancy-results.txt; grep_result=$?
+              set -e
+              # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.
+              if [[ $nancy_result -ne 0 && $grep_result -eq 0 ]]; then
+                echo Ignoring failed scan due to problem with the external scanner.
+                exit 0
+              fi
+              exit $nancy_result

--- a/src/jobs/go-test.yaml
+++ b/src/jobs/go-test.yaml
@@ -30,6 +30,12 @@ parameters:
     description: |
       Executes the requested Makefile target.
     type: string
+  run_nancy:
+    default: true
+    description: |
+      Whether to scan dependencies for known vulnerabilities with nancy. Set to false when the scan
+      runs elsewhere (e.g. a GitHub Actions merge-queue check) to avoid scanning on every build.
+    type: boolean
 executor: "architect"
 resource_class: "<< parameters.resource_class >>"
 steps:
@@ -40,4 +46,5 @@ steps:
       path: << parameters.path >>
       pre_test_target: <<parameters.pre_test_target>>
       test_target: <<parameters.test_target>>
+      run_nancy: <<parameters.run_nancy>>
   - go-cache-save


### PR DESCRIPTION
## What

Adds a `run_nancy` boolean parameter (default `true`) to the `go-test` job/command. When set to `false`, the per-build nancy vulnerability scan is skipped.

## Why

The `go-test` command runs `nancy sleuth` on **every** build. Because the scan authenticates against OSS Index, that per-build volume (push, rebase, draft, Renovate) is what drove the Sonatype credit overrun. We are moving the blocking scan to a GitHub Actions merge-queue check (scans the exact commit that lands, once). Repos adopting that path set `run_nancy: false` here to avoid scanning twice; the default keeps every other repo unchanged.

## Testing

Reference the dev tag in a consuming repo: `giantswarm/architect@dev:go-test-optional-nancy`, set `run_nancy: false`, and confirm the "Check if dependencies have known security vulnerabilities" step no longer runs.