### PR TITLE
feat(push-to-app-catalog): report published chart version on the PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `push-to-app-catalog`: new `comment_on_pr` parameter (default `true`) that reports the published
+  chart name and version on the pull request. Off-tag builds stamp
+  `X.Y.Z-dev.<branch>.<date>.<time>`, which is collision-proof but not guessable, so reviewers had to
+  open the CircleCI job and read the log to find out what to install. The comment also carries the
+  OCI reference, the digest, a `helm pull` command and a link to the git catalog.
+
+  It is a single sticky comment, found by a hidden marker keyed on the `chart` parameter and updated
+  in place on later pushes — a `PATCH` sends no notification, so a long branch produces one comment
+  instead of one per push, and a repo publishing several charts gets one comment per chart.
+
+  The pull request is resolved via `GET /repos/{o}/{r}/commits/{sha}/pulls` rather than
+  `CIRCLE_PULL_REQUEST`, which CircleCI does not provide under its GitHub App integration and which
+  is unreliable for same-repo pull requests under OAuth.
+
+  **Requires the `CircleCI architect` GitHub App to hold `Pull requests: write`** (plus
+  `Issues: write`, since pull request comments live on the issues endpoints), accepted by an
+  organisation owner. Until that is granted the step logs a warning naming the missing permission.
+  Every failure path is non-fatal by construction — no pull request yet, forked pull request (no
+  context, so no token), missing permission, rate limit — because the chart has already been
+  published by the time it runs. Nothing is posted for tag builds, default-branch builds, or when
+  both pushes are disabled.
+
+- `generate-github-token`: new `non_fatal` parameter (default `false`, so existing callers are
+  unaffected). When `true`, a missing App key or a failed `gh-token` call warns and exits 0 with
+  `GITHUB_TOKEN` unset instead of failing the step, for best-effort features that must never break a
+  build.
+
+### Fixed
+
+- `generate-github-token`: a failing `gh-token generate` left the step green with an empty token,
+  surfacing later as a confusing "GITHUB_TOKEN is not set" in whichever command needed it. The exit
+  status and an empty result are now checked at the source.
+
 ## [10.0.0] - 2026-08-18
 
 ### Deprecated

