### PR TITLE
fix(push-helm): sign published Helm charts again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `push-to-app-catalog`, `push-helm`: Helm chart signing was silently skipped — `sign: true` is the
+  default, yet every public chart published since 2026-05-20 shipped **unsigned** while CI reported
+  success. `push-helm` staged the chart's OCI reference with `echo -n`, so `/tmp/.cosign_refs` had no
+  trailing newline; `cosign-sign-verify` consumes that file with `while IFS= read -r`, which discards
+  a final line lacking a newline. The chart writes exactly one reference, so the loop body never ran.
+  The `[[ ! -s "$refs_file" ]]` guard passed (the file was non-empty), `cosign version` printed, and
+  the step exited 0 having signed nothing.
+
+  Container images and Go binaries were unaffected: their producers append with plain `echo`, so their
+  entries were newline-terminated. The regression came in with #774, which folded chart sign+verify
+  into the shared `cosign-sign-verify` command — the `echo -n` was carried over from the previous
+  single-value scratch files (`/tmp/.chart_digest`, `/tmp/.chart_registry`), where a missing newline
+  was harmless, and became a dropped line once the same file was read as line-oriented input.
+
+  Note this only fixes new publishes. Chart versions already in `gsoci.azurecr.io/charts/giantswarm`
+  remain unsigned; re-signing them is tracked separately, since a manual re-sign cannot carry the
+  CircleCI pipeline OIDC identity the verify assertions expect.
+
+- `cosign-sign-verify`: harden the command against this class of failure rather than the one instance.
+  All three read loops (`oci`, `blob`, `attest`) consume caller-supplied files and now tolerate a
+  missing final newline (`while … read … || [[ -n "$var" ]]`). The step also counts the actionable
+  entries in the file up front and fails if any of them never reached cosign, so a future silent skip
+  is a red build instead of a green one. The `oci` loop's blank/comment predicate now matches that
+  count (it reads with an empty `IFS`, so unlike the other two it also saw whitespace-only and
+  space-indented `#` lines as entries). Truncating the refs file to skip signing — how private charts
+  and images opt out — still exits 0 as before.
+
 ## [10.0.0] - 2026-08-18
 
 ### Deprecated

--- a/src/commands/cosign-sign-verify.yaml
+++ b/src/commands/cosign-sign-verify.yaml
@@ -18,9 +18,15 @@
 #                 `gsoci.azurecr.io/giantswarm/myapp@sha256:… spdxjson /tmp/sbom.spdx.json`
 #                 (signs the predicate as a cosign DSSE attestation referrer on <ref>).
 # Blank lines and lines starting with `#` are ignored. If the file does not
-# exist or is empty, the step exits 0 without doing anything (so callers that
-# decide at runtime to skip signing — e.g. private artifacts — can do so by
-# truncating the file).
+# exist, is empty, or holds only ignored lines, the step exits 0 without doing
+# anything (so callers that decide at runtime to skip signing — e.g. private
+# artifacts — can do so by truncating the file).
+#
+# A final line without a trailing newline still counts: every entry the file
+# lists must reach cosign, and the step fails if one does not. Producers should
+# still terminate each line (`echo "$entry" >> "$file"`) — an entry that never
+# reaches cosign means an artifact published unsigned on a green build, which is
+# what #878 was.
 
 parameters:
   kind:
@@ -52,6 +58,18 @@ steps:
           echo "No entries in $refs_file; nothing to sign."
           exit 0
         fi
+
+        # Count the entries the loops below will actually act on (same blank-line and
+        # `#`-comment skipping), and assert at the end that every one was processed.
+        # A non-empty file whose entries all get skipped used to exit 0 silently —
+        # that is how chart signing went missing for three months (#878). `grep -c`
+        # exits 1 on zero matches, which `set -e` would take as a failure.
+        expected=$(grep -cvE '^[[:space:]]*($|#)' "$refs_file" || true)
+        if [[ "$expected" -eq 0 ]]; then
+          echo "No actionable entries in $refs_file; nothing to sign."
+          exit 0
+        fi
+        processed=0
 
         cosign version
 
@@ -145,8 +163,12 @@ steps:
 
         case "<<parameters.kind>>" in
           oci)
