### PR TITLE
chore(deps): update app-build-suite executor image to 2.2.0-circleci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Bump the `app-build-suite` executor image to `2.2.0-circleci` (was `2.1.3-circleci`), picking up abs v2.2.0: package-time Artifact Hub metadata injection and the `HelmTemplateValidator` build step ([giantswarm/roadmap#3940](https://github.com/giantswarm/roadmap/issues/3940)).
+
 ## [9.5.5] - 2026-06-24
 
 ### Fixed

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,4 +1,4 @@
 docker:
   - entrypoint: /bin/bash
     # registry: gsoci.azurecr.io/giantswarm/app-build-suite
-    image: gsoci.azurecr.io/giantswarm/app-build-suite:2.1.3-circleci
+    image: gsoci.azurecr.io/giantswarm/app-build-suite:2.2.0-circleci


### PR DESCRIPTION
Bumps the `app-build-suite` executor image `2.1.3-circleci → 2.2.0-circleci`, picking up **abs v2.2.0**:
- package-time **Artifact Hub metadata injection** (`artifacthub.io/license` + `artifacthub.io/links`, chart README) — [giantswarm/roadmap#3940](https://github.com/giantswarm/roadmap/issues/3940)
- the `HelmTemplateValidator` build step (rejects duplicate keys / invalid rendered YAML)

The `2.2.0-circleci` image is already published to gsoci. Renovate doesn't track this pin (the `-circleci` suffix), hence the manual bump.

Once released (new orb version), chart repos that bump the orb and cut a release get the injected AH metadata on their Artifact Hub pages.