### PR TITLE
fix(push-to-registries): degrade SBOM attestation gracefully when Rekor rejects oversized predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `push-to-registries` (cosign SBOM attestation): an oversized SBOM predicate (e.g. the `vllm` CUDA image, whose multi-MB SPDX overruns the public Rekor gateway and returns `502`) no longer fails the whole release. When the `cosign attest` transparency-log upload fails persistently after retries, the orb re-attests with `--tlog-upload=false` so the SBOM attestation stays signed and attached as an OCI referrer (without a public Rekor entry) and verifies it with `--insecure-ignore-tlog`. Image signing stays strict and the normal sub-limit path is unchanged (keeps its Rekor entry).
+
 ## [9.5.0] - 2026-06-21
 
 ### Added

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -202,24 +202,50 @@ steps:
           attest)
             # Large-SBOM dependency: real SBOM predicates routinely exceed public
             # Rekor's 100 KB attestation limit (the live app-operator SPDX is ~465 KB).
-            # This only works because the pinned cosign writes new-format sigstore
-            # bundles (v0.3), whose Rekor `dsse` entries upload hashes rather than the
-            # full payload. If cosign ever defaults back to the legacy `intoto` upload
-            # path (or `--new-bundle-format=false` is added), every large-SBOM build
-            # starts failing here with a Rekor size-limit error.
+            # The common case works because the pinned cosign writes new-format
+            # sigstore bundles (v0.3), whose Rekor `dsse` entries upload hashes rather
+            # than the full payload. But the `cosign attest` request still POSTs the
+            # full DSSE envelope (the base64 SBOM) to Rekor, and a multi-MB predicate
+            # (e.g. the vllm CUDA image SBOM) overruns the public Rekor gateway's
+            # request limit — it returns 502, not a clean size error, so the transient
+            # retry loop above exhausts and the call fails.
+            #
+            # The image signature is already in the transparency log (the `oci` kind
+            # above signs it strictly). Rather than fail the whole release on the
+            # supplementary SBOM attestation, fall back to attesting WITHOUT the tlog
+            # upload (--tlog-upload=false): the signed attestation is still attached as
+            # an OCI referrer on the image, it just gets no public Rekor entry. The
+            # follow-up verify then runs with --insecure-ignore-tlog (the Fulcio cert
+            # is still inside its short validity window this same job). This degrades
+            # gracefully for oversized SBOMs and never blocks a publish; the normal
+            # (sub-limit) path is unchanged and keeps its Rekor entry.
             while IFS=' ' read -r ref type predicate; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign attest --type $type $ref (predicate: $predicate)"
+              no_tlog=0
               rc=0; cosign_retry "attest $ref ($type)" quiet \
                 cosign attest --yes --type "$type" --predicate "$predicate" "$ref" || rc=$?
               if [[ "$rc" -eq 42 ]]; then
                 echo "Rekor: entry already exists for $ref ($type), skipping attest."
               elif [[ "$rc" -ne 0 ]]; then
-                exit 1
+                # The only failure --tlog-upload=false can rescue is the transparency-log
+                # upload itself; Fulcio/registry/auth errors recur and still exit 1 below.
+                echo "WARNING: attest $ref ($type): transparency-log upload failed after retries (typically an oversized SBOM the public Rekor gateway rejects). Re-attesting without the tlog upload — the SBOM attestation stays signed and attached as an OCI referrer, but has no public Rekor entry." >&2
+                no_tlog=1
+                rc=0; cosign_retry "attest $ref ($type, no-tlog)" quiet \
+                  cosign attest --yes --tlog-upload=false --type "$type" --predicate "$predicate" "$ref" || rc=$?
+                if [[ "$rc" -eq 42 ]]; then
+                  echo "Rekor: entry already exists for $ref ($type), skipping attest."
+                elif [[ "$rc" -ne 0 ]]; then
+                  exit 1
+                fi
               fi
               echo "cosign verify-attestation --type $type $ref"
+              verify_tlog_args=()
+              if [[ "$no_tlog" -eq 1 ]]; then verify_tlog_args+=("--insecure-ignore-tlog"); fi
               cosign_retry "verify-attestation $ref ($type)" show cosign verify-attestation \
                 --type "$type" \
+                "${verify_tlog_args[@]+"${verify_tlog_args[@]}"}" \
                 --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
                 --certificate-identity-regexp "$IDENTITY_REGEX" \
                 "$ref" || exit 1


### PR DESCRIPTION
## Problem

`vllm` releases (and any image with a very large SBOM) fail at the cosign SBOM-attestation step of `push-to-registries`. The `cosign attest --type spdxjson` call POSTs the full DSSE envelope (the multi-MB SPDX predicate) to the public Rekor log, which rejects the oversized request with `502 Bad Gateway`. The orb's transient-retry loop exhausts and the whole publish job fails — even though the image signature itself was already logged successfully, and the image + chart were already pushed.

This is deterministic and pre-existing: `vllm` `v0.4.0` (legacy release), `v0.4.1` (original) and the `v0.4.1` rerun all failed identically at this step over a ~3h window with Rekor otherwise healthy. It is isolated to the largest image; smaller SBOMs (e.g. app-operator's ~465 KB) still upload fine via cosign's hash-only new-bundle-format entries.

## Solution

When the `cosign attest` transparency-log upload fails persistently after the retry loop, re-attest with `--tlog-upload=false`: the signed SBOM attestation is still attached as an OCI referrer on the image, it just gets no public Rekor entry. The follow-up `verify-attestation` then runs with `--insecure-ignore-tlog` (the Fulcio cert is still within its short validity window in the same job).

- Image signing (`oci` kind) stays **strict** — unchanged, still fails hard if it can't be logged.
- The normal sub-limit attestation path is **unchanged** and keeps its Rekor entry.
- Only the supplementary SBOM attestation degrades, and only after persistent failure — a publish is never blocked by an oversized SBOM. The fallback can only rescue tlog-upload failures; Fulcio/registry/auth errors recur and still fail.

## Acceptance criteria

- [ ] `push-to-registries` on a large-SBOM image (vllm) completes successfully, attaching a signed SBOM attestation as an OCI referrer with a clear warning that the public Rekor entry was skipped.
- [ ] Normal-size SBOM images are unchanged and still get a Rekor-logged attestation.
- [ ] Image signature behaviour is unchanged (strict).

Tested against a consuming repo via the `dev:harden-oversized-sbom-attest-tlog-fallback` orb tag.

Made with [Cursor](https://cursor.com)