-            while IFS= read -r ref; do
-              [[ -z "$ref" || "$ref" =~ ^# ]] && continue
+            while IFS= read -r ref || [[ -n "$ref" ]]; do
+              # `oci` reads with an empty IFS to keep refs verbatim, so unlike the
+              # `blob`/`attest` loops it sees leading whitespace; match the blank/comment
+              # predicate `expected` uses above so the two cannot disagree.
+              [[ -z "${ref//[[:space:]]/}" || "$ref" =~ ^[[:space:]]*# ]] && continue
+              processed=$((processed + 1))
               echo "cosign sign $ref"
               rc=0; cosign_retry "sign $ref" quiet cosign sign --yes "$ref" || rc=$?
               if [[ "$rc" -eq 42 ]]; then
@@ -170,8 +192,9 @@ steps:
             # invocation — a retry produces a new, non-equivalent entry — so a
             # full re-run resolves the conflict. Transient backend errors are
             # retried the same way (with backoff); both share MAX_ATTEMPTS.
-            while IFS=' ' read -r file bundle; do
+            while IFS=' ' read -r file bundle || [[ -n "$file" ]]; do
               [[ -z "$file" || "$file" =~ ^# ]] && continue
+              processed=$((processed + 1))
               echo "cosign sign-blob $file → $bundle"
               for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
                 rm -f "$bundle"
@@ -230,8 +253,9 @@ steps:
             # `--signing-config` requires `--new-bundle-format`. The signing config is
             # built once and reused for every ref/arch in the loop.
             no_rekor_signing_config=/tmp/.cosign_signing_config_no_rekor.json
-            while IFS=' ' read -r ref type predicate; do
+            while IFS=' ' read -r ref type predicate || [[ -n "$ref" ]]; do
               [[ -z "$ref" || "$ref" =~ ^# ]] && continue
+              processed=$((processed + 1))
               echo "cosign attest --type $type $ref (predicate: $predicate)"
               no_tlog=0
               rc=0; cosign_retry "attest $ref ($type)" quiet \
@@ -282,3 +306,14 @@ steps:
             done < "$refs_file"
             ;;
         esac
+
+        # The loops read via a `<` redirection, not a pipe, so they run in this shell
+        # and the counter survives. Any entry that never reached cosign is a bug in the
+        # producing command's file format — fail red rather than report a green build
+        # for an unsigned artifact.
+        if [[ "$processed" -ne "$expected" ]]; then
+          echo "ERROR: $refs_file lists $expected entr(ies) but only $processed were processed." >&2
+          echo "  Signing was silently skipped. Check that the file is newline-terminated," >&2
+          echo "  one entry per line — see giantswarm/architect-orb#878." >&2
+          exit 1
+        fi

--- a/src/commands/push-helm.yaml
+++ b/src/commands/push-helm.yaml
@@ -203,9 +203,12 @@ steps:
               # Strip the :<version> tag from the pushed ref to get the bare repo path.
               chart_repo="${pushed_ref%:*}"
 
-              # Persist for the cosign step (separate shell).
+              # Persist for the cosign step (separate shell). The refs file is
+              # line-oriented input for `cosign-sign-verify` (one ref per line), so it
+              # must be newline-terminated — a bare `echo -n` here writes a final line
+              # that the reading `while read` loop discards, silently skipping the sign.
               echo -n "${CHART_ACCESS}" > /tmp/.chart_access
-              echo -n "${chart_repo}@${chart_digest}" > /tmp/.cosign_refs.candidate
+              echo "${chart_repo}@${chart_digest}" > /tmp/.cosign_refs.candidate
         - when:
             condition: <<parameters.sign>>
             steps:


### PR DESCRIPTION
Fixes #878.

## What

`sign: true` is the default on `push-to-app-catalog`, but **published Helm charts were never signed**. The cosign step ran, printed its version banner, exited 0, and produced no signature — so every public chart published since 2026-05-20 shipped unsigned while CI reported success.

## Root cause

`push-helm` staged the chart's OCI reference with `echo -n`, so `/tmp/.cosign_refs` had no trailing newline. `cosign-sign-verify` consumes that file with `while IFS= read -r`, which discards a final line lacking a newline — and the chart writes exactly one reference, so the loop body never executed. The `[[ ! -s "$refs_file" ]]` guard passed (the file was non-empty), so the step fell through silently.

Images and Go binaries were unaffected: their producers (`image-build-and-push.yaml:541/685/701`, `go-build.yaml:218`) append with plain `echo >>` and get their newline. `push-helm.yaml:208` was the only cosign-refs writer in the repo using `echo -n`.

The `echo -n` came in with #774, carried over from the previous single-value scratch files (`/tmp/.chart_digest`, `/tmp/.chart_registry`) where a missing newline was harmless. It became a dropped line once the same file was read as line-oriented input.

Same failure mode as #791, one path over.

## Changes

1. **`push-helm.yaml`** — newline-terminate the staged chart ref (`echo` instead of `echo -n`). `/tmp/.chart_access` keeps `echo -n`; it is read with `$(cat …)`, which strips the newline anyway, so it is not line-oriented input.
2. **`cosign-sign-verify.yaml`** — close the class, not just this instance. All three read loops (`oci`, `blob`, `attest`) consume caller-supplied files and now tolerate a missing final newline.
3. **`cosign-sign-verify.yaml`** — fail loudly. The step counts the actionable entries up front and fails if any never reached cosign, so a future silent skip is a red build instead of a green one. Confirmed: with this assertion in place, #774 would have failed CI in May instead of merging green.
4. The `oci` loop's blank/comment predicate now matches that count. It reads with an empty `IFS`, so unlike the other two loops it treated whitespace-only and space-indented `#` lines as entries — a latent bug that would otherwise make the two counts disagree.
5. **CHANGELOG.md** — `### Fixed` under `[Unreleased]`.

Truncating the refs file to opt out of signing — how private charts and images skip — still exits 0 as before.

## Testing

Dev orb `dev:fix-chart-signing-silent-skip`, consumed from two repos already pinned to `10.0.0` (this branch's base), so no version skew. In both cases creating the test branch also triggered a build of `main` under the old pin, giving a same-repo control.

**Chart path — the bug** (`hello-world-app`, both builds green):

| chart | orb | `oras discover` | `cosign v3 verify` |
| --- | --- | --- | --- |
| `…habcd963` | `10.0.0` | no referrers | `Error: no signatures found` |
| `…hdd5ff8f` | dev orb | `sigstore.bundle.v0.3` | **passes** |

Passing is the full assertion: cosign claims validated, Rekor entry verified offline, certificate chain verified against trusted CAs, identity matching the orb's own issuer/pipeline-definition regexes.

**Regression check** (`konfigure`, `go-build` + `push-to-registries` green) — control and fixed identical:

| path | control (`10.0.0`) | fixed (dev orb) |
| --- | --- | --- |
| image signature (`kind=oci`, multi-registry) | verifies | verifies |
| SPDX SBOM attestation (`kind=attest`) | verifies | verifies |
| binary signing (`kind=blob`, 6 arches) | job green | job green |

`kind=blob` is attested by the job passing — `upload-release-assets` is tags-only, so branch builds never publish the bundles. It still exercises the new assertion across 6 entries.

Test branches deleted; the `-dev.*` tags remain in the registries as any branch build leaves behind.

> **Reviewer note:** verify with **cosign v3**. cosign v2.4.1 returns `no signatures found` against a correctly-signed artifact — v3 attaches signatures as OCI referrers rather than `.sig` tags, and `--registry-referrers-mode` does not exist on v2.4.1's `verify`. A quick check without cosign: `oras discover <ref>` should show `application/vnd.dev.sigstore.bundle.v0.3+json`. SBOM attestations attach to the per-platform digests, not the index.

## Not in scope

Re-signing the ~3 months of already-published unsigned public charts. This fix only signs new publishes. A retroactive re-sign cannot carry the CircleCI pipeline OIDC identity the verify assertions expect, so it needs its own identity decision — worth a separate issue referencing #878.

## Checklist

- [x] Make yourself familiar with following readme sections:
    - [x] [Coding Standards](https://github.com/giantswarm/architect-orb#coding-guidelines).
    - [x] [Development](https://github.com/giantswarm/architect-orb#development).
    - [x] [Design and Goals](https://github.com/giantswarm/architect-orb#design-and-goals).
- [x] :warning: Update changelog in [CHANGELOG.md](https://github.com/giantswarm/architect-orb/tree/master/CHANGELOG.md).
