### PR TITLE
chore: remove ct_config and skip_conftest_deprek8ion params from push-to-app-catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - `push-to-registries`: register QEMU/binfmt handlers only when at least one target platform differs from the build host. Single-arch repos (`platforms: linux/amd64`) were paying a privileged `tonistiigi/binfmt --install all` image pull on every build for handlers that could never be used, since no `RUN` step is emulated when the target matches the host. Multi-arch builds are unchanged, and if the host platform cannot be determined the handlers are registered as before rather than risking an un-emulated cross build.
+- `executor` parameter on `push-to-app-catalog` is now **permanently retained** rather than pending removal.
+  It accepts only `app-build-suite`, which is also the default, so passing it is already a no-op — but ~275
+  repos set it explicitly and removing it would break all of them for no benefit.
+
+### Removed
+
+- **Breaking.** `skip_conftest_deprek8ion` parameter on `push-to-app-catalog`. It has been ignored since
+  v6.3.2, when the `helm-conftest` step it controlled was removed. The third-party
+  [deprek8ion](https://github.com/swade1987/deprek8ion) policies that step ran have been unmaintained since
+  2021 and only covered Kubernetes API deprecations up to 1.22; app-build-suite runs kube-linter over the
+  same manifests. `conftest` is also gone from the architect, app-build-suite, and app-test-suite images.
+- **Breaking.** `ct_config` parameter on `push-to-app-catalog`. It has been ignored since v9.0.0, when the
+  `helm-lint` step it controlled was removed along with the `architect`-executor path. Chart-testing config
+  is still honoured by app-build-suite via `ct-config` in `.abs/main.yaml` — only the orb parameter is gone,
+  so no `ct-config.yaml` files need to change.
+
+> **Upgrading from v9.x?** See [docs/migration-v9-to-v10.md](docs/migration-v9-to-v10.md).
 
 ## [9.6.0] - 2026-07-24
 

--- a/docs/migration-v9-to-v10.md
+++ b/docs/migration-v9-to-v10.md
@@ -1,0 +1,49 @@
+# Migrating from architect-orb v9 to v10
+
+v10 removes two parameters from `push-to-app-catalog` that the orb has ignored for at least a major
+version. There are no behaviour changes — if your config does not pass either parameter, upgrading to v10
+is a no-op.
+
+## What to check
+
+Search your `.circleci/config.yml` for these two keys:
+
+```
+ct_config
+skip_conftest_deprek8ion
+```
+
+If neither appears, you are done — merge the version bump.
+
+If either appears, **delete the line**. CircleCI fails config compilation on unknown job arguments, so
+leaving it in place will break the `push-to-app-catalog` job on v10.
+
+## Why they went
+
+### `skip_conftest_deprek8ion` — ignored since v6.3.2
+
+This controlled the `helm-conftest` step, which ran the third-party
+[deprek8ion](https://github.com/swade1987/deprek8ion) rego policies to flag Kubernetes API deprecations.
+The step was removed in v6.3.2 after a conftest upgrade made it incompatible with those policies.
+
+It was not restored: the policy set has been unmaintained since 2021 and only covered deprecations up to
+Kubernetes 1.22, while app-build-suite already runs kube-linter over the same manifests in the helm build
+pipeline. The `conftest` binary has also been dropped from the architect, app-build-suite, and
+app-test-suite images.
+
+See [roadmap#4066](https://github.com/giantswarm/roadmap/issues/4066).
+
+### `ct_config` — ignored since v9.0.0
+
+This pointed at a chart-testing config file for the `helm-lint` step. That step was removed in v9.0.0
+along with the whole `architect`-executor path, when packaging moved to app-build-suite.
+
+**Your `ct-config.yaml` file does not need to change.** app-build-suite still reads chart-testing config,
+via the `ct-config` key in `.abs/main.yaml` — most repos already configure it there, and that path is
+unaffected. Only the orb parameter is gone.
+
+## What is *not* changing
+
+The `executor` parameter stays. It accepts only `app-build-suite` (also the default), so passing it is
+already a no-op, but around 275 repos set it explicitly. It is now permanently retained rather than
+deprecated — you can leave it in place indefinitely.

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -20,10 +20,6 @@ parameters:
     description: |
       If 'explicit_allow_chart_name_mismatch' is set to true, the name of the chart can be anything.
       Otherwise the name set in the 'chart' parameter must start with the repository name and optionally continue with '-app'.
-  ct_config:
-    description: "Chart Testing Config file path"
-    type: "string"
-    default: ""
   on_tag:
     type: boolean
     default: true
@@ -36,8 +32,9 @@ parameters:
     enum: ["app-build-suite"]
     default: "app-build-suite"
     description: |
-      Kept for backwards compatibility. Only `app-build-suite` is accepted.
-      Will be removed in a future version.
+      Kept for backwards compatibility. Only `app-build-suite` is accepted, and it is the default,
+      so passing this parameter has no effect. Retained permanently: ~275 repos still set it
+      explicitly, and removing it would break every one of them for no benefit.
   push_to_appcatalog:
     default: true
     description: |
@@ -68,12 +65,6 @@ parameters:
       for details.
     type: "enum"
     enum: ["small", "medium", "medium+", "large", "xlarge"]
-  skip_conftest_deprek8ion:
-    type: boolean
-    default: false
-    description: |
-      This parameter has no effect anymore, it is kept for backwards compatibility.
-      Will be removed in a future version.
   override_chart_version:
     type: boolean
     default: true


### PR DESCRIPTION
Retires the two `push-to-app-catalog` parameters that the orb has ignored for at least a major version. **Breaking — targets v10.0.0.**

| Param | Ignored since | Repos still passing it |
|---|---|---|
| `skip_conftest_deprek8ion` | v6.3.2 (`helm-conftest` step removed) | 2 |
| `ct_config` | v9.0.0 (`helm-lint` step removed) | 20 |

### Consumers are already cleaned

All 22 consumer repos have PRs open removing the params, so this can be released without breaking anyone. Tracking list is in giantswarm/roadmap#4066.

### `executor` is deliberately *not* removed

v9.0.0 parked three compat params for "a future version". Only two go here. `executor` accepts a single valid value that is also the default, so passing it is already a no-op — but **~275 repos set it explicitly**, and removing it would break all of them for zero benefit. Its description is updated to say it is permanently retained, so it stops reading as pending removal.

### Also in this PR

- `docs/migration-v9-to-v10.md`, matching the v8→v9 precedent, so the Renovate major PRs have something to link to. It makes the point that **`ct-config.yaml` files do not need to change** — app-build-suite still reads chart-testing config via `ct-config` in `.abs/main.yaml`; only the orb parameter is gone.

### Release

**Merging this does not release it.** Production publish is tag-driven, and the tag comes from merging a release PR created by pushing `main#release#major`. That should happen only once the 22 consumer PRs have actually merged.

Companion image PRs: giantswarm/architect#1391, giantswarm/app-build-suite#581, giantswarm/app-test-suite#699.

Part of giantswarm/roadmap#4066