### PR TITLE
fix(go-cache): bump build-cache key to v2 after GOCACHE path move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `go-cache-restore`/`go-cache-save`: bump the build-cache key from `go-build-cache-v1-` to `go-build-cache-v2-`. 9.5.3 moved `GOCACHE` from `/go/cache/go-build` to `$HOME/.cache/go-build` without changing the key, but CircleCI cache keys are immutable, so `restore_cache` kept matching the archive saved by 9.5.2 builds under the `v1` key (containing the old `/go/cache/go-build` path) and unpacked it where `GOCACHE` no longer points — a permanent cold compile, with `save_cache` a no-op against the existing key so it never self-corrected until the next `go.sum` change. On 6-arch repos with `build_concurrency` enabled this turned every build into parallel cold cross-compiles and OOM-killed memory-heavy builds (observed on `mcp-kubernetes`). The `v2` key opens a fresh namespace matching the new path so warm caching actually takes effect. The module-cache key (`go-build-go-mod-v1-`, path unchanged) is left as-is.
+
 ## [9.5.4] - 2026-06-24
 
 ### Fixed

--- a/src/commands/go-cache-restore.yaml
+++ b/src/commands/go-cache-restore.yaml
@@ -10,4 +10,4 @@ steps:
   - restore_cache:
       name: Restore Go build cache
       keys:
-        - go-build-cache-v1-{{ checksum "go.sum" }}
+        - go-build-cache-v2-{{ checksum "go.sum" }}

--- a/src/commands/go-cache-save.yaml
+++ b/src/commands/go-cache-save.yaml
@@ -6,6 +6,6 @@ steps:
         - "/go/pkg/mod"
   - save_cache:
       name: Save Go build cache
-      key: go-build-cache-v1-{{ checksum "go.sum" }}
+      key: go-build-cache-v2-{{ checksum "go.sum" }}
       paths:
         - "~/.cache/go-build"


### PR DESCRIPTION
## Problem

The Go build-cache work shipped in two parts and the seam between them is broken:

- **#838** (v9.5.0) added `$GOCACHE` persistence keyed on `go.sum`, pinning `GOCACHE=/go/cache/go-build`, plus the opt-in `build_concurrency` parameter.
- **#853** (v9.5.3) moved `GOCACHE` to `$HOME/.cache/go-build` (so it works on machine executors where `/go` does not exist) — but **left the cache key at `go-build-cache-v1-{{ checksum "go.sum" }}`** in both `go-cache-save` and `go-cache-restore`.

CircleCI cache keys are immutable (first writer under a key wins). So on v9.5.3+:

1. `restore_cache` matches the archive a v9.5.2 build already saved under the `v1` key — which contains the **old** `/go/cache/go-build` path — and unpacks it there, while `GOCACHE` now points at `$HOME/.cache/go-build` (empty) → **cold compile on every build**.
2. `save_cache` reuses the same already-existing `v1` key → no-op → the cache **never self-corrects** until `go.sum` changes.

On the 6-arch `cli`-flavour repos with `build_concurrency` enabled, this permanent cold cache means N simultaneous client-go cold compiles → **OOM kill** (observed on `mcp-kubernetes`). The intended 5.1x warm speedup from #838 never materializes, and the parallel-build feature becomes actively harmful.

### Proof (from a failing `mcp-kubernetes` build on orb 9.5.3)

```
Restore Go build cache:
  Found a cache from job 6146 at go-build-cache-v1-...
  Cached paths:
    * /go/cache/go-build          <- restored here
Pin GOCACHE:
  export GOCACHE=$HOME/.cache/go-build   <- but Go reads here (empty)
```

## Solution

Bump the build-cache key from `go-build-cache-v1-` to `go-build-cache-v2-` in both `go-cache-save` and `go-cache-restore`. `v2` opens a fresh, empty namespace, so the first build saves an archive containing `~/.cache/go-build` and subsequent builds with the same `go.sum` restore it at the correct path → warm cache, and the OOM disappears.

The module-cache key (`go-build-go-mod-v1-`, path `/go/pkg/mod` unchanged) is intentionally **not** bumped.

## Acceptance criteria

- [ ] A warm build (same `go.sum`, post-merge) shows a build-cache hit at `$HOME/.cache/go-build` and recompiles only changed packages.
- [ ] `mcp-kubernetes` 6-arch build with `build_concurrency` no longer OOMs.

Made with [Cursor](https://cursor.com)