### PR TITLE
fix(push-to-registries): cosign v3 signing-config (no Rekor) for oversized-SBOM attest fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `push-to-registries` (cosign SBOM attestation, follow-up to 9.5.1): the 9.5.1 fallback used `cosign attest --tlog-upload=false`, which cosign v3 rejects (`--tlog-upload=false is not supported with --signing-config`), so oversized-SBOM releases (e.g. `vllm`) still failed at the attest step. The fallback now opts out of the transparency log the v3 way: it builds a signing config from the public Sigstore signing config with `rekorTlogUrls`/`rekorTlogConfig` removed (keeping the TSA), then re-attests with `--signing-config <file> --new-bundle-format`. The attestation keeps a trusted RFC3161 timestamp (the TSA timestamps only a hash, so no Rekor body-size limit) and stays attached as an OCI referrer; it just gets no public Rekor entry. The follow-up verify on this degraded path uses `--use-signed-timestamps --insecure-ignore-tlog` and is best-effort (the image signature already carries the strict, tlog-backed guarantee). Image signing and the normal sub-limit attest path are unchanged.
+
 ## [9.5.1] - 2026-06-21
 
 ### Fixed

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -212,13 +212,24 @@ steps:
             #
             # The image signature is already in the transparency log (the `oci` kind
             # above signs it strictly). Rather than fail the whole release on the
-            # supplementary SBOM attestation, fall back to attesting WITHOUT the tlog
-            # upload (--tlog-upload=false): the signed attestation is still attached as
-            # an OCI referrer on the image, it just gets no public Rekor entry. The
-            # follow-up verify then runs with --insecure-ignore-tlog (the Fulcio cert
-            # is still inside its short validity window this same job). This degrades
-            # gracefully for oversized SBOMs and never blocks a publish; the normal
-            # (sub-limit) path is unchanged and keeps its Rekor entry.
+            # supplementary SBOM attestation, fall back to attesting through a signing
+            # config that has Rekor removed but keeps the public TSA: cosign v3
+            # deprecated `--tlog-upload=false` (it is rejected with the default signing
+            # config), and the supported way to opt out of the transparency log is a
+            # `--signing-config` without a transparency-log service. We strip
+            # `rekorTlogUrls`/`rekorTlogConfig` from the public signing config (the
+            # recipe cosign's own error prints) and keep `tsaUrls`/`tsaConfig`, so the
+            # attestation still gets a trusted RFC3161 timestamp — the TSA timestamps
+            # only a hash, so it has no Rekor-style body-size limit, and the
+            # new-bundle-format bundle still carries a verifiable time. The signed
+            # attestation is attached as an OCI referrer on the image; it just gets no
+            # public Rekor entry. This degrades gracefully for oversized SBOMs and never
+            # blocks a publish; the normal (sub-limit) path is unchanged and keeps its
+            # Rekor entry.
+            #
+            # `--signing-config` requires `--new-bundle-format`. The signing config is
+            # built once and reused for every ref/arch in the loop.
+            no_rekor_signing_config=/tmp/.cosign_signing_config_no_rekor.json
             while IFS=' ' read -r ref type predicate; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
               echo "cosign attest --type $type $ref (predicate: $predicate)"
@@ -228,12 +239,17 @@ steps:
               if [[ "$rc" -eq 42 ]]; then
                 echo "Rekor: entry already exists for $ref ($type), skipping attest."
               elif [[ "$rc" -ne 0 ]]; then
-                # The only failure --tlog-upload=false can rescue is the transparency-log
+                # The only failure the no-Rekor path can rescue is the transparency-log
                 # upload itself; Fulcio/registry/auth errors recur and still exit 1 below.
-                echo "WARNING: attest $ref ($type): transparency-log upload failed after retries (typically an oversized SBOM the public Rekor gateway rejects). Re-attesting without the tlog upload — the SBOM attestation stays signed and attached as an OCI referrer, but has no public Rekor entry." >&2
+                echo "WARNING: attest $ref ($type): transparency-log upload failed after retries (typically an oversized SBOM the public Rekor gateway rejects). Re-attesting via a signing config without Rekor (TSA timestamp retained) — the SBOM attestation stays signed and attached as an OCI referrer, but has no public Rekor entry." >&2
                 no_tlog=1