--- a/docs/job/push-to-app-catalog.md
+++ b/docs/job/push-to-app-catalog.md
@@ -67,6 +67,33 @@ is why [override_chart_version](#override_chart_version-optional-deprecated) is 
 ignored — leaving the version from `Chart.yaml` in place let a branch build that had not bumped the
 version by hand republish, and so overwrite, the released chart.
 
+## Reporting the published version on a pull request
+
+That dev-version scheme is exactly why this is needed: `X.Y.Z-dev.<branch>.<date>.<time>` is
+collision-proof but not guessable, so a reviewer who wants to install the chart from a pull request
+would otherwise have to open the CircleCI job and read the log.
+
+With [comment_on_pr](#comment_on_pr-optional-boolean-defaulttrue) (the default), the job posts a
+single comment on the pull request stating the chart name and version it published, plus the OCI
+reference, the digest, and a `helm pull` command. Later pushes **update that same comment in place**
+rather than adding new ones, so a long-running branch produces one comment and one notification.
+
+**Prerequisite.** The `CircleCI architect` GitHub App must hold `Pull requests: write` (and
+`Issues: write` — pull request conversation comments live on the issues endpoints) on the
+repository, accepted by an organisation owner. Without it the job logs a warning naming the missing
+permission and carries on.
+
+Known limitations, all of which log a line and leave the build green:
+
+- Nothing is posted for tag builds or default-branch builds — there is no pull request, and a tag
+  build's version follows the tag anyway.
+- Nothing is posted for forked pull requests: CircleCI withholds context environment variables from
+  them, so no GitHub token can be minted.
+- If the push predates the pull request, the comment appears on the first build **after** it is
+  opened.
+- Nothing is posted when both `push_to_appcatalog` and `push_to_oci_registry` are `false`, since
+  nothing was published.
+
 ## Parameters
 
 - [common parameters](common.md#parameters) shared in all jobs.
@@ -75,12 +102,13 @@ version by hand republish, and so overwrite, the released chart.
 - [chart](#chart) name of the directory containing the chart in `helm/`
 - [on_tag](#on_tag-optional-boolean-defaulttrue) only push tagged commits to `app_catalog`
 - [explicit_allow_chart_name_mismatch](#explicit_allow_chart_name_mismatch-optional-boolean-defaultfalse)
-- [persist_chart_archive](#persist_chart_archive-boolean-defaultfalse)
+- [persist_chart_archive](#persist_chart_archive-optional-boolean-defaultfalse)
 - [push_to_appcatalog](#push_to_appcatalog-optional-boolean-defaulttrue)
 - [push_to_oci_registry](#push_to_oci_registry-optional-boolean-defaulttrue)
 - [sign](#sign-optional-boolean-defaulttrue)
 - [override_chart_version](#override_chart_version-optional-deprecated) (optional, deprecated, always treated as `true`)
 - [override_app_version](#override_app_version-optional-boolean-defaulttrue)
+- [comment_on_pr](#comment_on_pr-optional-boolean-defaulttrue)
 
 ### attach_workspace
 
@@ -185,3 +213,19 @@ When `true` (the default), passes `--override-app-version` to App Build Suite, s
 chart's `appVersion` field with the value computed by `gitsemver` (or read from the
 `.build_version` workspace file). Set to `false` to leave the `appVersion` field in `Chart.yaml`
 unchanged.
+
+### comment_on_pr (optional boolean, default=true)
+
+When `true` (the default), the job posts a comment on the pull request stating the chart name and
+version it published, together with the OCI reference, the digest, a `helm pull` command and a link
+to the git catalog. On subsequent pushes the same comment is updated in place, identified by a
+hidden HTML marker keyed on the `chart` parameter — so a repository publishing several charts gets
+one comment per chart.
+
+Set to `false` to disable it.
+
+Requires the `CircleCI architect` GitHub App to hold `Pull requests: write` on the repository. Every
+failure path — no pull request yet, a forked pull request, a missing App permission, a rate limit —
+logs a warning and leaves the build green; the chart has already been published by the time this
+runs. See [Reporting the published version on a pull
+request](#reporting-the-published-version-on-a-pull-request) for the prerequisites and limitations.

--- a/src/commands/comment-chart-version.yaml
+++ b/src/commands/comment-chart-version.yaml
@@ -1,0 +1,305 @@
+# Posts — or updates — a single sticky comment on the pull request stating the
+# chart name and version that were just published.
+#
+# Why this exists: off-tag builds stamp the chart version from `gitsemver` as
+# `X.Y.Z-dev.<branch>.<date>.<time>`. That is deliberately collision-proof, but it
+# is not something a reviewer can guess or derive, so today they have to open the
+# CircleCI job and read the log to find out what to install.
+#
+# Every failure mode is non-fatal by construction: no pull request yet, no token
+# (forked PR, or no `context: architect`), a missing GitHub App permission, a rate
+# limit — all log a warning and exit 0. The job's contract is "the chart is
+# published", and by the time this runs that has already happened.
+#
+# Inputs, written by earlier commands in the job:
+#   .build_chart_name, .build_chart_version  — package-helm-with-abs
+#   .app_catalog_name                        — determine-catalog-name
+#   /tmp/.build_chart_oci_ref                — push-helm (OCI push only)
+#   /tmp/.build_chart_digest                 — push-helm (OCI push only)
+#   /tmp/.chart_access                       — push-helm (OCI push only)
+parameters:
+  chart:
+    description: |
+      The job's `chart` parameter. Used as the sticky-comment marker key, so a
+      repository publishing several charts gets one comment per chart rather than
+      two jobs fighting over one, and so the key stays stable even if the name in
+      Chart.yaml changes during the pull request.
+    type: string
+  push_to_appcatalog:
+    description: Whether the chart was also pushed to the GitHub app catalog repository.
+    type: boolean
+    default: true
+steps:
+  - generate-github-token:
+      non_fatal: true
+  - run:
+      name: "architect/comment-chart-version: Report published chart version on the pull request"
+      command: |
+        # This step reports information; it does not produce an artifact, so it must
+        # never fail the build. CircleCI runs steps under `bash -eo pipefail`, so -e is
+        # turned off explicitly, and everything runs in a SUBSHELL — a `set -u` violation
+        # or a stray non-zero return inside it kills only the subshell, leaving the
+        # trailing `exit 0` to run.
+        set +e
+        set -u -o pipefail
+
+        warn() { printf 'WARNING: comment-chart-version: %s\n' "$@" >&2; }
+
+        api="https://api.github.com"
+        # Set to false around a call whose 401/403/404 has a likelier explanation than a
+        # missing App permission, so the advice below is not printed misleadingly.
+        GH_ADVISE=true
+        owner="${CIRCLE_PROJECT_USERNAME:-}"
+        repo="${CIRCLE_PROJECT_REPONAME:-}"
+        marker="<!-- architect-orb:chart-version:<< parameters.chart >> -->"
+
+        # gh_api <METHOD> <url> [json-body-file] — sets GH_STATUS and GH_BODY.
+        gh_api() {
+          local method="$1" url="$2" data="${3:-}" out
+          local -a args=(
+            -sS -w '\n%{http_code}' -X "$method"
+            -H "Authorization: token ${GITHUB_TOKEN}"
+            -H "Accept: application/vnd.github+json"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+          )
+          if [[ -n "$data" ]]; then
+            args+=( --data-binary "@${data}" )
+          fi
+
+          out=$(curl "${args[@]}" "$url")
+          if [[ $? -ne 0 ]]; then
+            warn "${method} ${url} — curl failed."
+            return 1
+          fi
+
+          GH_STATUS=$(printf '%s' "$out" | tail -1)
+          GH_BODY=$(printf '%s' "$out" | sed '$d')
+
+          case "$GH_STATUS" in
+            2*)
+              return 0
+              ;;
+            401 | 403 | 404)
+              # GitHub answers 404 rather than 403 for some permission failures, so as
+              # to not leak whether a resource exists. All three therefore mean the
+              # same thing operationally and get the same advice.
+              if [[ "$GH_ADVISE" = "true" ]]; then
+                warn "${method} ${url} returned HTTP ${GH_STATUS}." \
+                     "The 'CircleCI architect' GitHub App most likely lacks 'Pull requests: write' on ${owner}/${repo}" \
+                     "— an organisation owner has to accept the updated App permissions."
+              else
+                warn "${method} ${url} returned HTTP ${GH_STATUS}."
+              fi
+              printf '%s\n' "$GH_BODY" | head -5 >&2
+              return 1
+              ;;
+            *)
+              warn "${method} ${url} returned HTTP ${GH_STATUS}."
+              printf '%s\n' "$GH_BODY" | head -5 >&2
+              return 1
+              ;;
+          esac
+        }
+
+        # resolve_prs — writes the open pull request numbers, one per line, to
+        # /tmp/.chart_prs. Returns 0 when at least one lookup succeeded (the file may
+        # still legitimately be empty), and 1 when every lookup failed — so the caller
+        # can tell "there is no pull request" apart from "we could not find out".
+        resolve_prs() {
+          local ok=1 nums
+          : > /tmp/.chart_prs
+
+          # CircleCI-provided values first: a free hit under the OAuth integration. Both
+          # are absent under the GitHub App integration and unreliable for same-repo PRs
+          # under OAuth, so they are an optimisation, not the mechanism.
+          if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
+            echo "${CIRCLE_PR_NUMBER}" > /tmp/.chart_prs
+            return 0
+          fi
+          if [[ -n "${CIRCLE_PULL_REQUEST:-}" ]]; then
+            echo "${CIRCLE_PULL_REQUEST##*/}" > /tmp/.chart_prs
+            return 0
+          fi
+
+          # Pull requests containing the exact commit that was built. Preferred over
+          # `?head=owner:branch` because it needs no knowledge of the head repository's
+          # owner — so it also covers forked PRs, whose PR object lives in the base
+          # repository — and because it matches a PR opened after this commit was pushed.
+          if gh_api GET "${api}/repos/${owner}/${repo}/commits/${CIRCLE_SHA1:-}/pulls?per_page=100"; then
+            ok=0
+            nums=$(printf '%s' "$GH_BODY" | jq -r '.[] | select(.state == "open") | .number' | head -5)
+            if [[ -n "$nums" ]]; then
+              printf '%s\n' "$nums" > /tmp/.chart_prs
+              return 0
+            fi
+          fi
+
+          # Fallback for same-repo branches, in case the commit-to-PR association index
+          # has not caught up yet. Only reached when the call above found nothing.
+          if gh_api GET "${api}/repos/${owner}/${repo}/pulls?head=${owner}:${CIRCLE_BRANCH:-}&state=open&per_page=100"; then
+            ok=0
+            nums=$(printf '%s' "$GH_BODY" | jq -r '.[].number' | head -5)
+            if [[ -n "$nums" ]]; then
+              printf '%s\n' "$nums" > /tmp/.chart_prs
+              return 0
+            fi
+          fi
+
+          return $ok
+        }
+
+        # build_body — renders the comment into /tmp/.chart_comment.md.
+        build_body() {
+          local name version access="" ref="" digest="" registry="" chart_repo="" catalog="" sha
+
+          name=$(cat .build_chart_name)
+          version=$(cat .build_chart_version)
+          sha="${CIRCLE_SHA1:-}"
+
+          # Driven off file existence rather than the job's parameters, so a row only
+          # appears when the corresponding push actually happened.
+          [[ -s /tmp/.build_chart_oci_ref ]] && ref=$(cat /tmp/.build_chart_oci_ref)
+          [[ -s /tmp/.build_chart_digest ]] && digest=$(cat /tmp/.build_chart_digest)
+          [[ -s /tmp/.chart_access ]] && access=$(cat /tmp/.chart_access)
+          [[ -s .app_catalog_name ]] && catalog=$(cat .app_catalog_name)
+
+          if [[ -n "$ref" ]]; then
+            registry="${ref%%/*}"
+            chart_repo="${ref%:*}"
+          fi
+
+          {
+            printf '%s\n\n' "$marker"
+            printf '### Published Helm chart `%s`\n\n' "$name"
+
+            # The bare fenced version is the one thing a reviewer actually needs, so it
+            # comes first and unadorned — copy-pasteable in a single gesture.
+            printf '```\n%s\n```\n\n' "$version"
+
+            printf '|  |  |\n| --- | --- |\n'
+            printf '| Chart | `%s` |\n' "$name"
+            printf '| Version | `%s` |\n' "$version"
+            [[ -n "$ref" ]] && printf '| OCI reference | `oci://%s` |\n' "$ref"
+            [[ -n "$digest" ]] && printf '| Digest | `%s` |\n' "$digest"
+            [[ -n "$registry" ]] && printf '| Registry | %s — `%s` |\n' "${access:-unknown}" "$registry"
+            if [[ "<< parameters.push_to_appcatalog >>" = "true" && -n "$catalog" ]]; then
+              printf '| Git catalog | [%s](https://github.com/giantswarm/%s) ([index](https://giantswarm.github.io/%s/)) |\n' "$catalog" "$catalog" "$catalog"
+            fi
+            printf '\n'
+
+            if [[ -n "$chart_repo" ]]; then
+              printf '<details><summary>Pull this chart</summary>\n\n'
+              printf '```console\nhelm pull oci://%s --version %s\n```\n' "$chart_repo" "$version"
+              if [[ "$access" = "private" ]]; then
+                # Pulling from the private registry is not anonymous, so the snippet above
+                # fails for everyone outside CI without this.
+                printf '\nThis chart is private: run `helm registry login %s` first, with the `ACR_GSOCIPRIVATE_*` credentials from 1Password.\n' "$registry"
+              fi
+              printf '</details>\n\n'
+            fi
+
+            # Deliberately prose rather than a copy-pasteable App CR snippet: the Catalog
+            # CR name is not mechanically derivable from the catalog repository name, and a
+            # snippet naming the wrong catalog is worse than no snippet at all.
+            printf 'To try it on a cluster, set `.spec.version` on the App CR to the version above.\n\n'
+
+            printf '<sub>Posted by <a href="https://github.com/giantswarm/architect-orb">architect-orb</a>'
+            [[ -n "${CIRCLE_BUILD_URL:-}" ]] && printf ' · <a href="%s">build %s</a>' "${CIRCLE_BUILD_URL}" "${CIRCLE_BUILD_NUM:-}"
+            [[ -n "$sha" ]] && printf ' · commit <code>%s</code>' "${sha:0:7}"
+            printf ' · updated in place on every push</sub>\n'
+          } > /tmp/.chart_comment.md
+
+          # Never hand-assemble the JSON payload.
+          jq -Rs '{body: .}' < /tmp/.chart_comment.md > /tmp/.chart_comment.json
+        }
+
+        # upsert <pr-number> — patch the existing sticky comment, or post a new one.
+        upsert() {
+          local pr="$1" page=1 id="" count max_pages=10
+          while :; do
+            gh_api GET "${api}/repos/${owner}/${repo}/issues/${pr}/comments?per_page=100&page=${page}" || return 1
+            id=$(printf '%s' "$GH_BODY" | jq -r --arg m "$marker" '[.[] | select((.body // "") | contains($m))] | .[0].id // empty')
+            [[ -n "$id" ]] && break
+            count=$(printf '%s' "$GH_BODY" | jq 'length')
+            [[ "$count" -lt 100 ]] && break
+            if [[ "$page" -ge "$max_pages" ]]; then
+              # Say so rather than truncating quietly: past this point the existing sticky
+              # comment cannot be found, so a duplicate gets posted instead of an update.
+              warn "PR #${pr} has more than $(( max_pages * 100 )) comments; gave up looking for the existing" \
+                   "chart-version comment and will post a new one."
+              break
+            fi
+            page=$(( page + 1 ))
+          done
+
+          if [[ -n "$id" ]]; then
+            # A 404 here almost certainly means the comment was deleted between the
+            # listing and the update, not a permission problem — we just listed it.
+            GH_ADVISE=false
+            gh_api PATCH "${api}/repos/${owner}/${repo}/issues/comments/${id}" /tmp/.chart_comment.json
+            local rc=$?
+            GH_ADVISE=true
+            if [[ $rc -eq 0 ]]; then
+              # A PATCH sends no notification, which is the whole point of the sticky
+              # comment: a thirty-push branch produces one comment and one notification.
+              echo "Updated existing comment ${id} on PR #${pr}."
+              return 0
+            fi
+            echo "Could not update comment ${id} (it may have been deleted); posting a new one instead." >&2
+          fi
+
+          gh_api POST "${api}/repos/${owner}/${repo}/issues/${pr}/comments" /tmp/.chart_comment.json || return 1
+          echo "Created comment $(printf '%s' "$GH_BODY" | jq -r '.id // "?"') on PR #${pr}."
+        }
+
+        main() {
+          if [[ -n "${CIRCLE_TAG:-}" ]]; then
+            echo "Tag build (${CIRCLE_TAG}) — the chart version follows the tag and there is no pull request. Nothing to report."
+            return 0
+          fi
+
+          case "${CIRCLE_BRANCH:-}" in
+            master | main)
+              echo "Default-branch build — no pull request to comment on."
+              return 0
+              ;;
+          esac
+
+          if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+            warn "no GITHUB_TOKEN — this is a forked-PR build, or 'context: architect' is not attached to the job. Skipping."
+            return 0
+          fi
+
+          if [[ -z "$owner" || -z "$repo" ]]; then
+            warn "CIRCLE_PROJECT_USERNAME/CIRCLE_PROJECT_REPONAME are not set. Skipping."
+            return 0
+          fi
+
+          if [[ ! -s .build_chart_name || ! -s .build_chart_version ]]; then
+            warn "the published chart name and version were not recorded — did package-helm-with-abs run? Skipping."
+            return 0
+          fi
+
+          if ! resolve_prs; then
+            warn "could not determine which pull request this commit belongs to (see above). Skipping."
+            return 0
+          fi
+
+          local prs
+          prs=$(cat /tmp/.chart_prs)
+          if [[ -z "$prs" ]]; then
+            echo "No open pull request found for ${CIRCLE_SHA1:-this commit} — nothing to comment on."
+            echo "(When the push predates the pull request, the comment appears on the first build after it is opened.)"
+            return 0
+          fi
+
+          build_body || return 1
+
+          local pr
+          for pr in $prs; do
+            upsert "$pr"
+          done
+        }
+
+        ( main ) || warn "the published chart version was not reported (see above). This never fails the build."
+        exit 0

--- a/src/commands/generate-github-token.yaml
+++ b/src/commands/generate-github-token.yaml
@@ -16,10 +16,37 @@ parameters:
       the variable is absent or empty.
     type: string
     default: ""
+  non_fatal:
+    description: |
+      When `true`, a missing App private key or a failed token generation logs a
+      warning and exits 0 instead of failing the step, leaving GITHUB_TOKEN unset.
+      Callers must then treat an empty GITHUB_TOKEN as "skip".
+
+      Meant for best-effort features that must never break a build — most notably
+      on forked-PR builds, where CircleCI withholds the context environment
+      variables entirely, so no token can be minted at all.
+
+      Defaults to `false`, which is the historical behaviour: every caller that
+      actually needs the token to do its job keeps failing loudly without one.
+    type: boolean
+    default: false
 steps:
   - run:
       name: Generate temporary GitHub token
       command: |
+        NON_FATAL="<< parameters.non_fatal >>"
+
+        # give_up <message ...> — abort the step, honouring the non_fatal contract.
+        give_up() {
+          if [[ "${NON_FATAL}" = "true" ]]; then
+            printf 'WARNING: %s\n' "$@" >&2
+            echo "WARNING: continuing without a GitHub token ('non_fatal' is set)." >&2
+            exit 0
+          fi
+          printf 'ERROR: %s\n' "$@" >&2
+          exit 1
+        }
+
         # If a pre-minted token env var is specified and populated, use it directly.
         TOKEN_ENV_VAR="<< parameters.token-env-var >>"
         if [[ -n "$TOKEN_ENV_VAR" ]]; then
@@ -33,13 +60,21 @@ steps:
         fi
 
         if [[ -z "${<< parameters.private_key_base64_env_var >>:-}" ]]; then
-          echo "ERROR: << parameters.private_key_base64_env_var >> is not set." >&2
-          echo "Add 'context: architect' to this job in .circleci/config.yml to enable artifact signing." >&2
-          exit 1
+          give_up "<< parameters.private_key_base64_env_var >> is not set." \
+                  "Add 'context: architect' to this job in .circleci/config.yml."
         fi
 
         echo -n "${<< parameters.private_key_base64_env_var >>}" | base64 -d > /tmp/private-key.pem
 
-        TOKEN=$(gh-token generate --key /tmp/private-key.pem --app-id "${<< parameters.app_id_env_var >>}" --installation-id "${<< parameters.installation_id_env_var >>}" --token-only)
+        # Without an explicit status check a failing `gh-token generate` would leave the
+        # step green with an empty token, surfacing much later as a confusing "GITHUB_TOKEN
+        # is not set" in whichever command needed it.
+        if ! TOKEN=$(gh-token generate --key /tmp/private-key.pem --app-id "${<< parameters.app_id_env_var >>}" --installation-id "${<< parameters.installation_id_env_var >>}" --token-only); then
+          give_up "gh-token failed to generate an installation token."
+        fi
+
+        if [[ -z "$TOKEN" ]]; then
+          give_up "gh-token returned an empty token."
+        fi
 
         echo "export GITHUB_TOKEN=\"$TOKEN\"" >> $BASH_ENV

--- a/src/commands/package-helm-with-abs.yaml
+++ b/src/commands/package-helm-with-abs.yaml
@@ -45,6 +45,9 @@ steps:
           echo "ERROR: could not determine build version (.build_version is empty and gitsemver returned nothing)"
           exit 1
         fi
+        # Record the stamped version so later steps can report what was published
+        # without recomputing it (see the `comment-chart-version` command).
+        printf '%s' "${VERSION}" > .build_chart_version
         if [ "<< parameters.override_chart_version >>" != "true" ]; then
           echo "NOTE: 'override_chart_version' is deprecated and ignored; stamping chart version ${VERSION} anyway."
         fi
@@ -59,3 +62,41 @@ steps:
           --catalog-base-url "https://giantswarm.github.io/$(cat .app_catalog_name)/" \
           --keep-chart-changes \
           ${OVERRIDES}
+  - run:
+      name: "architect/package-helm-with-abs: Record published chart name"
+      command: |
+        # Best effort: this only feeds the informational `comment-chart-version`
+        # command, so it must never be the reason a chart publish fails.
+        set +e
+        set -u -o pipefail
+
+        shopt -s nullglob
+        archives=( build/*.tgz )
+
+        if [[ ${#archives[@]} -ne 1 ]]; then
+          echo "WARNING: expected exactly one chart archive in build/, found ${#archives[@]}; not recording the chart name." >&2
+          if [[ ${#archives[@]} -gt 0 ]]; then
+            printf '  %s\n' "${archives[@]}" >&2
+          fi
+          exit 0
+        fi
+
+        version=$(cat .build_chart_version)
+        base=$(basename "${archives[0]}" .tgz)
+
+        # Helm names archives `<chart-name>-<version>.tgz`, and the version was stamped
+        # by the step above, so stripping it yields the chart name exactly — no guessing
+        # where the name ends and the semver begins. Reading it off the produced artifact
+        # rather than the `chart` parameter is also what makes this correct for callers
+        # using `explicit_allow_chart_name_mismatch`, where the name in Chart.yaml differs
+        # from the chart directory. This mirrors why `push-helm` derives the pushed ref
+        # from `helm push` output instead of the parameter.
+        name="${base%-${version}}"
+
+        if [[ -z "$name" || "$name" == "$base" ]]; then
+          echo "WARNING: could not derive the chart name from '${base}' (version '${version}'); not recording it." >&2
+          exit 0
+        fi
+
+        printf '%s' "$name" > .build_chart_name
+        echo "Published chart: ${name} ${version}"

--- a/src/commands/push-helm.yaml
+++ b/src/commands/push-helm.yaml
@@ -206,6 +206,14 @@ steps:
               # Persist for the cosign step (separate shell).
               echo -n "${CHART_ACCESS}" > /tmp/.chart_access
               echo -n "${chart_repo}@${chart_digest}" > /tmp/.cosign_refs.candidate
+
+              # Persist the tagged ref and the digest separately for the
+              # `comment-chart-version` command. Kept apart from the cosign candidate
+              # above, which is digest-form with no tag and whose lifecycle belongs to
+              # signing — it is emptied for private charts and only staged when
+              # `sign: true`.
+              echo -n "${pushed_ref}" > /tmp/.build_chart_oci_ref
+              echo -n "${chart_digest}" > /tmp/.build_chart_digest
         - when:
             condition: <<parameters.sign>>
             steps:

--- a/src/jobs/push-to-app-catalog.yaml
+++ b/src/jobs/push-to-app-catalog.yaml
@@ -84,6 +84,22 @@ parameters:
       When `true` (the default), passes `--override-app-version` to App Build Suite,
       stamping the app version with the value from `gitsemver` (or `.build_version`
       workspace file).  Set to `false` to leave the appVersion in `Chart.yaml` unchanged.
+  comment_on_pr:
+    default: true
+    description: |
+      Post — and on later pushes update in place — a single comment on the pull request
+      stating the chart name and version that were published, along with the OCI
+      reference and digest.
+
+      Off-tag builds stamp a `X.Y.Z-dev.<branch>.<date>.<time>` version that a reviewer
+      cannot guess, so without this they have to open the CircleCI job and read the log
+      to find out what to install.
+
+      Requires the `CircleCI architect` GitHub App to hold `Pull requests: write` on the
+      repository. Every failure — no pull request yet, a forked PR (no context, so no
+      token), a missing permission, a rate limit — logs a warning and leaves the build
+      green.
+    type: boolean
   persist_chart_archive:
     type: boolean
     default: false
@@ -127,6 +143,20 @@ steps:
       force-public: <<parameters.force-public>>
       sign: << parameters.sign >>
       chart: << parameters.chart >>
+  - when:
+      condition:
+        and:
+          - << parameters.comment_on_pr >>
+          # With both pushes off nothing was published, and advertising a version that
+          # exists nowhere is worse than saying nothing. As a compile-time condition this
+          # also avoids minting a GitHub token for no reason.
+          - or:
+              - << parameters.push_to_appcatalog >>
+              - << parameters.push_to_oci_registry >>
+      steps:
+        - comment-chart-version:
+            chart: << parameters.chart >>
+            push_to_appcatalog: << parameters.push_to_appcatalog >>
   - when:
       condition: << parameters.persist_chart_archive >>
       steps:


### PR DESCRIPTION
## What

`architect/push-to-app-catalog` always stamps the chart version from `gitsemver`. Off-tag that yields `X.Y.Z-dev.<branch>.<date>.<time>` — collision-proof, but not guessable, so a reviewer who wants to install a PR's chart has to open the CircleCI job and read the log.

This adds a new `comment-chart-version` command that posts a single sticky comment on the pull request with the chart name, version, OCI reference, digest, a `helm pull` command and a link to the git catalog. Later pushes update that same comment in place, so a long-running branch produces one comment and one notification rather than one per push.

Enabled by default via a new `comment_on_pr` parameter on the job.

## How

- **New** `src/commands/comment-chart-version.yaml`. Sticky comment found by a hidden marker keyed on the `chart` parameter, so a repo publishing several charts gets one comment per chart and the key survives a `Chart.yaml` rename mid-PR. `PATCH` when found, `POST` otherwise.
- **PR resolution** goes through `GET /repos/{o}/{r}/commits/{sha}/pulls`, not `CIRCLE_PULL_REQUEST` — CircleCI does not provide that under its GitHub App integration, and it is unreliable for same-repo PRs under OAuth. This repo's own config already sets `enable_pr_comment: false` on `orb-tools/publish` for that reason. The commit-keyed endpoint also covers forked PRs and matches a PR opened *after* the push. `?head=owner:branch` remains as a fallback.
- `package-helm-with-abs` records `.build_chart_version` and derives `.build_chart_name` from the produced `build/*.tgz`. Reading it off the artifact rather than the `chart` parameter keeps it correct under `explicit_allow_chart_name_mismatch`, mirroring why `push-helm` already derives the pushed ref from `helm push` output.
- `push-helm` persists `/tmp/.build_chart_oci_ref` and `/tmp/.build_chart_digest`. Kept separate from `/tmp/.cosign_refs.candidate`, which is digest-form with no tag and whose lifecycle belongs to signing.
- `generate-github-token` gains `non_fatal` (default `false`, so the four existing call sites are untouched), and now checks `gh-token`'s exit status — previously a failure left the step green with an empty token, surfacing later as a confusing "GITHUB_TOKEN is not set".
- Table rows are omitted, not blanked, when the data is absent, driven off file existence rather than the parameters — so a row only appears if that push actually happened.

## Non-fatal by construction

CircleCI has no per-step `continue-on-error`, so the script turns off `-e` and runs its logic in a subshell with a trailing bare `exit 0`. Nothing is posted, and the build stays green, for: tag builds, default-branch builds, forked PRs (no context, so no token), a PR that does not exist yet, a missing App permission, or a rate limit. The chart has already been published by the time this runs.

## Prerequisite — needs action before release

The `CircleCI architect` GitHub App currently only needs *Metadata: read*. Posting a comment needs **`Pull requests: write`** (plus `Issues: write`, since PR conversation comments live on the issues endpoints), and an organisation owner has to accept the updated permission set on the installation.

Because `comment_on_pr` defaults to `true`, until that is granted every chart publish will log a one-line warning naming the missing permission. Builds stay green, but the grant should land before this is released.

## Testing

The orb can only really be exercised from a consumer repo, so the shell was extracted from the YAML and run against a mocked GitHub API first:

- 13 scenarios: create; in-place `PATCH`; `PATCH` 404 → `POST` fallback; 403 permission failure; no PR; `?head=` fallback; tag build; default branch; no token; chart facts not recorded; private chart; `push_to_oci_registry: false`; published name ≠ `chart` param; two open PRs. All exit 0.
- Pagination: marker on page 2 of a >100-comment PR is found and patched; hitting the 10-page cap logs a warning rather than truncating silently.
- 8 `generate-github-token` paths: missing key, `gh-token` failure and empty output, each with `non_fatal` true and false, plus the pre-minted-token override and its empty-value fallback.
- Chart-name derivation against `cluster-aws`, `prometheus-meta-operator`, `chart-2-0` and long dev versions, plus the zero-archive, two-archive and unparseable cases.
- `changelog-lint` and a yamllint-equivalent pass clean; a simulated `orb pack` resolves every command reference and parameter.

Still to verify on real CI, from a consumer repo pinned to `giantswarm/architect@dev:report-chart-version-on-pr`:

- [ ] Public repo, defaults: full comment renders.
- [ ] Second push updates the same comment id, no new comment.
- [ ] Private repo: `gsociprivate` row plus the `helm registry login` caveat.
- [ ] `push_to_oci_registry: false`: OCI rows omitted, catalog row present.
- [ ] `explicit_allow_chart_name_mismatch: true`: body shows the published name.
- [ ] Tag build and post-merge default-branch build both log their skip and stay green.
- [ ] **Most important:** a repo where the App lacks the permission stays **green**. If it goes red, the default must ship as `false`.
