### PR TITLE
fix(go-test): keep nancy scan log out of the worktree (fixes +dirty release binaries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `go-test` (nancy step): write the scan log to `/tmp/nancy-results.txt` instead of `./nancy-results.txt` in the repo root. The step runs between `make test` and the binary link, so the stray untracked file made Go's buildvcs stamp `vcs.modified=true`, and every release binary built by `go-build` reported `vX.Y.Z+dirty` (observed on `devctl` and `muster`). This also broke consumers that key off the version string — e.g. the `align-files` workflow's `DEVCTL_UNSAFE_FORCE_VERSION` self-update bypass, which compares against a `+dirty`-stripped version and so never matched. The scan log now lives outside the working tree like the other orb scratch files.
+
 ## [9.5.3] - 2026-06-22
 
 ### Fixed

--- a/src/commands/go-test.yaml
+++ b/src/commands/go-test.yaml
@@ -97,15 +97,20 @@ steps:
         CGO_ENABLED: "0"
       command: |
         set +e
+        # Write the scan log to /tmp, not the working tree: this command runs
+        # between `make test` and the binary link, and a stray untracked file in
+        # the repo makes Go's buildvcs stamp `vcs.modified=true`, so release
+        # binaries report `vX.Y.Z+dirty`. Keep it out of the tree like the other
+        # orb scratch files (/tmp/.cosign_blobs, /tmp/.gh_response_binsign).
         go list -json -m all \
           | nancy sleuth --skip-update-check \
             --quiet --exclude-vulnerability-file ./.nancy-ignore \
             --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 \
-            | tee ./nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
+            | tee /tmp/nancy-results.txt ; nancy_result=(${PIPESTATUS[1]})
         grep -qF \
             -e 'error accessing OSS Index' \
             -e 'Error: guide API request failed' \
-            nancy-results.txt; grep_result=$?
+            /tmp/nancy-results.txt; grep_result=$?
         set -e
         # If nancy gave us a bad exit code AND grep found an OSS index error in the output, then we don't fail the build.
         if [[ $nancy_result -ne 0 && $grep_result -eq 0 ]]; then


### PR DESCRIPTION
## Problem

Release binaries built by `go-build` embed `vX.Y.Z+dirty` even on clean tagged commits. Confirmed on the actual GitHub Release assets:

- `devctl` `v8.23.5+dirty` (`vcs.modified=true`)
- `muster` `v0.18.9+dirty` (`vcs.modified=true`, built at the v0.18.9 tag commit)

Root cause: the `go-test` nancy step writes its log with `tee ./nancy-results.txt` into the **repo root**. That file is not gitignored, and the step runs **between `make test` and the binary link** in `go-build`. At link time Go's buildvcs runs `git status --porcelain`, sees the untracked file, and stamps `vcs.modified=true` → `+dirty`.

A diagnostic placed at the end of a consumer's `make test` (before *and* after `go test ./...`) showed a clean tree, which localized the dirtying to this orb step — no consumer Makefile hook runs between nancy and the link, so this can only be fixed in the orb.

### Downstream impact

`+dirty` also breaks consumers that key off the version string. The `align-files` workflow strips the `+dirty` suffix when computing `DEVCTL_UNSAFE_FORCE_VERSION`, so devctl's self-update bypass never matched its own (`+dirty`) build-info version and aborted.

## Fix

Write the scan log to `/tmp/nancy-results.txt` instead of the working tree, matching the other orb scratch files (`/tmp/.cosign_blobs`, `/tmp/.gh_response_binsign`). The working tree stays clean at link time, so buildvcs no longer stamps `+dirty`.

## Test plan

- [ ] Point a Go consumer's `.circleci/config.yml` at `giantswarm/architect@dev:fix-nancy-results-dirty-tree`, run go-build, and confirm the built binary's `go version -m` reports no `+dirty` (vcs.modified=false).

Made with [Cursor](https://cursor.com)