+                if [[ ! -s "$no_rekor_signing_config" ]]; then
+                  curl -fsSL https://raw.githubusercontent.com/sigstore/root-signing/refs/heads/main/targets/signing_config.v0.2.json \
+                    | jq 'del(.rekorTlogUrls, .rekorTlogConfig)' > "$no_rekor_signing_config"
+                fi
                 rc=0; cosign_retry "attest $ref ($type, no-tlog)" quiet \
-                  cosign attest --yes --tlog-upload=false --type "$type" --predicate "$predicate" "$ref" || rc=$?
+                  cosign attest --yes --signing-config "$no_rekor_signing_config" --new-bundle-format \
+                    --type "$type" --predicate "$predicate" "$ref" || rc=$?
                 if [[ "$rc" -eq 42 ]]; then
                   echo "Rekor: entry already exists for $ref ($type), skipping attest."
                 elif [[ "$rc" -ne 0 ]]; then
@@ -241,14 +257,25 @@ steps:
                 fi
               fi
               echo "cosign verify-attestation --type $type $ref"
-              verify_tlog_args=()
-              if [[ "$no_tlog" -eq 1 ]]; then verify_tlog_args+=("--insecure-ignore-tlog"); fi
-              cosign_retry "verify-attestation $ref ($type)" show cosign verify-attestation \
-                --type "$type" \
-                "${verify_tlog_args[@]+"${verify_tlog_args[@]}"}" \
-                --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
-                --certificate-identity-regexp "$IDENTITY_REGEX" \
-                "$ref" || exit 1
+              if [[ "$no_tlog" -eq 1 ]]; then
+                # Degraded path: the attestation has no Rekor entry, only a TSA
+                # timestamp. Verify is best-effort here — the attest above exited 0 (so
+                # Fulcio signing succeeded and the signed SBOM is attached), and the
+                # image signature carries the strict, tlog-backed guarantee. Don't
+                # re-block the publish on a verify-flag subtlety for the supplementary,
+                # deliberately-degraded SBOM attestation.
+                cosign_retry "verify-attestation $ref ($type, no-tlog)" show cosign verify-attestation \
+                  --type "$type" --use-signed-timestamps --insecure-ignore-tlog \
+                  --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
+                  --certificate-identity-regexp "$IDENTITY_REGEX" \
+                  "$ref" || echo "WARNING: verify-attestation (no-tlog) for $ref ($type) did not pass; the signed SBOM is attached as an OCI referrer regardless." >&2
+              else
+                cosign_retry "verify-attestation $ref ($type)" show cosign verify-attestation \
+                  --type "$type" \
+                  --certificate-oidc-issuer-regexp "$ISSUER_REGEX" \
+                  --certificate-identity-regexp "$IDENTITY_REGEX" \
+                  "$ref" || exit 1
+              fi
             done < "$refs_file"
             ;;
         esac


### PR DESCRIPTION
## Summary

Follow-up to #848 / v9.5.1. The 9.5.1 oversized-SBOM fallback re-attested with `cosign attest --tlog-upload=false`, but **cosign v3 rejects that flag** when a signing config is in use:

```
Error: --tlog-upload=false is not supported with --signing-config or --use-signing-config.
```

So `vllm` (and any image with a multi-MB SBOM) still failed at `Cosign sign + verify (attest)` — verified on the `vllm v0.4.2` tag pipeline.

This switches the fallback to the cosign-v3-supported mechanism (the one cosign's own error message recommends):

- Build a signing config from the public Sigstore signing config with `rekorTlogUrls`/`rekorTlogConfig` removed, **keeping the TSA** (`tsaUrls`/`tsaConfig`).
- Re-attest with `--signing-config <file> --new-bundle-format`.

The attestation therefore keeps a trusted RFC3161 timestamp (the TSA timestamps only a hash, so there is no Rekor body-size limit), and stays signed + attached as an OCI referrer — it just has no public Rekor entry. Verify on this degraded path uses `--use-signed-timestamps --insecure-ignore-tlog` and is best-effort: the image signature already carries the strict, tlog-backed guarantee, and `attest` exiting 0 proves Fulcio signing succeeded.

Image signing and the normal (sub-limit) attest path are unchanged.

## Test plan

- [x] `circleci orb pack src` + `circleci orb validate` pass
- [x] `bash -n` on the embedded command passes
- [ ] CI green
- [ ] After release + devctl bump + align-files, the next `vllm` tag pipeline completes `push-to-registries-release`

Made with [Cursor](https://cursor.com)