### PR TITLE
fix: bump binfmt to qemu-v10.2.3 and add its renovate manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `image-build-and-push`: the QEMU/binfmt image is bumped from `qemu-v8.1.5` (January 2025) to
+  `qemu-v10.2.3`, two QEMU majors of emulation performance for every build that targets a platform the
+  build host does not run natively.
+- The `# renovate:` annotation on the binfmt line now has a matching custom manager in `renovate.json5`.
+  The shared `giantswarm/renovate-presets` only reads that annotation shape in Dockerfiles (next to an
+  `ARG ..._VERSION=`) and in `vendir.yml` (next to a `ref:`), so in `src/commands/` it matched no manager
+  and Renovate never saw the dependency. It is a `--privileged` container, so it also went unwatched for
+  CVEs.
+
 ## [10.0.0] - 2026-08-18
 
 ### Deprecated

--- a/renovate.json5
+++ b/renovate.json5
@@ -105,6 +105,24 @@
       datasourceTemplate: 'github-releases',
       extractVersionTemplate: '^v(?<version>.+)$',
     },
+    {
+      // The shared preset only reads `# renovate:` annotations in Dockerfiles and
+      // vendir.yml, so the annotation on the binfmt line needs its own manager.
+      // Only the numeric part is captured, which keeps the `qemu-v` tag prefix in
+      // place on rewrite, and the anchored extractVersion skips the build-suffixed
+      // tags (`qemu-v10.2.3-68`).
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^src/commands/image-build-and-push\\.yaml$/',
+      ],
+      matchStrings: [
+        'tonistiigi/binfmt:qemu-v(?<currentValue>[0-9.]+)',
+      ],
+      depNameTemplate: 'tonistiigi/binfmt',
+      datasourceTemplate: 'docker',
+      extractVersionTemplate: '^qemu-v(?<version>[0-9.]+)$',
+      versioningTemplate: 'semver',
+    },
   ],
   packageRules: [
     {

--- a/src/commands/image-build-and-push.yaml
+++ b/src/commands/image-build-and-push.yaml
@@ -341,7 +341,7 @@ steps:
         if [[ "$needs_emulation" == "true" ]]; then
           # Image is pinned via tag and bumped by Renovate.
           # renovate: datasource=docker depName=tonistiigi/binfmt
-          docker run --privileged --rm tonistiigi/binfmt:qemu-v8.1.5 --install all
+          docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3 --install all
         else
           echo "All target platforms match the build host ($host_platform); skipping QEMU/binfmt registration."
         fi


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37408

`image-build-and-push` registers QEMU/binfmt handlers from a pinned
`tonistiigi/binfmt` image. The pin has been on `qemu-v8.1.5` (published January
2025) since #740, while `qemu-v10.2.1` was already available in February 2026.
Every build that targets a platform the build host does not run natively has
been emulating on a QEMU two majors old.

The line carries a `# renovate: datasource=docker depName=tonistiigi/binfmt`
annotation, but nothing acted on it. `giantswarm/renovate-presets` reads that
annotation shape in two places only: Dockerfiles, next to an `ARG ..._VERSION=`,
and `vendir.yml`, next to a `ref:`. In `src/commands/*.yaml` it matches no
manager, so Renovate never created the dependency and has never opened a bump PR
for it. The generic YAML managers in the preset key on a preceding
`# registry:` / `# repo:` line and expect `image:` / `version:` / `default:`
shapes, so they do not cover a `docker run image:tag` line either.

This adds a custom manager for it and bumps the pin. The manager captures only
the numeric part of the tag, so the `qemu-v` prefix survives a rewrite, and the
anchored `extractVersionTemplate` skips the build-suffixed tags
(`qemu-v10.2.3-68`, `qemu-v9.2.0-51`) that would otherwise rank as candidates.

Worth noting separately: this is a `--privileged` container that nothing was
watching for updates, so the gap was a CVE exposure as well as a performance
one. Any other repo writing a `# renovate:` annotation outside a Dockerfile or
`vendir.yml` has the same silent no-op, which may be worth a preset-level fix.
