### PR TITLE
fix(go-cache): use HOME for GOCACHE instead of /go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `go-cache-restore`/`go-cache-save`: use `$HOME/.cache/go-build` for `GOCACHE` instead of `/go/cache/go-build`. `/go` only exists in Docker images derived from the official `golang` image; machine executors and other non-Go base images do not have it, causing `mkdir /go: permission denied` at build time.
+
 ## [9.5.2] - 2026-06-21
 
 ### Fixed

--- a/src/commands/go-cache-restore.yaml
+++ b/src/commands/go-cache-restore.yaml
@@ -2,7 +2,7 @@ steps:
   - run:
       name: Pin GOCACHE
       command: |
-        echo 'export GOCACHE=/go/cache/go-build' >> "$BASH_ENV"
+        echo "export GOCACHE=${HOME}/.cache/go-build" >> "$BASH_ENV"
   - restore_cache:
       name: Restore Go module cache
       keys:

--- a/src/commands/go-cache-save.yaml
+++ b/src/commands/go-cache-save.yaml
@@ -8,4 +8,4 @@ steps:
       name: Save Go build cache
       key: go-build-cache-v1-{{ checksum "go.sum" }}
       paths:
-        - "/go/cache/go-build"
+        - "~/.cache/go-build"


### PR DESCRIPTION
## What changed

`go-cache-restore` pins `GOCACHE=/go/cache/go-build` (introduced in #838). `/go` only exists in Docker images derived from the official `golang` image. Machine executors (e.g. `architect/machine`) don't have `/go` pre-created, so Go fails with `mkdir /go: permission denied` when initialising the build cache.

Changed to `$HOME/.cache/go-build`, which is Go's own default and is always writable regardless of executor type. The `save_cache` path is updated to match (`~/.cache/go-build`).

Fixes the regression reported in #838 (comment) against `giantswarm/clustertest`.