### PR TITLE
chore(deps): update app-build-suite executor image to 2.3.0-circleci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Bump the `app-build-suite` executor image to `2.3.0-circleci` (was `2.2.0-circleci`), picking up abs v2.3.0:
+  `HelmTemplateValidator` now skips Helm library charts instead of failing, and explains how to get past a
+  failed render ([roadmap#4066](https://github.com/giantswarm/roadmap/issues/4066)).
 - `push-to-registries`: register QEMU/binfmt handlers only when at least one target platform differs from the build host. Single-arch repos (`platforms: linux/amd64`) were paying a privileged `tonistiigi/binfmt --install all` image pull on every build for handlers that could never be used, since no `RUN` step is emulated when the target matches the host. Multi-arch builds are unchanged, and if the host platform cannot be determined the handlers are registered as before rather than risking an un-emulated cross build.
 - `executor` parameter on `push-to-app-catalog` is now **permanently retained** rather than pending removal.
   It accepts only `app-build-suite`, which is also the default, so passing it is already a no-op — but ~275

--- a/src/executors/app-build-suite.yaml
+++ b/src/executors/app-build-suite.yaml
@@ -1,4 +1,4 @@
 docker:
   - entrypoint: /bin/bash
     # registry: gsoci.azurecr.io/giantswarm/app-build-suite
-    image: gsoci.azurecr.io/giantswarm/app-build-suite:2.2.0-circleci
+    image: gsoci.azurecr.io/giantswarm/app-build-suite:2.3.0-circleci


### PR DESCRIPTION
Bumps the `app-build-suite` executor from `2.2.0-circleci` to `2.3.0-circleci`.

abs [v2.3.0](https://github.com/giantswarm/app-build-suite/releases/tag/v2.3.0) brings:

- **`HelmTemplateValidator` skips Helm library charts** instead of failing the build. Every library chart broke on abs 2.2.0 unless it set `disable-helm-template-validator` by hand — `helm template` refuses them with "library charts are not installable". This is what `cluster-shared` and `kubectl-apply-job` are currently working around.
- **Actionable hints on a failed render** — points at `--helm-template-extra-values`, and when the chart calls helm's `lookup` notes that no values file can substitute for cluster state.
- `conftest` removed from the image (giantswarm/roadmap#4066).

Verified against the published image rather than the build:

```
$ docker run --rm --entrypoint sh gsoci.azurecr.io/giantswarm/app-build-suite:2.3.0-circleci -c '…'
library-chart skip: True
lookup hint:        True
version: app_build_suite v2.3.0
conftest absent (expected)
```

Opened by hand rather than waiting for Renovate's next run, because the v10.0.0 release is queued behind it.

Part of giantswarm/roadmap#4066